### PR TITLE
Have one way to record measurements

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,8 +245,6 @@ and their registered views. Measurements are implicitly tagged with the
 tags in the context:
 
 ```go
-mi.Record(ctx, 1)
-mf.Record(ctx, 5.6)
 stats.Record(ctx, mi.M(4), mf.M(10.5))
 ```
 

--- a/examples/stats/main.go
+++ b/examples/stats/main.go
@@ -115,11 +115,7 @@ func main() {
 	)
 	ctx := tags.NewContext(context.Background(), tm)
 
-	// Recording single datapoint at a time.
-	videoSize.Record(ctx, 10.0)
-	videoSpamCount.Record(ctx, 1)
-
-	// Recording multiple datapoints at once.
+	// Recording datapoints.
 	stats.Record(ctx, videoSpamCount.M(2), videoSize.M(100.0))
 
 	// Wait for a duration longer than reporting duration to ensure the stats

--- a/plugins/grpc/stats/client_handler.go
+++ b/plugins/grpc/stats/client_handler.go
@@ -102,7 +102,7 @@ func (ch clientHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) cont
 	// TODO(acetechnologist): should we be recording this later? What is the
 	// point of updating d.reqLen & d.reqCount if we update now?
 	ctx = tags.NewContext(ctx, tagMap)
-	RPCClientStartedCount.Record(ctx, 1)
+	istats.Record(ctx, RPCClientStartedCount.M(1))
 
 	return context.WithValue(ctx, grpcClientRPCKey, d)
 }
@@ -132,7 +132,7 @@ func (ch clientHandler) handleRPCOutPayload(ctx context.Context, s *stats.OutPay
 		return
 	}
 
-	RPCClientRequestBytes.Record(ctx, int64(s.Length))
+	istats.Record(ctx, RPCClientRequestBytes.M(int64(s.Length)))
 	atomic.AddUint64(&d.reqCount, 1)
 }
 
@@ -145,7 +145,7 @@ func (ch clientHandler) handleRPCInPayload(ctx context.Context, s *stats.InPaylo
 		return
 	}
 
-	RPCClientResponseBytes.Record(ctx, int64(s.Length))
+	istats.Record(ctx, RPCClientResponseBytes.M(int64(s.Length)))
 	atomic.AddUint64(&d.respCount, 1)
 }
 

--- a/plugins/grpc/stats/server_handler.go
+++ b/plugins/grpc/stats/server_handler.go
@@ -99,7 +99,7 @@ func (sh serverHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) cont
 	}
 	ctx = tags.NewContext(ctx, ts)
 
-	RPCServerStartedCount.Record(ctx, 1)
+	istats.Record(ctx, RPCServerStartedCount.M(1))
 	return context.WithValue(ctx, grpcServerRPCKey, d)
 }
 
@@ -137,7 +137,7 @@ func (sh serverHandler) handleRPCInPayload(ctx context.Context, s *stats.InPaylo
 		return
 	}
 
-	RPCServerRequestBytes.Record(ctx, int64(s.Length))
+	istats.Record(ctx, RPCServerRequestBytes.M(int64(s.Length)))
 	atomic.AddUint64(&d.reqCount, 1)
 }
 
@@ -150,7 +150,7 @@ func (sh serverHandler) handleRPCOutPayload(ctx context.Context, s *stats.OutPay
 		return
 	}
 
-	RPCServerResponseBytes.Record(ctx, int64(s.Length))
+	istats.Record(ctx, RPCServerResponseBytes.M(int64(s.Length)))
 	atomic.AddUint64(&d.respCount, 1)
 }
 

--- a/stats/measure_float64.go
+++ b/stats/measure_float64.go
@@ -44,7 +44,7 @@ func (m *MeasureFloat64) removeView(v *View) {
 func (m *MeasureFloat64) viewsCount() int { return len(m.views) }
 
 // M creates a new float64 measurement.
-// Use Record to record multiple measurements.
+// Use Record to record measurements.
 func (m *MeasureFloat64) M(v float64) Measurement {
 	return &measurementFloat64{m: m, v: v}
 }

--- a/stats/measure_int64.go
+++ b/stats/measure_int64.go
@@ -44,7 +44,7 @@ func (m *MeasureInt64) removeView(v *View) {
 func (m *MeasureInt64) viewsCount() int { return len(m.views) }
 
 // M creates a new int64 measurement.
-// Use Record to record multiple measurements.
+// Use Record to record measurements.
 func (m *MeasureInt64) M(v int64) Measurement {
 	return &measurementInt64{m: m, v: v}
 }

--- a/stats/worker.go
+++ b/stats/worker.go
@@ -212,35 +212,9 @@ func (v *View) RetrieveData() ([]*Row, error) {
 	return resp.rows, resp.err
 }
 
-// Record records a float64 value against a measure and the tags passed
-// as part of the context.
-func (m *MeasureFloat64) Record(ctx context.Context, v float64) {
-	req := &recordFloat64Req{
-		now: time.Now(),
-		tm:  tags.FromContext(ctx),
-		mf:  m,
-		v:   v,
-	}
-	defaultWorker.c <- req
-}
-
-// Record records an int64 value against a measure and the tags passed as
-// part of the context.
-func (m *MeasureInt64) Record(ctx context.Context, v int64) {
-	req := &recordInt64Req{
-		now: time.Now(),
-		tm:  tags.FromContext(ctx),
-		mi:  m,
-		v:   v,
-	}
-	defaultWorker.c <- req
-}
-
 // Record records one or multiple measurements with the same tags at once.
+// If there are any tags in the context, measurements will be tagged with them.
 func Record(ctx context.Context, ms ...Measurement) {
-	// TODO(jbd): Reconsider this API. Is there a use case
-	// where (Measure).Record is not sufficient enough that
-	// we provide this API?
 	req := &recordReq{
 		now: time.Now(),
 		tm:  tags.FromContext(ctx),

--- a/stats/worker_test.go
+++ b/stats/worker_test.go
@@ -666,7 +666,7 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 		}
 
 		for _, value := range tc.records {
-			m.Record(ctx, value)
+			Record(ctx, m.M(value))
 		}
 
 		for _, w := range tc.wants {


### PR DESCRIPTION
The commonly required recording API is batch recording, but we provide two ways of recording measurements. Remove the (Measure).Record and encourage the use of Record every where to reduce the API surface and have better orthogonality. 