### PR TITLE
Revise Measure and Measurement API

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ if err != nil {
 Retrieve measure by name:
 
 ```go
-mf, err := stats.GetMeasureByName("/my/float64/measureName")
+mf, err := stats.FindMeasure("/my/float64/measureName")
 if err != nil {
     // handle error
 }
-mi, err := stats.GetMeasureByName("/my/otherName")
+mi, err := stats.FindMeasure("/my/otherName")
 if err != nil {
     // handle error
 }
@@ -230,15 +230,14 @@ if err := stats.StopForcedCollection(myView1); err != nil {
 ```
 
 ### Recording measurements
-Recording usage can only be performed against already registered measure and and their registered views. Measurements are implicitly tagged with the tags in the context:
+Recording usage can only be performed against already registered measure
+and their registered views. Measurements are implicitly tagged with the
+tags in the context:
 
 ```go
-// mi is a *MeasureInt64 and v is an int64 .
-stats.RecordInt64(ctx, mi, v)
-// mf is a *RecordFloat64 and v is an float64 .
-stats.RecordFloat64(ctx, mf, v)
-// multiple measurements can be performed at once.
-stats.Record(ctx, mi.Is(4), mf.Is(10.5))
+mi.Record(ctx, 1)
+mf.Record(ctx, 5.6)
+stats.Record(ctx, mi.M(4), mf.M(10.5))
 ```
 
 ### Retrieving collected data for a View

--- a/examples/stats/main.go
+++ b/examples/stats/main.go
@@ -117,11 +117,11 @@ func main() {
 	ctx := tags.NewContext(context.Background(), tsb.Build())
 
 	// Recording single datapoint at a time.
-	stats.RecordFloat64(ctx, videoSize, 10.0)
-	stats.RecordInt64(ctx, videoSpamCount, 1)
+	videoSize.Record(ctx, 10.0)
+	videoSpamCount.Record(ctx, 1)
 
 	// Recording multiple datapoints at once.
-	stats.Record(ctx, videoSpamCount.Is(2), videoSize.Is(100.0))
+	stats.Record(ctx, videoSpamCount.M(2), videoSize.M(100.0))
 
 	// Wait for a duration longer than reporting duration to ensure the stats
 	// library reports the collected data.

--- a/plugins/grpc/stats/client_handler.go
+++ b/plugins/grpc/stats/client_handler.go
@@ -102,8 +102,7 @@ func (ch clientHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) cont
 	// TODO(acetechnologist): should we be recording this later? What is the
 	// point of updating d.reqLen & d.reqCount if we update now?
 	ctx = tags.NewContext(ctx, tsb.Build())
-	istats.RecordInt64(ctx, RPCClientStartedCount, 1)
-
+	RPCClientStartedCount.Record(ctx, 1)
 	return context.WithValue(ctx, grpcClientRPCKey, d)
 }
 
@@ -132,7 +131,7 @@ func (ch clientHandler) handleRPCOutPayload(ctx context.Context, s *stats.OutPay
 		return
 	}
 
-	istats.RecordInt64(ctx, RPCClientRequestBytes, int64(s.Length))
+	RPCClientRequestBytes.Record(ctx, int64(s.Length))
 	atomic.AddUint64(&d.reqCount, 1)
 }
 
@@ -145,7 +144,7 @@ func (ch clientHandler) handleRPCInPayload(ctx context.Context, s *stats.InPaylo
 		return
 	}
 
-	istats.RecordInt64(ctx, RPCClientResponseBytes, int64(s.Length))
+	RPCClientResponseBytes.Record(ctx, int64(s.Length))
 	atomic.AddUint64(&d.respCount, 1)
 }
 
@@ -160,10 +159,10 @@ func (ch clientHandler) handleRPCEnd(ctx context.Context, s *stats.End) {
 	elapsedTime := time.Since(d.startTime)
 
 	var measurements []istats.Measurement
-	measurements = append(measurements, RPCClientRequestCount.Is(int64(d.reqCount)))
-	measurements = append(measurements, RPCClientResponseCount.Is(int64(d.respCount)))
-	measurements = append(measurements, RPCClientFinishedCount.Is(1))
-	measurements = append(measurements, RPCClientRoundTripLatency.Is(float64(elapsedTime)/float64(time.Millisecond)))
+	measurements = append(measurements, RPCClientRequestCount.M(int64(d.reqCount)))
+	measurements = append(measurements, RPCClientResponseCount.M(int64(d.respCount)))
+	measurements = append(measurements, RPCClientFinishedCount.M(1))
+	measurements = append(measurements, RPCClientRoundTripLatency.M(float64(elapsedTime)/float64(time.Millisecond)))
 
 	if s.Error != nil {
 		errorCode := s.Error.Error()
@@ -172,7 +171,7 @@ func (ch clientHandler) handleRPCEnd(ctx context.Context, s *stats.End) {
 		tsb.UpsertString(keyOpStatus, errorCode)
 
 		ctx = tags.NewContext(ctx, tsb.Build())
-		measurements = append(measurements, RPCClientErrorCount.Is(1))
+		measurements = append(measurements, RPCClientErrorCount.M(1))
 	}
 
 	istats.Record(ctx, measurements...)

--- a/plugins/grpc/stats/server_handler.go
+++ b/plugins/grpc/stats/server_handler.go
@@ -99,7 +99,7 @@ func (sh serverHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) cont
 	}
 	ctx = tags.NewContext(ctx, ts)
 
-	istats.RecordInt64(ctx, RPCServerStartedCount, 1)
+	RPCServerStartedCount.Record(ctx, 1)
 	return context.WithValue(ctx, grpcServerRPCKey, d)
 }
 
