### PR TITLE
Rename RestartWorker to Restart

### DIFF
--- a/plugins/grpc/stats/client_handler_test.go
+++ b/plugins/grpc/stats/client_handler_test.go
@@ -308,7 +308,7 @@ func TestClientDefaultCollections(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		istats.RestartWorker()
+		istats.Restart()
 		registerDefaultsClient()
 
 		h := NewClientHandler()

--- a/plugins/grpc/stats/server_handler_test.go
+++ b/plugins/grpc/stats/server_handler_test.go
@@ -308,7 +308,7 @@ func TestServerDefaultCollections(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		istats.RestartWorker()
+		istats.Restart()
 		registerDefaultsServer()
 
 		h := NewServerHandler()

--- a/stats/worker.go
+++ b/stats/worker.go
@@ -363,9 +363,11 @@ func (w *worker) reportUsage(now time.Time) {
 	}
 }
 
-// RestartWorker is used for testing only. It stops the old worker and creates
-// a new worker. It should never be called by production code.
-func RestartWorker() {
+// Restart stops the current processors and creates a new one.
+// This is for testing purposes only.
+// It should never be called by production code.
+func Restart() {
+	// TODO(jbd): Consider removing this API.
 	defaultWorker.stop()
 	defaultWorker = newWorker()
 	go defaultWorker.start()

--- a/stats/worker_test.go
+++ b/stats/worker_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func Test_Worker_MeasureCreation(t *testing.T) {
-	RestartWorker()
+	Restart()
 
 	if _, err := NewMeasureFloat64("MF1", "desc MF1", "unit"); err != nil {
 		t.Errorf("NewMeasureFloat64(\"MF1\", \"desc MF1\") got error %v, want no error", err)
@@ -58,7 +58,7 @@ func Test_Worker_MeasureCreation(t *testing.T) {
 }
 
 func Test_Worker_FindMeasure(t *testing.T) {
-	RestartWorker()
+	Restart()
 
 	someError := errors.New("some error")
 	mf1, err := NewMeasureFloat64("MF1", "desc MF1", "unit")
@@ -213,7 +213,7 @@ func Test_Worker_MeasureDelete(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		RestartWorker()
+		Restart()
 
 		for _, n := range tc.measureNames {
 			if _, err := NewMeasureInt64(n, "some desc", "unit"); err != nil {
@@ -418,7 +418,7 @@ func Test_Worker_ViewRegistration(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		RestartWorker()
+		Restart()
 
 		mf1, _ := NewMeasureFloat64("MF1", "desc MF1", "unit")
 		mf2, _ := NewMeasureFloat64("MF2", "desc MF2", "unit")
@@ -470,7 +470,7 @@ func Test_Worker_ViewRegistration(t *testing.T) {
 }
 
 func Test_Worker_RecordFloat64(t *testing.T) {
-	RestartWorker()
+	Restart()
 
 	someError := errors.New("some error")
 	m, err := NewMeasureFloat64("MF1", "desc MF1", "unit")


### PR DESCRIPTION
Worker is an internal terminology and user doesn't
have to know about it. Also add TODO about removing this API.