### PR TITLE
Remove the Window constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ if err := stats.DeleteMeasure(mi); err != nil {
 ```
 
 ### Creating an aggregation
+
 Currently only 2 types of aggregations are supported. The AggregationCount is used to count the number of times a sample was recorded. The AggregationDistribution is used to provide a histogram of the values of the samples.
 
 ```go
@@ -113,19 +114,26 @@ agg2 := stats.NewAggregationCount()
 ```
 
 ### Create an aggregation window
-Currently only 3 types of aggregation windows are supported. The WindowCumulative is used to continuously aggregate the data received. The WindowSlidingTime to aggregate the data received over the last specified time interval. The NewWindowSlidingCount to aggregate the data received over the last specified sample count.
-Currently all aggregation types are compatible with all aggregation windows. Later we might provide aggregation types that are incompatible with some windows.
+
+Currently only 3 types of aggregation windows are supported. The CumulativeWindow
+is used to continuously aggregate the data received.
+The SlidingTimeWindow to aggregate the data received over the last specified time interval.
+The SlidingCountWindow to aggregate the data received over the last specified sample count.
+Currently all aggregation types are compatible with all aggregation windows.
+Later we might provide aggregation types that are incompatible with some windows.
 
 ```go
-duration := 10 * time.Second
-precisionIntervals := 5
-wnd1 := stats.NewWindowSlidingTime(duration, precisionIntervals)
+wnd1 := stats.SlidingTimeWindow{
+    Duration:  10 * time.Second,
+    Intervals: 5,
+}
 
-lastNSamples := 100
-precisionSubsets := 10
-wnd2 := stats.NewWindowSlidingCount(lastNSamples, precisionSubsets)
+wnd2 := stats.SlidingCountWindow{
+    N:       100,
+    Subsets: 10,
+}
 
-wn3 := stats.NewWindowCumulative()
+wn3 := stats.CumulativeWindow{}
 ```
 
 ### Creating, registering and unregistering a view

--- a/examples/stats/main.go
+++ b/examples/stats/main.go
@@ -56,7 +56,7 @@ func main() {
 	agg1 := stats.NewAggregationDistribution(histogramBounds)
 	agg2 := stats.NewAggregationCount()
 
-	window := stats.NewWindowSlidingTime(10*time.Second, 10)
+	window := stats.SlidingTimeWindow{Duration: 10 * time.Second, Intervals: 10}
 
 	// Create views.
 	const (

--- a/plugins/grpc/stats/types.go
+++ b/plugins/grpc/stats/types.go
@@ -64,9 +64,9 @@ var (
 	aggDistMillis = istats.NewAggregationDistribution(rpcMillisBucketBoundaries)
 	aggDistCounts = istats.NewAggregationDistribution(rpcCountBucketBoundaries)
 
-	windowCumulative    = istats.NewWindowCumulative()
-	windowSlidingHour   = istats.NewWindowSlidingTime(1*time.Hour, 6)
-	windowSlidingMinute = istats.NewWindowSlidingTime(1*time.Minute, 6)
+	windowCumulative    = istats.CumulativeWindow{}
+	windowSlidingHour   = istats.SlidingTimeWindow{Duration: 1 * time.Hour, Intervals: 6}
+	windowSlidingMinute = istats.SlidingTimeWindow{Duration: 1 * time.Minute, Intervals: 6}
 
 	keyService  tags.StringKey
 	keyMethod   tags.StringKey

--- a/stats/view_test.go
+++ b/stats/view_test.go
@@ -27,7 +27,7 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowCumulative(t *testin
 	k2, _ := tags.NewStringKey("k2")
 	k3, _ := tags.NewStringKey("k3")
 	agg1 := NewAggregationDistribution([]float64{2})
-	vw1 := NewView("VF1", "desc VF1", []tags.Key{k1, k2}, nil, agg1, NewWindowCumulative())
+	vw1 := NewView("VF1", "desc VF1", []tags.Key{k1, k2}, nil, agg1, CumulativeWindow{})
 
 	type tagString struct {
 		k tags.StringKey
@@ -187,7 +187,7 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowSlidingTime(t *testi
 	k1, _ := tags.NewStringKey("k1")
 	k2, _ := tags.NewStringKey("k2")
 	agg1 := NewAggregationDistribution([]float64{2})
-	vw1 := NewView("VF1", "desc VF1", []tags.Key{k1, k2}, nil, agg1, NewWindowSlidingTime(10*time.Second, 5))
+	vw1 := NewView("VF1", "desc VF1", []tags.Key{k1, k2}, nil, agg1, SlidingTimeWindow{Duration: 10 * time.Second, Intervals: 5})
 
 	type tagString struct {
 		k tags.StringKey
@@ -377,7 +377,7 @@ func Test_View_MeasureFloat64_AggregationCount_WindowSlidingTime(t *testing.T) {
 	k1, _ := tags.NewStringKey("k1")
 	k2, _ := tags.NewStringKey("k2")
 	agg1 := NewAggregationCount()
-	vw1 := NewView("VF1", "desc VF1", []tags.Key{k1, k2}, nil, agg1, NewWindowSlidingTime(10*time.Second, 5))
+	vw1 := NewView("VF1", "desc VF1", []tags.Key{k1, k2}, nil, agg1, SlidingTimeWindow{Duration: 10 * time.Second, Intervals: 5})
 
 	type tagString struct {
 		k tags.StringKey
@@ -579,7 +579,7 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowSlidingCount(t *test
 	k1, _ := tags.NewStringKey("k1")
 	k2, _ := tags.NewStringKey("k2")
 	agg1 := NewAggregationDistribution([]float64{2})
-	vw1 := NewView("VF1", "desc VF1", []tags.Key{k1, k2}, nil, agg1, NewWindowSlidingCount(12, 4))
+	vw1 := NewView("VF1", "desc VF1", []tags.Key{k1, k2}, nil, agg1, SlidingCountWindow{N: 12, Subsets: 4})
 
 	type tagString struct {
 		k tags.StringKey

--- a/stats/worker.go
+++ b/stats/worker.go
@@ -357,7 +357,7 @@ func (w *worker) reportUsage(now time.Time) {
 			}
 		}
 
-		if _, ok := v.Window().(*WindowCumulative); !ok {
+		if _, ok := v.Window().(*CumulativeWindow); !ok {
 			v.clearRows()
 		}
 	}

--- a/stats/worker_test.go
+++ b/stats/worker_test.go
@@ -486,8 +486,8 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 	)
 	ctx := tags.NewContext(context.Background(), ts)
 
-	v1 := NewView("VF1", "desc VF1", []tags.Key{k1, k2}, m, NewAggregationCount(), NewWindowCumulative())
-	v2 := NewView("VF2", "desc VF2", []tags.Key{k1, k2}, m, NewAggregationCount(), NewWindowCumulative())
+	v1 := NewView("VF1", "desc VF1", []tags.Key{k1, k2}, m, NewAggregationCount(), CumulativeWindow{})
+	v2 := NewView("VF2", "desc VF2", []tags.Key{k1, k2}, m, NewAggregationCount(), CumulativeWindow{})
 
 	c1 := make(chan *ViewData)
 	type subscription struct {


### PR DESCRIPTION
Instead allow users to init with a literal. Use "Window" as a prefix to follow the natural
language instead of the current name formatting.

Updates #17.
Updates #53.