### PR TITLE
Import context from the standard library where possible

### DIFF
--- a/examples/stats/main.go
+++ b/examples/stats/main.go
@@ -19,13 +19,13 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
 
 	"github.com/census-instrumentation/opencensus-go/stats"
 	"github.com/census-instrumentation/opencensus-go/tags"
-	"golang.org/x/net/context"
 )
 
 func main() {

--- a/plugins/grpc/handlers.go
+++ b/plugins/grpc/handlers.go
@@ -16,7 +16,7 @@
 package grpc
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"google.golang.org/grpc/stats"
 )

--- a/plugins/grpc/stats/client_handler.go
+++ b/plugins/grpc/stats/client_handler.go
@@ -20,10 +20,11 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/net/context"
+
 	istats "github.com/census-instrumentation/opencensus-go/stats"
 	"github.com/census-instrumentation/opencensus-go/tags"
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/stats"
 )
 

--- a/plugins/grpc/stats/server_handler.go
+++ b/plugins/grpc/stats/server_handler.go
@@ -21,10 +21,11 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/net/context"
+
 	istats "github.com/census-instrumentation/opencensus-go/stats"
 	"github.com/census-instrumentation/opencensus-go/tags"
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/stats"
 )

--- a/stats/worker.go
+++ b/stats/worker.go
@@ -16,12 +16,12 @@
 package stats
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
 
 	"github.com/census-instrumentation/opencensus-go/tags"
-	"golang.org/x/net/context"
 )
 
 func init() {

--- a/stats/worker_test.go
+++ b/stats/worker_test.go
@@ -20,8 +20,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/census-instrumentation/opencensus-go/tags"
 	"golang.org/x/net/context"
+
+	"github.com/census-instrumentation/opencensus-go/tags"
 )
 
 func Test_Worker_MeasureCreation(t *testing.T) {

--- a/tags/tag_set.go
+++ b/tags/tag_set.go
@@ -17,10 +17,9 @@ package tags
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"sort"
-
-	"golang.org/x/net/context"
 )
 
 // Tag is a key value pair that can be propagated on wire.

--- a/tags/tag_set_test.go
+++ b/tags/tag_set_test.go
@@ -16,11 +16,10 @@
 package tags
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestContext(t *testing.T) {


### PR DESCRIPTION
Once https://github.com/grpc/grpc-go/pull/1492 is merged, we will entirely remove the dependency to golang.org/x/net.