### PR TITLE
Use simpler names for binary encoder/decoder

### DIFF
--- a/plugins/grpc/stats/client_handler.go
+++ b/plugins/grpc/stats/client_handler.go
@@ -91,7 +91,7 @@ func (ch clientHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) cont
 	}
 
 	ts := tags.FromContext(ctx)
-	encoded := tags.EncodeToFullSignature(ts)
+	encoded := tags.Encode(ts)
 	ctx = stats.SetTags(ctx, encoded)
 
 	tsb := tags.NewTagSetBuilder(ts)

--- a/plugins/grpc/stats/client_handler_test.go
+++ b/plugins/grpc/stats/client_handler_test.go
@@ -318,7 +318,7 @@ func TestClientDefaultCollections(t *testing.T) {
 				tsb.UpsertString(t.k, t.v)
 			}
 			ts := tsb.Build()
-			encoded := tags.EncodeToFullSignature(ts)
+			encoded := tags.Encode(ts)
 			ctx := stats.SetTags(context.Background(), encoded)
 
 			ctx = h.TagRPC(ctx, rpc.tagInfo)

--- a/plugins/grpc/stats/server_handler.go
+++ b/plugins/grpc/stats/server_handler.go
@@ -190,7 +190,7 @@ func (sh serverHandler) createTagSet(ctx context.Context, serviceName, methodNam
 	if tagsBin := stats.Tags(ctx); tagsBin == nil {
 		tsb = tags.NewTagSetBuilder(nil)
 	} else {
-		ts, err := tags.DecodeFromFullSignature([]byte(tagsBin))
+		ts, err := tags.Decode([]byte(tagsBin))
 		if err != nil {
 			return nil, fmt.Errorf("serverHandler.createTagSet failed to decode tagsBin: %v. %v", tagsBin, err)
 		}

--- a/plugins/grpc/stats/server_handler_test.go
+++ b/plugins/grpc/stats/server_handler_test.go
@@ -318,7 +318,7 @@ func TestServerDefaultCollections(t *testing.T) {
 				tsb.UpsertString(t.k, t.v)
 			}
 			ts := tsb.Build()
-			encoded := tags.EncodeToFullSignature(ts)
+			encoded := tags.Encode(ts)
 			ctx := stats.SetTags(context.Background(), encoded)
 
 			ctx = h.TagRPC(ctx, rpc.tagInfo)

--- a/tags/tag_set_codec.go
+++ b/tags/tag_set_codec.go
@@ -188,7 +188,7 @@ func Decode(bytes []byte) (*TagSet, error) {
 
 	version := eg.readByte()
 	if version > tagsVersionID {
-		return nil, fmt.Errorf("not supported version: %q; supports only up to: %q", version, tagsVersionID)
+		return nil, fmt.Errorf("unsupported version: %q; supports only up to: %q", version, tagsVersionID)
 	}
 
 	for !eg.readEnded() {

--- a/tags/tag_set_codec.go
+++ b/tags/tag_set_codec.go
@@ -198,7 +198,7 @@ func Decode(bytes []byte) (*TagSet, error) {
 		case keyTypeString:
 			break
 		default:
-			return nil, fmt.Errorf("key type invalid: %q", typ)
+			return nil, fmt.Errorf("invalid key type: %q", typ)
 		}
 
 		k, err := eg.readBytesWithVarintLen()

--- a/tags/tag_set_codec.go
+++ b/tags/tag_set_codec.go
@@ -159,8 +159,8 @@ func (eg *encoderGRPC) bytes() []byte {
 	return eg.buf[:eg.writeIdx]
 }
 
-// EncodeToFullSignature will encode the tagSet to []byte.
-func EncodeToFullSignature(ts *TagSet) []byte {
+// Encode will encode the tag set into a []byte.
+func Encode(ts *TagSet) []byte {
 	eg := &encoderGRPC{
 		buf: make([]byte, len(ts.m)),
 	}
@@ -175,8 +175,8 @@ func EncodeToFullSignature(ts *TagSet) []byte {
 	return eg.bytes()
 }
 
-// DecodeFromFullSignature will decode the []byte encoded tagSet.
-func DecodeFromFullSignature(bytes []byte) (*TagSet, error) {
+// Decode will decode the given []byte into a tag set.
+func Decode(bytes []byte) (*TagSet, error) {
 	ts := newTagSet(0)
 
 	eg := &encoderGRPC{
@@ -188,7 +188,7 @@ func DecodeFromFullSignature(bytes []byte) (*TagSet, error) {
 
 	version := eg.readByte()
 	if version > tagsVersionID {
-		return nil, fmt.Errorf("DecodeFromFullSignature doesn't support version %v. Supports only up to: %v", version, tagsVersionID)
+		return nil, fmt.Errorf("not supported version: %q; supports only up to: %q", version, tagsVersionID)
 	}
 
 	for !eg.readEnded() {
@@ -198,7 +198,7 @@ func DecodeFromFullSignature(bytes []byte) (*TagSet, error) {
 		case keyTypeString:
 			break
 		default:
-			return nil, fmt.Errorf("DecodeFromFullSignature failed. Key type invalid %v", typ)
+			return nil, fmt.Errorf("key type invalid: %q", typ)
 		}
 
 		k, err := eg.readBytesWithVarintLen()

--- a/tags/tag_set_codec.go
+++ b/tags/tag_set_codec.go
@@ -159,7 +159,8 @@ func (eg *encoderGRPC) bytes() []byte {
 	return eg.buf[:eg.writeIdx]
 }
 
-// Encode will encode the tag set into a []byte.
+// Encode encodes the tag set into a []byte. It is useful to propagate
+// the tag sets on wire in binary format.
 func Encode(ts *TagSet) []byte {
 	eg := &encoderGRPC{
 		buf: make([]byte, len(ts.m)),

--- a/tags/tag_set_codec_test.go
+++ b/tags/tag_set_codec_test.go
@@ -82,18 +82,18 @@ func Test_EncodeDecode_TagSet(t *testing.T) {
 		}
 		ts := tsb.Build()
 
-		encoded := EncodeToFullSignature(ts)
-		decoded, err := DecodeFromFullSignature(encoded)
+		encoded := Encode(ts)
+		decoded, err := Decode(encoded)
 
 		if err != nil {
-			t.Errorf("Test case '%v'. Decoding encoded tagSet failed. %v", tc.label, err)
+			t.Errorf("%q: Decoding encoded tagSet failed: %v", tc.label, err)
 		}
 
 		got := make([]pair, 0)
 		for k, v := range decoded.m {
 			ks, ok := k.(*KeyString)
 			if !ok {
-				t.Errorf("Test case '%v'. Wrong key type. got %T, want *KeyString", tc.label, k)
+				t.Errorf("%q: Wrong key type; got %T, want *KeyString", tc.label, k)
 			}
 			got = append(got, pair{ks, string(v)})
 		}
@@ -103,7 +103,7 @@ func Test_EncodeDecode_TagSet(t *testing.T) {
 		sort.Slice(want, func(i, j int) bool { return uintptr(unsafe.Pointer(want[i].k)) < uintptr(unsafe.Pointer(want[j].k)) })
 
 		if !reflect.DeepEqual(got, tc.pairs) {
-			t.Errorf("Test case '%v'. Decoded tagSet is wrong. Got %v, want %v", tc.label, got, tc.pairs)
+			t.Errorf("%q: Got pairs %v, want %v", tc.label, got, tc.pairs)
 		}
 
 	}


### PR DESCRIPTION
Fixes #23.