### PR TITLE
Convert View into a concrete type

### DIFF
--- a/plugins/grpc/stats/client_handler_test.go
+++ b/plugins/grpc/stats/client_handler_test.go
@@ -37,7 +37,7 @@ func TestClientDefaultCollections(t *testing.T) {
 	}
 
 	type wantData struct {
-		v    func() istats.View
+		v    func() *istats.View
 		rows []*istats.Row
 	}
 	type rpc struct {
@@ -71,7 +71,7 @@ func TestClientDefaultCollections(t *testing.T) {
 			},
 			[]*wantData{
 				{
-					func() istats.View { return RPCClientRequestCountView },
+					func() *istats.View { return RPCClientRequestCountView },
 					[]*istats.Row{
 						{
 							[]tags.Tag{
@@ -83,7 +83,7 @@ func TestClientDefaultCollections(t *testing.T) {
 					},
 				},
 				{
-					func() istats.View { return RPCClientResponseCountView },
+					func() *istats.View { return RPCClientResponseCountView },
 					[]*istats.Row{
 						{
 							[]tags.Tag{
@@ -95,7 +95,7 @@ func TestClientDefaultCollections(t *testing.T) {
 					},
 				},
 				{
-					func() istats.View { return RPCClientRequestBytesView },
+					func() *istats.View { return RPCClientRequestBytesView },
 					[]*istats.Row{
 						{
 							[]tags.Tag{
@@ -107,7 +107,7 @@ func TestClientDefaultCollections(t *testing.T) {
 					},
 				},
 				{
-					func() istats.View { return RPCClientResponseBytesView },
+					func() *istats.View { return RPCClientResponseBytesView },
 					[]*istats.Row{
 						{
 							[]tags.Tag{
@@ -152,7 +152,7 @@ func TestClientDefaultCollections(t *testing.T) {
 			},
 			[]*wantData{
 				{
-					func() istats.View { return RPCClientErrorCountView },
+					func() *istats.View { return RPCClientErrorCountView },
 					[]*istats.Row{
 						{
 							[]tags.Tag{
@@ -165,7 +165,7 @@ func TestClientDefaultCollections(t *testing.T) {
 					},
 				},
 				{
-					func() istats.View { return RPCClientRequestCountView },
+					func() *istats.View { return RPCClientRequestCountView },
 					[]*istats.Row{
 						{
 							[]tags.Tag{
@@ -177,7 +177,7 @@ func TestClientDefaultCollections(t *testing.T) {
 					},
 				},
 				{
-					func() istats.View { return RPCClientResponseCountView },
+					func() *istats.View { return RPCClientResponseCountView },
 					[]*istats.Row{
 						{
 							[]tags.Tag{
@@ -235,7 +235,7 @@ func TestClientDefaultCollections(t *testing.T) {
 			},
 			[]*wantData{
 				{
-					func() istats.View { return RPCClientErrorCountView },
+					func() *istats.View { return RPCClientErrorCountView },
 					[]*istats.Row{
 						{
 							[]tags.Tag{
@@ -256,7 +256,7 @@ func TestClientDefaultCollections(t *testing.T) {
 					},
 				},
 				{
-					func() istats.View { return RPCClientRequestCountView },
+					func() *istats.View { return RPCClientRequestCountView },
 					[]*istats.Row{
 						{
 							[]tags.Tag{
@@ -268,7 +268,7 @@ func TestClientDefaultCollections(t *testing.T) {
 					},
 				},
 				{
-					func() istats.View { return RPCClientResponseCountView },
+					func() *istats.View { return RPCClientResponseCountView },
 					[]*istats.Row{
 						{
 							[]tags.Tag{
@@ -280,7 +280,7 @@ func TestClientDefaultCollections(t *testing.T) {
 					},
 				},
 				{
-					func() istats.View { return RPCClientRequestBytesView },
+					func() *istats.View { return RPCClientRequestBytesView },
 					[]*istats.Row{
 						{
 							[]tags.Tag{
@@ -292,7 +292,7 @@ func TestClientDefaultCollections(t *testing.T) {
 					},
 				},
 				{
-					func() istats.View { return RPCClientResponseBytesView },
+					func() *istats.View { return RPCClientResponseBytesView },
 					[]*istats.Row{
 						{
 							[]tags.Tag{
@@ -335,7 +335,7 @@ func TestClientDefaultCollections(t *testing.T) {
 		}
 
 		for _, wantData := range tc.wants {
-			gotRows, err := istats.RetrieveData(wantData.v())
+			gotRows, err := wantData.v().RetrieveData()
 			if err != nil {
 				t.Errorf("Test case '%v'. RetrieveData for %v failed. %v", tc.label, wantData.v().Name(), err)
 				continue

--- a/plugins/grpc/stats/client_metrics.go
+++ b/plugins/grpc/stats/client_metrics.go
@@ -40,30 +40,30 @@ var (
 	RPCClientResponseCount    *istats.MeasureInt64
 
 	// Default client views
-	RPCClientErrorCountView       istats.View
-	RPCClientRoundTripLatencyView istats.View
-	RPCClientRequestBytesView     istats.View
-	RPCClientResponseBytesView    istats.View
-	RPCClientRequestCountView     istats.View
-	RPCClientResponseCountView    istats.View
+	RPCClientErrorCountView       *istats.View
+	RPCClientRoundTripLatencyView *istats.View
+	RPCClientRequestBytesView     *istats.View
+	RPCClientResponseBytesView    *istats.View
+	RPCClientRequestCountView     *istats.View
+	RPCClientResponseCountView    *istats.View
 
-	RPCClientRoundTripLatencyMinuteView istats.View
-	RPCClientRequestBytesMinuteView     istats.View
-	RPCClientResponseBytesMinuteView    istats.View
-	RPCClientErrorCountMinuteView       istats.View
-	RPCClientStartedCountMinuteView     istats.View
-	RPCClientFinishedCountMinuteView    istats.View
-	RPCClientRequestCountMinuteView     istats.View
-	RPCClientResponseCountMinuteView    istats.View
+	RPCClientRoundTripLatencyMinuteView *istats.View
+	RPCClientRequestBytesMinuteView     *istats.View
+	RPCClientResponseBytesMinuteView    *istats.View
+	RPCClientErrorCountMinuteView       *istats.View
+	RPCClientStartedCountMinuteView     *istats.View
+	RPCClientFinishedCountMinuteView    *istats.View
+	RPCClientRequestCountMinuteView     *istats.View
+	RPCClientResponseCountMinuteView    *istats.View
 
-	RPCClientRoundTripLatencyHourView istats.View
-	RPCClientRequestBytesHourView     istats.View
-	RPCClientResponseBytesHourView    istats.View
-	RPCClientErrorCountHourView       istats.View
-	RPCClientStartedCountHourView     istats.View
-	RPCClientFinishedCountHourView    istats.View
-	RPCClientRequestCountHourView     istats.View
-	RPCClientResponseCountHourView    istats.View
+	RPCClientRoundTripLatencyHourView *istats.View
+	RPCClientRequestBytesHourView     *istats.View
+	RPCClientResponseBytesHourView    *istats.View
+	RPCClientErrorCountHourView       *istats.View
+	RPCClientStartedCountHourView     *istats.View
+	RPCClientFinishedCountHourView    *istats.View
+	RPCClientRequestCountHourView     *istats.View
+	RPCClientResponseCountHourView    *istats.View
 )
 
 func createDefaultMeasuresClient() {
@@ -98,7 +98,7 @@ func createDefaultMeasuresClient() {
 }
 
 func registerDefaultViewsClient() {
-	var views []istats.View
+	var views []*istats.View
 
 	RPCClientErrorCountView = istats.NewView("grpc.io/client/error_count/distribution_cumulative", "RPC Errors", []tags.Key{keyOpStatus, keyService, keyMethod}, RPCClientErrorCount, aggCount, windowCumulative)
 	views = append(views, RPCClientErrorCountView)
@@ -150,10 +150,10 @@ func registerDefaultViewsClient() {
 	// Registering views
 	for _, v := range views {
 		if err := istats.RegisterView(v); err != nil {
-			log.Fatalf("init() failed to register %v.%v\n", v, err)
+			log.Fatalf("init() failed to register %v: %v.\n", v, err)
 		}
-		if err := istats.ForceCollection(v); err != nil {
-			log.Fatalf("init() failed to ForceCollection %v.%v\n", v, err)
+		if err := v.ForceCollect(); err != nil {
+			log.Fatalf("init() failed to ForceCollect %v: %v.\n", v, err)
 		}
 	}
 }

--- a/plugins/grpc/stats/server_handler_test.go
+++ b/plugins/grpc/stats/server_handler_test.go
@@ -37,7 +37,7 @@ func TestServerDefaultCollections(t *testing.T) {
 	}
 
 	type wantData struct {
-		v    func() istats.View
+		v    func() *istats.View
 		rows []*istats.Row
 	}
 	type rpc struct {
@@ -71,7 +71,7 @@ func TestServerDefaultCollections(t *testing.T) {
 			},
 			[]*wantData{
 				{
-					func() istats.View { return RPCServerRequestCountView },
+					func() *istats.View { return RPCServerRequestCountView },
 					[]*istats.Row{
 						{
 							[]tags.Tag{
@@ -83,7 +83,7 @@ func TestServerDefaultCollections(t *testing.T) {
 					},
 				},
 				{
-					func() istats.View { return RPCServerResponseCountView },
+					func() *istats.View { return RPCServerResponseCountView },
 					[]*istats.Row{
 						{
 							[]tags.Tag{
@@ -95,7 +95,7 @@ func TestServerDefaultCollections(t *testing.T) {
 					},
 				},
 				{
-					func() istats.View { return RPCServerRequestBytesView },
+					func() *istats.View { return RPCServerRequestBytesView },
 					[]*istats.Row{
 						{
 							[]tags.Tag{
@@ -107,7 +107,7 @@ func TestServerDefaultCollections(t *testing.T) {
 					},
 				},
 				{
-					func() istats.View { return RPCServerResponseBytesView },
+					func() *istats.View { return RPCServerResponseBytesView },
 					[]*istats.Row{
 						{
 							[]tags.Tag{
@@ -152,7 +152,7 @@ func TestServerDefaultCollections(t *testing.T) {
 			},
 			[]*wantData{
 				{
-					func() istats.View { return RPCServerErrorCountView },
+					func() *istats.View { return RPCServerErrorCountView },
 					[]*istats.Row{
 						{
 							[]tags.Tag{
@@ -165,7 +165,7 @@ func TestServerDefaultCollections(t *testing.T) {
 					},
 				},
 				{
-					func() istats.View { return RPCServerRequestCountView },
+					func() *istats.View { return RPCServerRequestCountView },
 					[]*istats.Row{
 						{
 							[]tags.Tag{
@@ -177,7 +177,7 @@ func TestServerDefaultCollections(t *testing.T) {
 					},
 				},
 				{
-					func() istats.View { return RPCServerResponseCountView },
+					func() *istats.View { return RPCServerResponseCountView },
 					[]*istats.Row{
 						{
 							[]tags.Tag{
@@ -235,7 +235,7 @@ func TestServerDefaultCollections(t *testing.T) {
 			},
 			[]*wantData{
 				{
-					func() istats.View { return RPCServerErrorCountView },
+					func() *istats.View { return RPCServerErrorCountView },
 					[]*istats.Row{
 						{
 							[]tags.Tag{
@@ -256,7 +256,7 @@ func TestServerDefaultCollections(t *testing.T) {
 					},
 				},
 				{
-					func() istats.View { return RPCServerRequestCountView },
+					func() *istats.View { return RPCServerRequestCountView },
 					[]*istats.Row{
 						{
 							[]tags.Tag{
@@ -268,7 +268,7 @@ func TestServerDefaultCollections(t *testing.T) {
 					},
 				},
 				{
-					func() istats.View { return RPCServerResponseCountView },
+					func() *istats.View { return RPCServerResponseCountView },
 					[]*istats.Row{
 						{
 							[]tags.Tag{
@@ -280,7 +280,7 @@ func TestServerDefaultCollections(t *testing.T) {
 					},
 				},
 				{
-					func() istats.View { return RPCServerRequestBytesView },
+					func() *istats.View { return RPCServerRequestBytesView },
 					[]*istats.Row{
 						{
 							[]tags.Tag{
@@ -292,7 +292,7 @@ func TestServerDefaultCollections(t *testing.T) {
 					},
 				},
 				{
-					func() istats.View { return RPCServerResponseBytesView },
+					func() *istats.View { return RPCServerResponseBytesView },
 					[]*istats.Row{
 						{
 							[]tags.Tag{
@@ -335,7 +335,7 @@ func TestServerDefaultCollections(t *testing.T) {
 		}
 
 		for _, wantData := range tc.wants {
-			gotRows, err := istats.RetrieveData(wantData.v())
+			gotRows, err := wantData.v().RetrieveData()
 			if err != nil {
 				t.Errorf("Test case '%v'. RetrieveData for %v failed. %v", tc.label, wantData.v().Name(), err)
 				continue

--- a/plugins/grpc/stats/server_metrics.go
+++ b/plugins/grpc/stats/server_metrics.go
@@ -40,30 +40,30 @@ var (
 	RPCServerResponseCount     *istats.MeasureInt64
 
 	// Default server views
-	RPCServerErrorCountView        istats.View
-	RPCServerServerElapsedTimeView istats.View
-	RPCServerRequestBytesView      istats.View
-	RPCServerResponseBytesView     istats.View
-	RPCServerRequestCountView      istats.View
-	RPCServerResponseCountView     istats.View
+	RPCServerErrorCountView        *istats.View
+	RPCServerServerElapsedTimeView *istats.View
+	RPCServerRequestBytesView      *istats.View
+	RPCServerResponseBytesView     *istats.View
+	RPCServerRequestCountView      *istats.View
+	RPCServerResponseCountView     *istats.View
 
-	RPCServerServerElapsedTimeMinuteView istats.View
-	RPCServerRequestBytesMinuteView      istats.View
-	RPCServerResponseBytesMinuteView     istats.View
-	RPCServerErrorCountMinuteView        istats.View
-	RPCServerStartedCountMinuteView      istats.View
-	RPCServerFinishedCountMinuteView     istats.View
-	RPCServerRequestCountMinuteView      istats.View
-	RPCServerResponseCountMinuteView     istats.View
+	RPCServerServerElapsedTimeMinuteView *istats.View
+	RPCServerRequestBytesMinuteView      *istats.View
+	RPCServerResponseBytesMinuteView     *istats.View
+	RPCServerErrorCountMinuteView        *istats.View
+	RPCServerStartedCountMinuteView      *istats.View
+	RPCServerFinishedCountMinuteView     *istats.View
+	RPCServerRequestCountMinuteView      *istats.View
+	RPCServerResponseCountMinuteView     *istats.View
 
-	RPCServerServerElapsedTimeHourView istats.View
-	RPCServerRequestBytesHourView      istats.View
-	RPCServerResponseBytesHourView     istats.View
-	RPCServerErrorCountHourView        istats.View
-	RPCServerStartedCountHourView      istats.View
-	RPCServerFinishedCountHourView     istats.View
-	RPCServerRequestCountHourView      istats.View
-	RPCServerResponseCountHourView     istats.View
+	RPCServerServerElapsedTimeHourView *istats.View
+	RPCServerRequestBytesHourView      *istats.View
+	RPCServerResponseBytesHourView     *istats.View
+	RPCServerErrorCountHourView        *istats.View
+	RPCServerStartedCountHourView      *istats.View
+	RPCServerFinishedCountHourView     *istats.View
+	RPCServerRequestCountHourView      *istats.View
+	RPCServerResponseCountHourView     *istats.View
 )
 
 func createDefaultMeasuresServer() {
@@ -98,7 +98,7 @@ func createDefaultMeasuresServer() {
 }
 
 func registerDefaultViewsServer() {
-	var views []istats.View
+	var views []*istats.View
 
 	RPCServerErrorCountView = istats.NewView("grpc.io/server/error_count/distribution_cumulative", "RPC Errors", []tags.Key{keyMethod, keyOpStatus, keyService}, RPCServerErrorCount, aggCount, windowCumulative)
 	views = append(views, RPCServerErrorCountView)
@@ -150,10 +150,10 @@ func registerDefaultViewsServer() {
 	// Registering views
 	for _, v := range views {
 		if err := istats.RegisterView(v); err != nil {
-			log.Fatalf("init() failed to register %v.%v\n", v, err)
+			log.Fatalf("init() failed to register %v: %v.\n", v, err)
 		}
-		if err := istats.ForceCollection(v); err != nil {
-			log.Fatalf("init() failed to ForceCollection %v.%v\n", v, err)
+		if err := v.ForceCollect(); err != nil {
+			log.Fatalf("init() failed to ForceCollect %v: %v.\n", v, err)
 		}
 	}
 }

--- a/samples/stats/main.go
+++ b/samples/stats/main.go
@@ -88,13 +88,13 @@ func main() {
 		}
 	}(subCh)
 
-	if err = stats.SubscribeToView(videoSizeView, subCh); err != nil {
+	if err = videoSizeView.Subscribe(subCh); err != nil {
 		log.Fatalf("Subscription to view %v failed. %v", videoSizeView, err)
 	}
 
 	// stats.ForceCollection explicitly instructs the library to collect the
 	// view data for on-demand retrieval.
-	if err := stats.ForceCollection(videoSpamCountView); err != nil {
+	if err := videoSpamCountView.ForceCollect(); err != nil {
 		log.Fatalf("Forced collection of view %v failed. %v", videoSpamCountView, err)
 	}
 
@@ -121,7 +121,7 @@ func main() {
 
 	fmt.Print("\nRetrieve data on demand\n")
 	// Pull collected data synchronously from the library
-	rows, err := stats.RetrieveData(videoSpamCountView)
+	rows, err := videoSpamCountView.RetrieveData()
 	if err != nil {
 		log.Fatalf("Retrieving data from view %v failed. %v", videoSpamCountView, err)
 	}

--- a/stats/measure.go
+++ b/stats/measure.go
@@ -19,8 +19,8 @@ package stats
 // defining a view.
 type Measure interface {
 	Name() string
-	addView(v View)
-	removeView(v View)
+	addView(v *View)
+	removeView(v *View)
 	viewsCount() int
 }
 

--- a/stats/measure_float64.go
+++ b/stats/measure_float64.go
@@ -20,7 +20,7 @@ type MeasureFloat64 struct {
 	name        string
 	unit        string
 	description string
-	views       map[View]bool
+	views       map[*View]bool
 }
 
 // Name returns the name of the measure.
@@ -33,11 +33,11 @@ func (m *MeasureFloat64) Unit() string {
 	return m.unit
 }
 
-func (m *MeasureFloat64) addView(v View) {
+func (m *MeasureFloat64) addView(v *View) {
 	m.views[v] = true
 }
 
-func (m *MeasureFloat64) removeView(v View) {
+func (m *MeasureFloat64) removeView(v *View) {
 	delete(m.views, v)
 }
 

--- a/stats/measure_int64.go
+++ b/stats/measure_int64.go
@@ -20,7 +20,7 @@ type MeasureInt64 struct {
 	name        string
 	unit        string
 	description string
-	views       map[View]bool
+	views       map[*View]bool
 }
 
 // Name returns the name of the measure.
@@ -33,11 +33,11 @@ func (m *MeasureInt64) Unit() string {
 	return m.unit
 }
 
-func (m *MeasureInt64) addView(v View) {
+func (m *MeasureInt64) addView(v *View) {
 	m.views[v] = true
 }
 
-func (m *MeasureInt64) removeView(v View) {
+func (m *MeasureInt64) removeView(v *View) {
 	delete(m.views, v)
 }
 

--- a/stats/view.go
+++ b/stats/view.go
@@ -24,36 +24,9 @@ import (
 	"github.com/census-instrumentation/opencensus-go/tags"
 )
 
-// View is the generic interface defining the various type of views.
-type View interface {
-	Name() string        // Name returns the name of a View.
-	Description() string // Description returns the description of a View.
-	Window() Window
-	Aggregation() Aggregation
-	Measure() Measure
-
-	addSubscription(c chan *ViewData)
-	deleteSubscription(c chan *ViewData)
-	subscriptionExists(c chan *ViewData) bool
-	subscriptionsCount() int
-	subscriptions() map[chan *ViewData]subscription
-
-	startForcedCollection()
-	stopForcedCollection()
-
-	isCollecting() bool
-
-	clearRows()
-
-	collector() *collector
-	collectedRows(now time.Time) []*Row
-
-	addSample(ts *tags.TagSet, val interface{}, now time.Time)
-}
-
-// view is the data structure that holds the info describing the view as well
+// View is the data structure that holds the info describing the view as well
 // as the aggregated data.
-type view struct {
+type View struct {
 	// name of View. Must be unique.
 	name        string
 	description string
@@ -76,17 +49,20 @@ type view struct {
 	// model.
 	isForcedCollection bool
 
+	// TODO(jbd): Guard isForcedCollection.
+
 	c *collector
 }
 
-// NewView creates a new View.
-func NewView(name, description string, keys []tags.Key, measure Measure, agg Aggregation, wnd Window) View {
+// NewView creates a new view. Views need to be registered
+// via RegisterView to enable data collection.
+func NewView(name, description string, keys []tags.Key, measure Measure, agg Aggregation, window Window) *View {
 	var keysCopy []tags.Key
 	for _, k := range keys {
 		keysCopy = append(keysCopy, k)
 	}
 
-	return &view{
+	return &View{
 		name,
 		description,
 		keysCopy,
@@ -94,82 +70,83 @@ func NewView(name, description string, keys []tags.Key, measure Measure, agg Agg
 		time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC),
 		make(map[chan *ViewData]subscription),
 		false,
-		&collector{
-			make(map[string]aggregator),
-			agg,
-			wnd,
-		},
+		&collector{make(map[string]aggregator), agg, window},
 	}
 }
 
 // Name returns the name of view.
-func (v *view) Name() string {
+func (v *View) Name() string {
 	return v.name
 }
 
 // Description returns the name of view.
-func (v *view) Description() string {
+func (v *View) Description() string {
 	return v.description
 }
 
-func (v *view) addSubscription(c chan *ViewData) {
+func (v *View) addSubscription(c chan *ViewData) {
 	v.ss[c] = subscription{}
 }
 
-func (v *view) deleteSubscription(c chan *ViewData) {
+func (v *View) deleteSubscription(c chan *ViewData) {
 	delete(v.ss, c)
 }
 
-func (v *view) subscriptionExists(c chan *ViewData) bool {
+func (v *View) subscriptionExists(c chan *ViewData) bool {
 	_, ok := v.ss[c]
 	return ok
 }
 
-func (v *view) subscriptionsCount() int {
+func (v *View) subscriptionsCount() int {
 	return len(v.ss)
 }
 
-func (v *view) subscriptions() map[chan *ViewData]subscription {
+func (v *View) subscriptions() map[chan *ViewData]subscription {
 	return v.ss
 }
 
-func (v *view) startForcedCollection() {
+func (v *View) startForcedCollection() {
 	v.isForcedCollection = true
 }
 
-func (v *view) stopForcedCollection() {
+func (v *View) stopForcedCollection() {
 	v.isForcedCollection = false
 }
 
-func (v *view) isCollecting() bool {
+func (v *View) isCollecting() bool {
 	return v.subscriptionsCount() > 0 || v.isForcedCollection
 }
 
-func (v *view) clearRows() {
+func (v *View) clearRows() {
 	v.c.clearRows()
 }
 
-func (v *view) collector() *collector {
+func (v *View) collector() *collector {
 	return v.c
 }
 
-func (v *view) Window() Window {
+// Window returns the timing window is being used to collect
+// metrics on this view.
+func (v *View) Window() Window {
 	return v.c.w
 }
 
-func (v *view) Aggregation() Aggregation {
+// Aggregation returns the Aggregation used to aggregate the measurements
+// collected by this view.
+func (v *View) Aggregation() Aggregation {
 	return v.c.a
 }
 
-func (v *view) Measure() Measure {
+// Measure returns the measure type the view is collecting measurements for.
+func (v *View) Measure() Measure {
 	return v.m
 }
 
-func (v *view) collectedRows(now time.Time) []*Row {
+func (v *View) collectedRows(now time.Time) []*Row {
 	return v.c.collectedRows(v.tagKeys, now)
 }
 
-func (v *view) addSample(ts *tags.TagSet, val interface{}, now time.Time) {
+func (v *View) addSample(ts *tags.TagSet, val interface{}, now time.Time) {
 	if !v.isCollecting() {
 		return
 	}
@@ -181,7 +158,7 @@ func (v *view) addSample(ts *tags.TagSet, val interface{}, now time.Time) {
 // with the given view during a particular window. Each row is specific to a
 // unique set of tags.
 type ViewData struct {
-	V          View
+	V          *View
 	Start, End time.Time
 	Rows       []*Row
 }

--- a/stats/worker_commands.go
+++ b/stats/worker_commands.go
@@ -96,7 +96,7 @@ type getViewByNameReq struct {
 }
 
 type getViewByNameResp struct {
-	v   View
+	v   *View
 	err error
 }
 
@@ -116,7 +116,7 @@ func (cmd *getViewByNameReq) handleCommand(w *worker) {
 
 // registerViewReq is the command to register a view with the library.
 type registerViewReq struct {
-	v   View
+	v   *View
 	err chan error
 }
 
@@ -126,7 +126,7 @@ func (cmd *registerViewReq) handleCommand(w *worker) {
 
 // unregisterViewReq is the command to unregister a view from the library.
 type unregisterViewReq struct {
-	v   View
+	v   *View
 	err chan error
 }
 
@@ -155,7 +155,7 @@ func (cmd *unregisterViewReq) handleCommand(w *worker) {
 
 // subscribeToViewReq is the command to subscribe to a view.
 type subscribeToViewReq struct {
-	v   View
+	v   *View
 	c   chan *ViewData
 	err chan error
 }
@@ -179,7 +179,7 @@ func (cmd *subscribeToViewReq) handleCommand(w *worker) {
 // impact on the data collection for client that are pulling data from the
 // library.
 type unsubscribeFromViewReq struct {
-	v   View
+	v   *View
 	c   chan *ViewData
 	err chan error
 }
@@ -202,7 +202,7 @@ func (cmd *unsubscribeFromViewReq) handleCommand(w *worker) {
 // startForcedCollection is the command to start collecting data for a view
 // without subscribing to it.
 type startForcedCollectionReq struct {
-	v   View
+	v   *View
 	err chan error
 }
 
@@ -224,7 +224,7 @@ func (cmd *startForcedCollectionReq) handleCommand(w *worker) {
 // clients will be requesting data for a view. Has no impact on the
 // subscriptions.
 type stopForcedCollectionReq struct {
-	v   View
+	v   *View
 	err chan error
 }
 
@@ -244,7 +244,7 @@ func (cmd *stopForcedCollectionReq) handleCommand(w *worker) {
 // retrieveDataReq is the command to retrieve data for a view.
 type retrieveDataReq struct {
 	now time.Time
-	v   View
+	v   *View
 	c   chan *retrieveDataResp
 }
 

--- a/stats/worker_test.go
+++ b/stats/worker_test.go
@@ -422,7 +422,7 @@ func Test_Worker_ViewRegistration(t *testing.T) {
 		mf1, _ := NewMeasureFloat64("MF1", "desc MF1", "unit")
 		mf2, _ := NewMeasureFloat64("MF2", "desc MF2", "unit")
 
-		views := make(map[string]View)
+		views := make(map[string]*View)
 		views["v1ID"] = NewView("VF1", "desc VF1", nil, mf1, nil, nil)
 		views["v1SameNameID"] = NewView("VF1", "desc duplicate name VF1.", nil, mf1, nil, nil)
 		views["v2ID"] = NewView("VF2", "desc VF2", nil, mf2, nil, nil)
@@ -435,34 +435,34 @@ func Test_Worker_ViewRegistration(t *testing.T) {
 			if (err != nil) != (reg.err != nil) {
 				t.Errorf("RegisterView. got error %v, want %v. Test case: %v", err, reg.err, tc.label)
 			}
-			ForceCollection(v)
+			v.ForceCollect()
 		}
 
 		for _, s := range tc.subscriptions {
 			v := views[s.vID]
-			err := SubscribeToView(v, s.c)
+			err := v.Subscribe(s.c)
 			if (err != nil) != (s.err != nil) {
-				t.Errorf("SubscribeToView. got error %v, want %v. Test case: %v", err, s.err, tc.label)
+				t.Errorf("Subscribe. got error %v, want %v. Test case: %v", err, s.err, tc.label)
 			}
 		}
 
 		for _, unreg := range tc.unregs {
 			v := views[unreg.vID]
-			err := UnregisterView(v)
+			err := v.Unregister()
 			if (err != nil) != (unreg.err != nil) {
-				t.Errorf("UnregisterView. got error %v, want %v. Test case: %v", err, unreg.err, tc.label)
+				t.Errorf("Unregister errored = %v; want %v. Test case: %v", err, unreg.err, tc.label)
 			}
 		}
 
 		for _, byname := range tc.bynames {
-			v, err := GetViewByName(byname.name)
+			v, err := FindView(byname.name)
 			if (err != nil) != (byname.err != nil) {
-				t.Errorf("GetViewByName. got error %v, want %v. Test case: %v", err, byname.err, tc.label)
+				t.Errorf("FindView. got error %v, want %v. Test case: %v", err, byname.err, tc.label)
 			}
 
 			wantV := views[byname.vID]
 			if v != wantV {
-				t.Errorf("GetViewByName. got view '%v' '%v', want view %v. Test case: %v", v.Name(), v.Description(), wantV, tc.label)
+				t.Errorf("FindView. got view '%v' '%v', want view %v. Test case: %v", v.Name(), v.Description(), wantV, tc.label)
 			}
 		}
 	}
@@ -490,19 +490,19 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 
 	c1 := make(chan *ViewData)
 	type subscription struct {
-		v View
+		v *View
 		c chan *ViewData
 	}
 	type want struct {
-		v    View
+		v    *View
 		rows []*Row
 		err  error
 	}
 	type testCase struct {
 		label           string
-		registrations   []View
+		registrations   []*View
 		subscriptions   []subscription
-		forcedCollected []View
+		forcedCollected []*View
 		records         []float64
 		wants           []want
 	}
@@ -510,17 +510,17 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 	tcs := []testCase{
 		{
 			"0",
-			[]View{v1, v2},
+			[]*View{v1, v2},
 			[]subscription{},
-			[]View{},
+			[]*View{},
 			[]float64{1, 1},
 			[]want{{v1, nil, someError}, {v2, nil, someError}},
 		},
 		{
 			"1",
-			[]View{v1, v2},
+			[]*View{v1, v2},
 			[]subscription{},
-			[]View{v1},
+			[]*View{v1},
 			[]float64{1, 1},
 			[]want{
 				{
@@ -538,9 +538,9 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 		},
 		{
 			"2",
-			[]View{v1, v2},
+			[]*View{v1, v2},
 			[]subscription{},
-			[]View{v1, v2},
+			[]*View{v1, v2},
 			[]float64{1, 1},
 			[]want{
 				{
@@ -567,9 +567,9 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 		},
 		{
 			"3",
-			[]View{v1, v2},
+			[]*View{v1, v2},
 			[]subscription{{v1, c1}},
-			[]View{},
+			[]*View{},
 			[]float64{1, 1},
 			[]want{
 				{
@@ -587,9 +587,9 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 		},
 		{
 			"4",
-			[]View{v1, v2},
+			[]*View{v1, v2},
 			[]subscription{{v1, c1}, {v2, c1}},
-			[]View{},
+			[]*View{},
 			[]float64{1, 1},
 			[]want{
 				{
@@ -616,9 +616,9 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 		},
 		{
 			"5",
-			[]View{v1, v2},
+			[]*View{v1, v2},
 			[]subscription{{v1, c1}},
-			[]View{v2},
+			[]*View{v2},
 			[]float64{1, 1, 10},
 			[]want{
 				{
@@ -653,14 +653,14 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 		}
 
 		for _, s := range tc.subscriptions {
-			if err := SubscribeToView(s.v, s.c); err != nil {
-				t.Fatalf("SubscribeToView '%v' got error '%v', want no error for test case: '%v'", s.v.Name(), err, tc.label)
+			if err := s.v.Subscribe(s.c); err != nil {
+				t.Fatalf("Subscribe '%v' got error '%v', want no error for test case: '%v'", s.v.Name(), err, tc.label)
 			}
 		}
 
 		for _, v := range tc.forcedCollected {
-			if err := ForceCollection(v); err != nil {
-				t.Fatalf("ForceCollection '%v' got error '%v', want no error for test case: '%v'", v.Name(), err, tc.label)
+			if err := v.ForceCollect(); err != nil {
+				t.Fatalf("ForceCollect '%v' got error '%v', want no error for test case: '%v'", v.Name(), err, tc.label)
 			}
 		}
 
@@ -669,7 +669,7 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 		}
 
 		for _, w := range tc.wants {
-			gotRows, err := RetrieveData(w.v)
+			gotRows, err := w.v.RetrieveData()
 			if (err != nil) != (w.err != nil) {
 				t.Fatalf("RetrieveData '%v' got error '%v', want no error for test case: '%v'", w.v.Name(), err, tc.label)
 			}
@@ -690,20 +690,20 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 
 		// cleaning up
 		for _, v := range tc.forcedCollected {
-			if err := StopForcedCollection(v); err != nil {
-				t.Fatalf("StopForcedCollection '%v' got error '%v', want no error for test case: '%v'", v.Name(), err, tc.label)
+			if err := v.StopForceCollection(); err != nil {
+				t.Fatalf("%v: StopForceCollection for %v = %v; want no errors", tc.label, v.Name(), err)
 			}
 		}
 
 		for _, s := range tc.subscriptions {
-			if err := UnsubscribeFromView(s.v, s.c); err != nil {
-				t.Fatalf("UnsubscribeFromView '%v' got error '%v', want no error for test case: '%v'", s.v.Name(), err, tc.label)
+			if err := s.v.Unsubscribe(s.c); err != nil {
+				t.Fatalf("%v: Unsubscribing from view %v errored with %v; want no error", tc.label, s.v.Name(), err)
 			}
 		}
 
 		for _, v := range tc.registrations {
-			if err := UnregisterView(v); err != nil {
-				t.Fatalf("UnregisterView '%v' got error '%v', want no error for test case: '%v'", v.Name(), err, tc.label)
+			if err := v.Unregister(); err != nil {
+				t.Fatalf("%v: Unregistering view %v errrored with %v; want no error", tc.label, v.Name(), err)
 			}
 		}
 	}


### PR DESCRIPTION
There will be a single View implementation, hence
View is converted into a concrete type. This model also
is compatible with the Java client.

Renamed GetViewByName given views can only be retrieved
by name and the function performs a look-up to find
a view in the registry.

Moved some view related functions under View to be
methods.

Added some more godoc and made a few style improvements.