### PR TITLE
Rename GetMeasureByName and GetViewByName, simpler error messages

### DIFF
--- a/stats/aggregation.go
+++ b/stats/aggregation.go
@@ -72,11 +72,8 @@ type AggregationDistribution struct {
 // [bounds[i-1], bounds[i]) for 0 < i < len(Bounds)
 // [bounds[i-1], +infinity) for i = len(Bounds)
 func NewAggregationDistribution(bounds []float64) *AggregationDistribution {
-	var copyBounds []float64
-	for _, b := range bounds {
-		copyBounds = append(copyBounds, b)
-	}
-
+	copyBounds := make([]float64, len(bounds))
+	copy(copyBounds, bounds)
 	return &AggregationDistribution{
 		bounds: copyBounds,
 	}

--- a/stats/collector.go
+++ b/stats/collector.go
@@ -45,11 +45,9 @@ func (c *collector) addSample(s string, v interface{}, now time.Time) {
 func (c *collector) collectedRows(keys []tags.Key, now time.Time) []*Row {
 	var rows []*Row
 	for sig, aggregator := range c.signatures {
-		ts := tags.ToOrderedTagsSlice(sig, keys)
-		rows = append(rows, &Row{
-			ts,
-			aggregator.retrieveCollected(now),
-		})
+		tags := tags.ToOrderedTagsSlice(sig, keys)
+		row := &Row{tags, aggregator.retrieveCollected(now)}
+		rows = append(rows, row)
 	}
 	return rows
 }

--- a/stats/doc.go
+++ b/stats/doc.go
@@ -16,5 +16,5 @@
 // Package stats contains the OpenCensus stats collection APIs.
 package stats
 
-// TODO(acetechnologist): Add a linnk to the language independent opencensus
-// doc when it is available.
+// TODO(acetechnologist): Add a link to the language independent OpenCensus
+// spec when it is available.

--- a/stats/view.go
+++ b/stats/view.go
@@ -49,6 +49,7 @@ type View interface {
 	collectedRows(now time.Time) []*Row
 
 	addSample(ts *tags.TagSet, val interface{}, now time.Time)
+	// TODO(jbd): Remove View interface? Are we expecting custom interface types?
 }
 
 // view is the data structure that holds the info describing the view as well

--- a/stats/worker.go
+++ b/stats/worker.go
@@ -83,8 +83,8 @@ func NewMeasureInt64(name, description, unit string) (*MeasureInt64, error) {
 	return m, nil
 }
 
-// GetMeasureByName returns the registered measure associated with name.
-func GetMeasureByName(name string) (Measure, error) {
+// MeasureByName returns the registered measure associated with name.
+func MeasureByName(name string) (Measure, error) {
 	req := &getMeasureByNameReq{
 		name: name,
 		c:    make(chan *getMeasureByNameResp),
@@ -106,8 +106,8 @@ func DeleteMeasure(m Measure) error {
 	return <-req.err
 }
 
-// GetViewByName returns the registered view associated with this name.
-func GetViewByName(name string) (View, error) {
+// ViewByName returns the registered view associated with this name.
+func ViewByName(name string) (View, error) {
 	req := &getViewByNameReq{
 		name: name,
 		c:    make(chan *getViewByNameResp),
@@ -160,9 +160,8 @@ func UnregisterView(v View) error {
 // buffered channel or blocking on the channel waiting for the collected data.
 func SubscribeToView(v View, c chan *ViewData) error {
 	if v == nil {
-		return errors.New("cannot SubscribeToView for nil view")
+		return errors.New("cannot subscribe nil view")
 	}
-
 	req := &subscribeToViewReq{
 		v:   v,
 		c:   c,
@@ -178,9 +177,8 @@ func SubscribeToView(v View, c chan *ViewData) error {
 // view.
 func UnsubscribeFromView(v View, c chan *ViewData) error {
 	if v == nil {
-		return errors.New("cannot UnsubscribeFromView for nil view")
+		return errors.New("cannot unsubscribe nil view")
 	}
-
 	req := &unsubscribeFromViewReq{
 		v:   v,
 		c:   c,
@@ -194,9 +192,8 @@ func UnsubscribeFromView(v View, c chan *ViewData) error {
 // listeners are subscribed to it.
 func ForceCollection(v View) error {
 	if v == nil {
-		return errors.New("cannot ForceCollection for nil view")
+		return errors.New("cannot for collect nil view")
 	}
-
 	req := &startForcedCollectionReq{
 		v:   v,
 		err: make(chan error),
@@ -209,9 +206,8 @@ func ForceCollection(v View) error {
 // 1 listener is subscribed to it.
 func StopForcedCollection(v View) error {
 	if v == nil {
-		return errors.New("cannot StopForcedCollection for nil view")
+		return errors.New("cannot stop force collection for nil view")
 	}
-
 	req := &stopForcedCollectionReq{
 		v:   v,
 		err: make(chan error),
@@ -223,7 +219,7 @@ func StopForcedCollection(v View) error {
 // RetrieveData returns the current collected data for the view.
 func RetrieveData(v View) ([]*Row, error) {
 	if v == nil {
-		return nil, errors.New("cannot retrieve data for nil view")
+		return nil, errors.New("cannot retrieve data from nil view")
 	}
 	req := &retrieveDataReq{
 		now: time.Now(),
@@ -321,15 +317,14 @@ func (w *worker) start() {
 
 func (w *worker) stop() {
 	w.quit <- true
-	_ = <-w.done
+	<-w.done
 }
 
 func (w *worker) tryRegisterMeasure(m Measure) error {
 	if x, ok := w.measuresByName[m.Name()]; ok {
 		if x != m {
-			return fmt.Errorf("cannot register the measure with name '%v' because a different measure with the same name is already registered", m.Name())
+			return fmt.Errorf("cannot register measure %q; another measure with the same name is already registered", m.Name())
 		}
-
 		// the measure is already registered so there is nothing to do and the
 		// command is considered successful.
 		return nil
@@ -343,7 +338,7 @@ func (w *worker) tryRegisterMeasure(m Measure) error {
 func (w *worker) tryRegisterView(v View) error {
 	if x, ok := w.viewsByName[v.Name()]; ok {
 		if x != v {
-			return fmt.Errorf("cannot register the view with name '%v' because a different view with the same name is already registered", v.Name())
+			return fmt.Errorf("cannot register view %q; another view with the same name is already registered", v.Name())
 		}
 
 		// the view is already registered so there is nothing to do and the
@@ -354,7 +349,7 @@ func (w *worker) tryRegisterView(v View) error {
 	// view is not registered and needs to be registered, but first its measure
 	// needs to be registered.
 	if err := w.tryRegisterMeasure(v.Measure()); err != nil {
-		return fmt.Errorf("%v. Hence cannot register view '%v,", err, v.Name())
+		return fmt.Errorf("cannot register view %q: %v", v.Name(), err)
 	}
 
 	w.viewsByName[v.Name()] = v

--- a/stats/worker_test.go
+++ b/stats/worker_test.go
@@ -126,13 +126,12 @@ func Test_Worker_MeasureByName(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		m, err := GetMeasureByName(tc.name)
+		m, err := MeasureByName(tc.name)
 		if (err != nil) != (tc.err != nil) {
-			t.Errorf("GetMeasureByName. got error %v, want %v. Test case: %v", err, tc.err, tc.label)
+			t.Errorf("MeasureByName(%q) = %v, want %v", tc.label, err, tc.err)
 		}
-
 		if m != tc.m {
-			t.Errorf("GetMeasureByName. got measure %v, want measure %v. Test case: %v", m, tc.m, tc.label)
+			t.Errorf("MeasureByName(%q) got measure %v; want %v", tc.label, m, tc.m)
 		}
 	}
 }
@@ -217,26 +216,26 @@ func Test_Worker_MeasureDelete(t *testing.T) {
 
 		for _, n := range tc.measureNames {
 			if _, err := NewMeasureInt64(n, "some desc", "unit"); err != nil {
-				t.Errorf("Creating measure got error '%v'. test case: '%v'", err, tc.label)
+				t.Errorf("%v: Cannot create measure: %v'", tc.label, err)
 			}
 		}
 
 		for _, r := range tc.registrations {
-			m, err := GetMeasureByName(r.measureName)
+			m, err := MeasureByName(r.measureName)
 			if err != nil {
-				t.Errorf("Retrieving measure '%v' got '%v', want no error. test case: '%v'", r.measureName, err, tc.label)
+				t.Errorf("%v: MeasureByName(%q) = %v; want no error", tc.label, r.measureName, err)
 				continue
 			}
 			if err = r.regFunc(m); err != nil {
-				t.Errorf("Registring view got '%v', want no error. test case: '%v'", err, tc.label)
+				t.Errorf("%v: Cannot register view: %v", tc.label, err)
 				continue
 			}
 		}
 
 		for _, d := range tc.deletions {
-			m, err := GetMeasureByName(d.name)
+			m, err := MeasureByName(d.name)
 			if (err != nil) != (d.getErr != nil) {
-				t.Errorf("Retrieving measure got '%v', want '%v'. test case: '%v'", err, d.getErr, tc.label)
+				t.Errorf("%v: MeasureByName = %v; want %v", tc.label, d.getErr, err)
 				continue
 			}
 
@@ -247,7 +246,7 @@ func Test_Worker_MeasureDelete(t *testing.T) {
 
 			err = DeleteMeasure(m)
 			if (err != nil) != (d.deleteErr != nil) {
-				t.Errorf("Deleting measure got '%v', want '%v'. test case: '%v'", err, d.deleteErr, tc.label)
+				t.Errorf("%v: Cannot delete measure: got %v as error; want %v", tc.label, err, d.deleteErr)
 			}
 
 			var deleted bool
@@ -255,8 +254,9 @@ func Test_Worker_MeasureDelete(t *testing.T) {
 				deleted = true
 			}
 
-			if _, err := GetMeasureByName(d.name); deleted && (err == nil) {
-				t.Errorf("Retrieving measure succedded after delete succeded. test case: '%v'", tc.label)
+			if _, err := MeasureByName(d.name); deleted && err == nil {
+				// TODO(jbd): Look for ErrNotExists instead.
+				t.Errorf("%v: Measure %q shouldn't exist after deletion but exists", tc.label, d.name)
 				continue
 			}
 		}
@@ -455,14 +455,14 @@ func Test_Worker_ViewRegistration(t *testing.T) {
 		}
 
 		for _, byname := range tc.bynames {
-			v, err := GetViewByName(byname.name)
+			v, err := ViewByName(byname.name)
 			if (err != nil) != (byname.err != nil) {
-				t.Errorf("GetViewByName. got error %v, want %v. Test case: %v", err, byname.err, tc.label)
+				t.Errorf("%v: ViewByName errored with %v, want %v", tc.label, err, byname.err)
 			}
 
 			wantV := views[byname.vID]
 			if v != wantV {
-				t.Errorf("GetViewByName. got view '%v' '%v', want view %v. Test case: %v", v.Name(), v.Description(), wantV, tc.label)
+				t.Errorf("%v: ViewByName = %v; want %v", tc.label, v, wantV)
 			}
 		}
 	}


### PR DESCRIPTION
Change also includes minor styling improvements and better error outputs from tests.

Fixes #31.