### PR TITLE
Follow naming conventions for Equals and Contains functions

### DIFF
--- a/plugins/grpc/stats/client_handler_test.go
+++ b/plugins/grpc/stats/client_handler_test.go
@@ -342,14 +342,14 @@ func TestClientDefaultCollections(t *testing.T) {
 			}
 
 			for _, gotRow := range gotRows {
-				if !istats.RowsContain(wantData.rows, gotRow) {
+				if !istats.ContainsRow(wantData.rows, gotRow) {
 					t.Errorf("Test case '%v'. View '%v' got unexpected row '%v'", tc.label, wantData.v().Name(), gotRow)
 					break
 				}
 			}
 
 			for _, wantRow := range wantData.rows {
-				if !istats.RowsContain(gotRows, wantRow) {
+				if !istats.ContainsRow(gotRows, wantRow) {
 					t.Errorf("Test case '%v'. View '%v' want row '%v'. Not received", tc.label, wantData.v().Name(), wantRow)
 					break
 				}

--- a/plugins/grpc/stats/server_handler_test.go
+++ b/plugins/grpc/stats/server_handler_test.go
@@ -342,14 +342,14 @@ func TestServerDefaultCollections(t *testing.T) {
 			}
 
 			for _, gotRow := range gotRows {
-				if !istats.RowsContain(wantData.rows, gotRow) {
+				if !istats.ContainsRow(wantData.rows, gotRow) {
 					t.Errorf("Test case '%v'. View '%v' got unexpected row '%v'", tc.label, wantData.v().Name(), gotRow)
 					break
 				}
 			}
 
 			for _, wantRow := range wantData.rows {
-				if !istats.RowsContain(gotRows, wantRow) {
+				if !istats.ContainsRow(gotRows, wantRow) {
 					t.Errorf("Test case '%v'. View '%v' want row '%v'. Not received", tc.label, wantData.v().Name(), wantRow)
 					break
 				}

--- a/stats/view.go
+++ b/stats/view.go
@@ -216,8 +216,8 @@ func (r *Row) Equal(other *Row) bool {
 	return reflect.DeepEqual(r.Tags, other.Tags) && r.AggregationValue.equal(other.AggregationValue)
 }
 
-// RowsContain returns true if rows contain r.
-func RowsContain(rows []*Row, r *Row) bool {
+// ContainsRow returns true if rows contain r.
+func ContainsRow(rows []*Row, r *Row) bool {
 	for _, x := range rows {
 		if r.Equal(x) {
 			return true
@@ -226,15 +226,15 @@ func RowsContain(rows []*Row, r *Row) bool {
 	return false
 }
 
-// RowsAreEqual returns true if rows1, rows2 are equivalent. The rows position
+// EqualRows returns true if rows1, rows2 are equivalent. The rows position
 // into the slice is taken into account.
-func RowsAreEqual(rows1, rows2 []*Row) (bool, string) {
+func EqualRows(rows1, rows2 []*Row) (bool, string) {
 	if len(rows1) != len(rows2) {
 		return false, fmt.Sprintf("len(rows1)=%v and len(rows2)=%v", len(rows1), len(rows2))
 	}
 
 	for _, r1 := range rows1 {
-		if !RowsContain(rows2, r1) {
+		if !ContainsRow(rows2, r1) {
 			return false, fmt.Sprintf("got unexpected row '%v' in rows1", r1)
 		}
 	}

--- a/stats/view_test.go
+++ b/stats/view_test.go
@@ -165,14 +165,14 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowCumulative(t *testin
 		gotRows := vw1.collectedRows(time.Now())
 
 		for _, gotRow := range gotRows {
-			if !RowsContain(tc.wantRows, gotRow) {
+			if !ContainsRow(tc.wantRows, gotRow) {
 				t.Errorf("got unexpected row '%v' for test case: '%v'", gotRow, tc.label)
 				break
 			}
 		}
 
 		for _, wantRow := range tc.wantRows {
-			if !RowsContain(gotRows, wantRow) {
+			if !ContainsRow(gotRows, wantRow) {
 				t.Errorf("want row '%v' for test case: '%v'. Not received", wantRow, tc.label)
 				break
 			}
@@ -352,14 +352,14 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowSlidingTime(t *testi
 			gotRows := vw1.collectedRows(wantRows.retrieveTime)
 
 			for _, gotRow := range gotRows {
-				if !RowsContain(wantRows.rows, gotRow) {
+				if !ContainsRow(wantRows.rows, gotRow) {
 					t.Errorf("got unexpected row '%v' for test case: '%v' with label '%v'", gotRow, tc.label, wantRows.label)
 					break
 				}
 			}
 
 			for _, wantRow := range wantRows.rows {
-				if !RowsContain(gotRows, wantRow) {
+				if !ContainsRow(gotRows, wantRow) {
 					t.Errorf("want row '%v' for test case: '%v' with label '%v'. Not received", wantRow, tc.label, wantRows.label)
 					break
 				}
@@ -555,14 +555,14 @@ func Test_View_MeasureFloat64_AggregationCount_WindowSlidingTime(t *testing.T) {
 			gotRows := vw1.collectedRows(wantRows.retrieveTime)
 
 			for _, gotRow := range gotRows {
-				if !RowsContain(wantRows.rows, gotRow) {
+				if !ContainsRow(wantRows.rows, gotRow) {
 					t.Errorf("got unexpected row '%v' for test case: '%v' with label '%v'", gotRow, tc.label, wantRows.label)
 					break
 				}
 			}
 
 			for _, wantRow := range wantRows.rows {
-				if !RowsContain(gotRows, wantRow) {
+				if !ContainsRow(gotRows, wantRow) {
 					t.Errorf("want row '%v' for test case: '%v' with label '%v'. Not received", wantRow, tc.label, wantRows.label)
 					break
 				}
@@ -681,14 +681,14 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowSlidingCount(t *test
 		gotRows := vw1.collectedRows(time.Now())
 
 		for _, gotRow := range gotRows {
-			if !RowsContain(tc.rows, gotRow) {
+			if !ContainsRow(tc.rows, gotRow) {
 				t.Errorf("got unexpected row '%v' for test case: '%v'", gotRow, tc.label)
 				break
 			}
 		}
 
 		for _, wantRow := range tc.rows {
-			if !RowsContain(gotRows, wantRow) {
+			if !ContainsRow(gotRows, wantRow) {
 				t.Errorf("want row '%v' for test case: '%v'. Not received", wantRow, tc.label)
 				break
 			}

--- a/stats/worker_test.go
+++ b/stats/worker_test.go
@@ -674,14 +674,14 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 				t.Fatalf("RetrieveData '%v' got error '%v', want no error for test case: '%v'", w.v.Name(), err, tc.label)
 			}
 			for _, gotRow := range gotRows {
-				if !RowsContain(w.rows, gotRow) {
+				if !ContainsRow(w.rows, gotRow) {
 					t.Errorf("got unexpected row '%v' for test case: '%v'", gotRow, tc.label)
 					break
 				}
 			}
 
 			for _, wantRow := range w.rows {
-				if !RowsContain(gotRows, wantRow) {
+				if !ContainsRow(gotRows, wantRow) {
 					t.Errorf("want row '%v' for test case: '%v'. Not received", wantRow, tc.label)
 					break
 				}


### PR DESCRIPTION
It is conventional to follow to use the ContainsX naming for contains utilities, see bytes.ContainsRune. Similarly for equality checks, EqualX is more common.