@@ -137,7 +137,7 @@ func (sh serverHandler) handleRPCInPayload(ctx context.Context, s *stats.InPaylo
 		return
 	}
 
-	istats.RecordInt64(ctx, RPCServerRequestBytes, int64(s.Length))
+	RPCServerRequestBytes.Record(ctx, int64(s.Length))
 	atomic.AddUint64(&d.reqCount, 1)
 }
 
@@ -150,7 +150,7 @@ func (sh serverHandler) handleRPCOutPayload(ctx context.Context, s *stats.OutPay
 		return
 	}
 
-	istats.RecordInt64(ctx, RPCServerResponseBytes, int64(s.Length))
+	RPCServerResponseBytes.Record(ctx, int64(s.Length))
 	atomic.AddUint64(&d.respCount, 1)
 }
 
@@ -165,10 +165,10 @@ func (sh serverHandler) handleRPCEnd(ctx context.Context, s *stats.End) {
 	elapsedTime := time.Since(d.startTime)
 
 	var measurements []istats.Measurement
-	measurements = append(measurements, RPCServerRequestCount.Is(int64(d.reqCount)))
-	measurements = append(measurements, RPCServerResponseCount.Is(int64(d.respCount)))
-	measurements = append(measurements, RPCServerFinishedCount.Is(1))
-	measurements = append(measurements, RPCServerServerElapsedTime.Is(float64(elapsedTime)/float64(time.Millisecond)))
+	measurements = append(measurements, RPCServerRequestCount.M(int64(d.reqCount)))
+	measurements = append(measurements, RPCServerResponseCount.M(int64(d.respCount)))
+	measurements = append(measurements, RPCServerFinishedCount.M(1))
+	measurements = append(measurements, RPCServerServerElapsedTime.M(float64(elapsedTime)/float64(time.Millisecond)))
 	if s.Error != nil {
 		errorCode := s.Error.Error()
 		ts := tags.FromContext(ctx)
@@ -177,7 +177,7 @@ func (sh serverHandler) handleRPCEnd(ctx context.Context, s *stats.End) {
 
 		ts = tsb.Build()
 		ctx = tags.NewContext(ctx, ts)
-		measurements = append(measurements, RPCServerErrorCount.Is(1))
+		measurements = append(measurements, RPCServerErrorCount.M(1))
 	}
 
 	istats.Record(ctx, measurements...)

--- a/stats/measure.go
+++ b/stats/measure.go
@@ -24,8 +24,32 @@ type Measure interface {
 	viewsCount() int
 }
 
-// Measurement is the interface for all measurement types. Measurements are
-// required when recording stats.
+// Measurement is the numeric value measured when recording stats. Each measure
+// provides methods to create measurements of their kind. For example, MeasureInt64
+// provides M to convert an int64 into a measurement.
 type Measurement interface {
-	isMeasurement() bool
+	isMeasurement()
+}
+
+// FindMeasure returns the registered measure associated with name.
+func FindMeasure(name string) (Measure, error) {
+	req := &getMeasureByNameReq{
+		name: name,
+		c:    make(chan *getMeasureByNameResp),
+	}
+	defaultWorker.c <- req
+	resp := <-req.c
+	return resp.m, resp.err
+}
+
+// DeleteMeasure deletes an existing measure to allow for creation of a new
+// measure with the same name. It returns an error if the measure cannot be
+// deleted (if one or multiple registered views refer to it).
+func DeleteMeasure(m Measure) error {
+	req := &deleteMeasureReq{
+		m:   m,
+		err: make(chan error),
+	}
+	defaultWorker.c <- req
+	return <-req.err
 }

--- a/stats/measure_float64.go
+++ b/stats/measure_float64.go
@@ -43,12 +43,10 @@ func (m *MeasureFloat64) removeView(v *View) {
 
 func (m *MeasureFloat64) viewsCount() int { return len(m.views) }
 
-// Is creates a new measurement/datapoint of type measurementFloat64.
-func (m *MeasureFloat64) Is(v float64) Measurement {
-	return &measurementFloat64{
-		m: m,
-		v: v,
-	}
+// M creates a new float64 measurement.
+// Use Record to record multiple measurements.
+func (m *MeasureFloat64) M(v float64) Measurement {
+	return &measurementFloat64{m: m, v: v}
 }
 
 type measurementFloat64 struct {
@@ -56,4 +54,4 @@ type measurementFloat64 struct {
 	v float64
 }
 
-func (mf *measurementFloat64) isMeasurement() bool { return true }
+func (mf *measurementFloat64) isMeasurement() {}

--- a/stats/measure_int64.go
+++ b/stats/measure_int64.go
@@ -43,12 +43,10 @@ func (m *MeasureInt64) removeView(v *View) {
 
 func (m *MeasureInt64) viewsCount() int { return len(m.views) }
 
-// Is creates a new measurement/datapoint of type measurementInt64.
-func (m *MeasureInt64) Is(v int64) Measurement {
-	return &measurementInt64{
-		m: m,
-		v: v,
-	}
+// M creates a new int64 measurement.
+// Use Record to record multiple measurements.
+func (m *MeasureInt64) M(v int64) Measurement {
+	return &measurementInt64{m: m, v: v}
 }
 
 type measurementInt64 struct {
@@ -56,4 +54,4 @@ type measurementInt64 struct {
 	v int64
 }
 
-func (mi *measurementInt64) isMeasurement() bool { return true }
+func (mi *measurementInt64) isMeasurement() {}

--- a/stats/worker_test.go
+++ b/stats/worker_test.go
@@ -57,7 +57,7 @@ func Test_Worker_MeasureCreation(t *testing.T) {
 	}
 }
 
-func Test_Worker_MeasureByName(t *testing.T) {
+func Test_Worker_FindMeasure(t *testing.T) {
 	RestartWorker()
 
 	someError := errors.New("some error")
@@ -127,12 +127,12 @@ func Test_Worker_MeasureByName(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		m, err := MeasureByName(tc.name)
+		m, err := FindMeasure(tc.name)
 		if (err != nil) != (tc.err != nil) {
-			t.Errorf("MeasureByName(%q) = %v, want %v", tc.label, err, tc.err)
+			t.Errorf("FindMeasure(%q) = %v, want %v", tc.label, err, tc.err)
 		}
 		if m != tc.m {
-			t.Errorf("MeasureByName(%q) got measure %v; want %v", tc.label, m, tc.m)
+			t.Errorf("FindMeasure(%q) got measure %v; want %v", tc.label, m, tc.m)
 		}
 	}
 }
@@ -222,9 +222,9 @@ func Test_Worker_MeasureDelete(t *testing.T) {
 		}
 
 		for _, r := range tc.registrations {
-			m, err := MeasureByName(r.measureName)
+			m, err := FindMeasure(r.measureName)
 			if err != nil {
-				t.Errorf("%v: MeasureByName(%q) = %v; want no error", tc.label, r.measureName, err)
+				t.Errorf("%v: FindMeasure(%q) = %v; want no error", tc.label, r.measureName, err)
 				continue
 			}
 			if err = r.regFunc(m); err != nil {
@@ -234,9 +234,9 @@ func Test_Worker_MeasureDelete(t *testing.T) {
 		}
 
 		for _, d := range tc.deletions {
-			m, err := MeasureByName(d.name)
+			m, err := FindMeasure(d.name)
 			if (err != nil) != (d.getErr != nil) {
-				t.Errorf("%v: MeasureByName = %v; want %v", tc.label, d.getErr, err)
+				t.Errorf("%v: FindMeasure = %v; want %v", tc.label, d.getErr, err)
 				continue
 			}
 
@@ -255,7 +255,7 @@ func Test_Worker_MeasureDelete(t *testing.T) {
 				deleted = true
 			}
 
-			if _, err := MeasureByName(d.name); deleted && err == nil {
+			if _, err := FindMeasure(d.name); deleted && err == nil {
 				// TODO(jbd): Look for ErrNotExists instead.
 				t.Errorf("%v: Measure %q shouldn't exist after deletion but exists", tc.label, d.name)
 				continue
@@ -666,7 +666,7 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 		}
 
 		for _, value := range tc.records {
-			RecordFloat64(ctx, m, value)
+			m.Record(ctx, value)
 		}
 
 		for _, w := range tc.wants {


### PR DESCRIPTION
- Simplify the Measurement interface.
- Rename MeasureByName to FindMeasure, measures are always retrieved by name.
- Export recorder functions on measure.
- Rename (*MeasureX).Is to (*MeasureX.M).
- Add TODOs, make some style improvements.