### PR TITLE
Rename tags package to tag

### DIFF
--- a/examples/stats/main.go
+++ b/examples/stats/main.go
@@ -25,17 +25,17 @@ import (
 	"time"
 
 	"github.com/census-instrumentation/opencensus-go/stats"
-	"github.com/census-instrumentation/opencensus-go/tags"
+	"github.com/census-instrumentation/opencensus-go/tag"
 )
 
 func main() {
 	// Creates keys. There will be two dimensions, device ID and OS version,
 	// that will be collected with the metrics we collect in the program.
-	deviceIDKey, err := tags.NewStringKey("/mycompany.com/key/deviceID")
+	deviceIDKey, err := tag.NewStringKey("/mycompany.com/key/deviceID")
 	if err != nil {
 		log.Fatalf("Device ID key not created: %v\n", err)
 	}
-	osVersionKey, err := tags.NewStringKey("/mycompany.com/key/osVersionKey")
+	osVersionKey, err := tag.NewStringKey("/mycompany.com/key/osVersionKey")
 	if err != nil {
 		log.Fatalf("OS version key not created: %v\n", err)
 	}
@@ -65,9 +65,9 @@ func main() {
 		videoSpamDesc = "count of videos marked as spam tagged by device ID"
 	)
 	// Create view to see video size over 10 seconds with device ID and OS version tags.
-	videoSizeView := stats.NewView(videoSizeName, videoSizeDesc, []tags.Key{deviceIDKey, osVersionKey}, videoSize, agg1, window)
+	videoSizeView := stats.NewView(videoSizeName, videoSizeDesc, []tag.Key{deviceIDKey, osVersionKey}, videoSize, agg1, window)
 	// Create view to see the count of spam videos over 10 sconds with device ID.
-	videoSpamCountView := stats.NewView(videoSpamName, videoSpamDesc, []tags.Key{deviceIDKey}, videoSpamCount, agg2, window)
+	videoSpamCountView := stats.NewView(videoSpamName, videoSpamDesc, []tag.Key{deviceIDKey}, videoSpamCount, agg2, window)
 
 	// Register views in order to collect data.
 	if err := stats.RegisterView(videoSizeView); err != nil {
@@ -109,11 +109,11 @@ func main() {
 
 	// Adding tags to context to record each datapoint with
 	// the following device ID and OS version.
-	tm := tags.NewMap(nil,
-		tags.UpsertString(deviceIDKey, "device-id-768dfd76"),
-		tags.UpsertString(osVersionKey, "mac-osx-10.12.6"),
+	tm := tag.NewMap(nil,
+		tag.UpsertString(deviceIDKey, "device-id-768dfd76"),
+		tag.UpsertString(osVersionKey, "mac-osx-10.12.6"),
 	)
-	ctx := tags.NewContext(context.Background(), tm)
+	ctx := tag.NewContext(context.Background(), tm)
 
 	// Recording datapoints.
 	stats.Record(ctx, videoSpamCount.M(2), videoSize.M(100.0))

--- a/plugins/grpc/stats/client_handler_test.go
+++ b/plugins/grpc/stats/client_handler_test.go
@@ -22,17 +22,17 @@ import (
 	"golang.org/x/net/context"
 
 	istats "github.com/census-instrumentation/opencensus-go/stats"
-	"github.com/census-instrumentation/opencensus-go/tags"
+	"github.com/census-instrumentation/opencensus-go/tag"
 
 	"google.golang.org/grpc/stats"
 )
 
 func TestClientDefaultCollections(t *testing.T) {
-	k1, _ := tags.NewStringKey("k1")
-	k2, _ := tags.NewStringKey("k2")
+	k1, _ := tag.NewStringKey("k1")
+	k2, _ := tag.NewStringKey("k2")
 
 	type tagPair struct {
-		k tags.StringKey
+		k tag.StringKey
 		v string
 	}
 
@@ -74,7 +74,7 @@ func TestClientDefaultCollections(t *testing.T) {
 					func() *istats.View { return RPCClientRequestCountView },
 					[]*istats.Row{
 						{
-							[]tags.Tag{
+							[]tag.Tag{
 								{Key: keyMethod, Value: []byte("method")},
 								{Key: keyService, Value: []byte("package.service")},
 							},
@@ -86,7 +86,7 @@ func TestClientDefaultCollections(t *testing.T) {
 					func() *istats.View { return RPCClientResponseCountView },
 					[]*istats.Row{
 						{
-							[]tags.Tag{
+							[]tag.Tag{
 								{Key: keyMethod, Value: []byte("method")},
 								{Key: keyService, Value: []byte("package.service")},
 							},
@@ -98,7 +98,7 @@ func TestClientDefaultCollections(t *testing.T) {
 					func() *istats.View { return RPCClientRequestBytesView },
 					[]*istats.Row{
 						{
-							[]tags.Tag{
+							[]tag.Tag{
 								{Key: keyMethod, Value: []byte("method")},
 								{Key: keyService, Value: []byte("package.service")},
 							},
@@ -110,7 +110,7 @@ func TestClientDefaultCollections(t *testing.T) {
 					func() *istats.View { return RPCClientResponseBytesView },
 					[]*istats.Row{
 						{
-							[]tags.Tag{
+							[]tag.Tag{
 								{Key: keyMethod, Value: []byte("method")},
 								{Key: keyService, Value: []byte("package.service")},
 							},
@@ -155,7 +155,7 @@ func TestClientDefaultCollections(t *testing.T) {
 					func() *istats.View { return RPCClientErrorCountView },
 					[]*istats.Row{
 						{
-							[]tags.Tag{
+							[]tag.Tag{
 								{Key: keyMethod, Value: []byte("method")},
 								{Key: keyOpStatus, Value: []byte("someError")},
 								{Key: keyService, Value: []byte("package.service")},
@@ -168,7 +168,7 @@ func TestClientDefaultCollections(t *testing.T) {
 					func() *istats.View { return RPCClientRequestCountView },
 					[]*istats.Row{
 						{
-							[]tags.Tag{
+							[]tag.Tag{
 								{Key: keyMethod, Value: []byte("method")},
 								{Key: keyService, Value: []byte("package.service")},
 							},
@@ -180,7 +180,7 @@ func TestClientDefaultCollections(t *testing.T) {
 					func() *istats.View { return RPCClientResponseCountView },
 					[]*istats.Row{
 						{
-							[]tags.Tag{
+							[]tag.Tag{
 								{Key: keyMethod, Value: []byte("method")},
 								{Key: keyService, Value: []byte("package.service")},
 							},
@@ -238,7 +238,7 @@ func TestClientDefaultCollections(t *testing.T) {
 					func() *istats.View { return RPCClientErrorCountView },
 					[]*istats.Row{
 						{
-							[]tags.Tag{
+							[]tag.Tag{
 								{Key: keyMethod, Value: []byte("method")},
 								{Key: keyOpStatus, Value: []byte("someError1")},
 								{Key: keyService, Value: []byte("package.service")},
@@ -246,7 +246,7 @@ func TestClientDefaultCollections(t *testing.T) {
 							newCountAggregationValue(1),
 						},
 						{
-							[]tags.Tag{
+							[]tag.Tag{
 								{Key: keyMethod, Value: []byte("method")},
 								{Key: keyOpStatus, Value: []byte("someError2")},
 								{Key: keyService, Value: []byte("package.service")},
@@ -259,7 +259,7 @@ func TestClientDefaultCollections(t *testing.T) {
 					func() *istats.View { return RPCClientRequestCountView },
 					[]*istats.Row{
 						{
-							[]tags.Tag{
+							[]tag.Tag{
 								{Key: keyMethod, Value: []byte("method")},
 								{Key: keyService, Value: []byte("package.service")},
 							},
@@ -271,7 +271,7 @@ func TestClientDefaultCollections(t *testing.T) {
 					func() *istats.View { return RPCClientResponseCountView },
 					[]*istats.Row{
 						{
-							[]tags.Tag{
+							[]tag.Tag{
 								{Key: keyMethod, Value: []byte("method")},
 								{Key: keyService, Value: []byte("package.service")},
 							},
@@ -283,7 +283,7 @@ func TestClientDefaultCollections(t *testing.T) {
 					func() *istats.View { return RPCClientRequestBytesView },
 					[]*istats.Row{
 						{
-							[]tags.Tag{
+							[]tag.Tag{
 								{Key: keyMethod, Value: []byte("method")},
 								{Key: keyService, Value: []byte("package.service")},
 							},
@@ -295,7 +295,7 @@ func TestClientDefaultCollections(t *testing.T) {
 					func() *istats.View { return RPCClientResponseBytesView },
 					[]*istats.Row{
 						{
-							[]tags.Tag{
+							[]tag.Tag{
 								{Key: keyMethod, Value: []byte("method")},
 								{Key: keyService, Value: []byte("package.service")},
 							},
@@ -313,12 +313,12 @@ func TestClientDefaultCollections(t *testing.T) {
 
 		h := NewClientHandler()
 		for _, rpc := range tc.rpcs {
-			mods := []tags.Mutator{}
+			mods := []tag.Mutator{}
 			for _, t := range rpc.tags {
-				mods = append(mods, tags.UpsertString(t.k, t.v))
+				mods = append(mods, tag.UpsertString(t.k, t.v))
 			}
-			tm := tags.NewMap(nil, mods...)
-			encoded := tags.Encode(tm)
+			tm := tag.NewMap(nil, mods...)
+			encoded := tag.Encode(tm)
 			ctx := stats.SetTags(context.Background(), encoded)
 
 			ctx = h.TagRPC(ctx, rpc.tagInfo)

--- a/plugins/grpc/stats/client_metrics.go
+++ b/plugins/grpc/stats/client_metrics.go
@@ -20,7 +20,7 @@ import (
 	"log"
 
 	istats "github.com/census-instrumentation/opencensus-go/stats"
-	"github.com/census-instrumentation/opencensus-go/tags"
+	"github.com/census-instrumentation/opencensus-go/tag"
 )
 
 // The following variables define the default hard-coded metrics to collect for
@@ -100,51 +100,51 @@ func createDefaultMeasuresClient() {
 func registerDefaultViewsClient() {
 	var views []*istats.View
 
-	RPCClientErrorCountView = istats.NewView("grpc.io/client/error_count/distribution_cumulative", "RPC Errors", []tags.Key{keyOpStatus, keyService, keyMethod}, RPCClientErrorCount, aggCount, windowCumulative)
+	RPCClientErrorCountView = istats.NewView("grpc.io/client/error_count/distribution_cumulative", "RPC Errors", []tag.Key{keyOpStatus, keyService, keyMethod}, RPCClientErrorCount, aggCount, windowCumulative)
 	views = append(views, RPCClientErrorCountView)
-	RPCClientRoundTripLatencyView = istats.NewView("grpc.io/client/roundtrip_latency/distribution_cumulative", "Latency in msecs", []tags.Key{keyService, keyMethod}, RPCClientRoundTripLatency, aggDistMillis, windowCumulative)
+	RPCClientRoundTripLatencyView = istats.NewView("grpc.io/client/roundtrip_latency/distribution_cumulative", "Latency in msecs", []tag.Key{keyService, keyMethod}, RPCClientRoundTripLatency, aggDistMillis, windowCumulative)
 	views = append(views, RPCClientRoundTripLatencyView)
-	RPCClientRequestBytesView = istats.NewView("grpc.io/client/request_bytes/distribution_cumulative", "Request bytes", []tags.Key{keyService, keyMethod}, RPCClientRequestBytes, aggDistBytes, windowCumulative)
+	RPCClientRequestBytesView = istats.NewView("grpc.io/client/request_bytes/distribution_cumulative", "Request bytes", []tag.Key{keyService, keyMethod}, RPCClientRequestBytes, aggDistBytes, windowCumulative)
 	views = append(views, RPCClientRequestBytesView)
-	RPCClientResponseBytesView = istats.NewView("grpc.io/client/response_bytes/distribution_cumulative", "Response bytes", []tags.Key{keyService, keyMethod}, RPCClientResponseBytes, aggDistBytes, windowCumulative)
+	RPCClientResponseBytesView = istats.NewView("grpc.io/client/response_bytes/distribution_cumulative", "Response bytes", []tag.Key{keyService, keyMethod}, RPCClientResponseBytes, aggDistBytes, windowCumulative)
 	views = append(views, RPCClientResponseBytesView)
-	RPCClientRequestCountView = istats.NewView("grpc.io/client/request_count/distribution_cumulative", "Count of request messages per client RPC", []tags.Key{keyService, keyMethod}, RPCClientRequestCount, aggDistCounts, windowCumulative)
+	RPCClientRequestCountView = istats.NewView("grpc.io/client/request_count/distribution_cumulative", "Count of request messages per client RPC", []tag.Key{keyService, keyMethod}, RPCClientRequestCount, aggDistCounts, windowCumulative)
 	views = append(views, RPCClientRequestCountView)
-	RPCClientResponseCountView = istats.NewView("grpc.io/client/response_count/distribution_cumulative", "Count of response messages per client RPC", []tags.Key{keyService, keyMethod}, RPCClientResponseCount, aggDistCounts, windowCumulative)
+	RPCClientResponseCountView = istats.NewView("grpc.io/client/response_count/distribution_cumulative", "Count of response messages per client RPC", []tag.Key{keyService, keyMethod}, RPCClientResponseCount, aggDistCounts, windowCumulative)
 	views = append(views, RPCClientResponseCountView)
 
-	RPCClientRoundTripLatencyMinuteView = istats.NewView("grpc.io/client/roundtrip_latency/minute_interval", "Minute stats for latency in msecs", []tags.Key{keyService, keyMethod}, RPCClientRoundTripLatency, aggDistMillis, windowSlidingMinute)
+	RPCClientRoundTripLatencyMinuteView = istats.NewView("grpc.io/client/roundtrip_latency/minute_interval", "Minute stats for latency in msecs", []tag.Key{keyService, keyMethod}, RPCClientRoundTripLatency, aggDistMillis, windowSlidingMinute)
 	views = append(views, RPCClientRoundTripLatencyMinuteView)
-	RPCClientRequestBytesMinuteView = istats.NewView("grpc.io/client/request_bytes/minute_interval", "Minute stats for request size in bytes", []tags.Key{keyService, keyMethod}, RPCClientRequestBytes, aggCount, windowSlidingMinute)
+	RPCClientRequestBytesMinuteView = istats.NewView("grpc.io/client/request_bytes/minute_interval", "Minute stats for request size in bytes", []tag.Key{keyService, keyMethod}, RPCClientRequestBytes, aggCount, windowSlidingMinute)
 	views = append(views, RPCClientRequestBytesMinuteView)
-	RPCClientResponseBytesMinuteView = istats.NewView("grpc.io/client/response_bytes/minute_interval", "Minute stats for response size in bytes", []tags.Key{keyService, keyMethod}, RPCClientResponseBytes, aggCount, windowSlidingMinute)
+	RPCClientResponseBytesMinuteView = istats.NewView("grpc.io/client/response_bytes/minute_interval", "Minute stats for response size in bytes", []tag.Key{keyService, keyMethod}, RPCClientResponseBytes, aggCount, windowSlidingMinute)
 	views = append(views, RPCClientResponseBytesMinuteView)
-	RPCClientErrorCountMinuteView = istats.NewView("grpc.io/client/error_count/minute_interval", "Minute stats for rpc errors", []tags.Key{keyService, keyMethod}, RPCClientErrorCount, aggCount, windowSlidingMinute)
+	RPCClientErrorCountMinuteView = istats.NewView("grpc.io/client/error_count/minute_interval", "Minute stats for rpc errors", []tag.Key{keyService, keyMethod}, RPCClientErrorCount, aggCount, windowSlidingMinute)
 	views = append(views, RPCClientErrorCountMinuteView)
-	RPCClientStartedCountMinuteView = istats.NewView("grpc.io/client/started_count/minute_interval", "Minute stats on the number of client RPCs started", []tags.Key{keyService, keyMethod}, RPCClientStartedCount, aggCount, windowSlidingMinute)
+	RPCClientStartedCountMinuteView = istats.NewView("grpc.io/client/started_count/minute_interval", "Minute stats on the number of client RPCs started", []tag.Key{keyService, keyMethod}, RPCClientStartedCount, aggCount, windowSlidingMinute)
 	views = append(views, RPCClientStartedCountMinuteView)
-	RPCClientFinishedCountMinuteView = istats.NewView("grpc.io/client/finished_count/minute_interval", "Minute stats on the number of client RPCs finished", []tags.Key{keyService, keyMethod}, RPCClientFinishedCount, aggCount, windowSlidingMinute)
+	RPCClientFinishedCountMinuteView = istats.NewView("grpc.io/client/finished_count/minute_interval", "Minute stats on the number of client RPCs finished", []tag.Key{keyService, keyMethod}, RPCClientFinishedCount, aggCount, windowSlidingMinute)
 	views = append(views, RPCClientFinishedCountMinuteView)
-	RPCClientRequestCountMinuteView = istats.NewView("grpc.io/client/request_count/minute_interval", "Minute stats on the count of request messages per client RPC", []tags.Key{keyService, keyMethod}, RPCClientRequestCount, aggCount, windowSlidingMinute)
+	RPCClientRequestCountMinuteView = istats.NewView("grpc.io/client/request_count/minute_interval", "Minute stats on the count of request messages per client RPC", []tag.Key{keyService, keyMethod}, RPCClientRequestCount, aggCount, windowSlidingMinute)
 	views = append(views, RPCClientRequestCountMinuteView)
-	RPCClientResponseCountMinuteView = istats.NewView("grpc.io/client/response_count/minute_interval", "Minute stats on the count of response messages per client RPC", []tags.Key{keyService, keyMethod}, RPCClientResponseCount, aggCount, windowSlidingMinute)
+	RPCClientResponseCountMinuteView = istats.NewView("grpc.io/client/response_count/minute_interval", "Minute stats on the count of response messages per client RPC", []tag.Key{keyService, keyMethod}, RPCClientResponseCount, aggCount, windowSlidingMinute)
 	views = append(views, RPCClientResponseCountMinuteView)
 
-	RPCClientRoundTripLatencyHourView = istats.NewView("grpc.io/client/roundtrip_latency/hour_interval", "Hour stats for latency in msecs", []tags.Key{keyService, keyMethod}, RPCClientRoundTripLatency, aggDistMillis, windowSlidingHour)
+	RPCClientRoundTripLatencyHourView = istats.NewView("grpc.io/client/roundtrip_latency/hour_interval", "Hour stats for latency in msecs", []tag.Key{keyService, keyMethod}, RPCClientRoundTripLatency, aggDistMillis, windowSlidingHour)
 	views = append(views, RPCClientRoundTripLatencyHourView)
-	RPCClientRequestBytesHourView = istats.NewView("grpc.io/client/request_bytes/hour_interval", "Hour stats for request size in bytes", []tags.Key{keyService, keyMethod}, RPCClientRequestBytes, aggCount, windowSlidingHour)
+	RPCClientRequestBytesHourView = istats.NewView("grpc.io/client/request_bytes/hour_interval", "Hour stats for request size in bytes", []tag.Key{keyService, keyMethod}, RPCClientRequestBytes, aggCount, windowSlidingHour)
 	views = append(views, RPCClientRequestBytesHourView)
-	RPCClientResponseBytesHourView = istats.NewView("grpc.io/client/response_bytes/hour_interval", "Hour stats for response size in bytes", []tags.Key{keyService, keyMethod}, RPCClientResponseBytes, aggCount, windowSlidingHour)
+	RPCClientResponseBytesHourView = istats.NewView("grpc.io/client/response_bytes/hour_interval", "Hour stats for response size in bytes", []tag.Key{keyService, keyMethod}, RPCClientResponseBytes, aggCount, windowSlidingHour)
 	views = append(views, RPCClientResponseBytesHourView)
-	RPCClientErrorCountHourView = istats.NewView("grpc.io/client/error_count/hour_interval", "Hour stats for rpc errors", []tags.Key{keyService, keyMethod}, RPCClientErrorCount, aggCount, windowSlidingHour)
+	RPCClientErrorCountHourView = istats.NewView("grpc.io/client/error_count/hour_interval", "Hour stats for rpc errors", []tag.Key{keyService, keyMethod}, RPCClientErrorCount, aggCount, windowSlidingHour)
 	views = append(views, RPCClientErrorCountHourView)
-	RPCClientStartedCountHourView = istats.NewView("grpc.io/client/started_count/hour_interval", "Hour stats on the number of client RPCs started", []tags.Key{keyService, keyMethod}, RPCClientStartedCount, aggCount, windowSlidingHour)
+	RPCClientStartedCountHourView = istats.NewView("grpc.io/client/started_count/hour_interval", "Hour stats on the number of client RPCs started", []tag.Key{keyService, keyMethod}, RPCClientStartedCount, aggCount, windowSlidingHour)
 	views = append(views, RPCClientStartedCountHourView)
-	RPCClientFinishedCountHourView = istats.NewView("grpc.io/client/finished_count/hour_interval", "Hour stats on the number of client RPCs finished", []tags.Key{keyService, keyMethod}, RPCClientFinishedCount, aggCount, windowSlidingHour)
+	RPCClientFinishedCountHourView = istats.NewView("grpc.io/client/finished_count/hour_interval", "Hour stats on the number of client RPCs finished", []tag.Key{keyService, keyMethod}, RPCClientFinishedCount, aggCount, windowSlidingHour)
 	views = append(views, RPCClientFinishedCountHourView)
-	RPCClientRequestCountHourView = istats.NewView("grpc.io/client/request_count/hour_interval", "Hour stats on the count of request messages per client RPC", []tags.Key{keyService, keyMethod}, RPCClientRequestCount, aggCount, windowSlidingHour)
+	RPCClientRequestCountHourView = istats.NewView("grpc.io/client/request_count/hour_interval", "Hour stats on the count of request messages per client RPC", []tag.Key{keyService, keyMethod}, RPCClientRequestCount, aggCount, windowSlidingHour)
 	views = append(views, RPCClientRequestCountHourView)
-	RPCClientResponseCountHourView = istats.NewView("grpc.io/client/response_count/hour_interval", "Hour stats on the count of response messages per client RPC", []tags.Key{keyService, keyMethod}, RPCClientResponseCount, aggCount, windowSlidingHour)
+	RPCClientResponseCountHourView = istats.NewView("grpc.io/client/response_count/hour_interval", "Hour stats on the count of response messages per client RPC", []tag.Key{keyService, keyMethod}, RPCClientResponseCount, aggCount, windowSlidingHour)
 	views = append(views, RPCClientResponseCountHourView)
 
 	// Registering views

--- a/plugins/grpc/stats/server_handler_test.go
+++ b/plugins/grpc/stats/server_handler_test.go
@@ -22,17 +22,17 @@ import (
 	"golang.org/x/net/context"
 
 	istats "github.com/census-instrumentation/opencensus-go/stats"
-	"github.com/census-instrumentation/opencensus-go/tags"
+	"github.com/census-instrumentation/opencensus-go/tag"
 
 	"google.golang.org/grpc/stats"
 )
 
 func TestServerDefaultCollections(t *testing.T) {
-	k1, _ := tags.NewStringKey("k1")
-	k2, _ := tags.NewStringKey("k2")
+	k1, _ := tag.NewStringKey("k1")
+	k2, _ := tag.NewStringKey("k2")
 
 	type tagPair struct {
-		k tags.StringKey
+		k tag.StringKey
 		v string
 	}
 
@@ -74,7 +74,7 @@ func TestServerDefaultCollections(t *testing.T) {
 					func() *istats.View { return RPCServerRequestCountView },
 					[]*istats.Row{
 						{
-							[]tags.Tag{
+							[]tag.Tag{
 								{Key: keyMethod, Value: []byte("method")},
 								{Key: keyService, Value: []byte("package.service")},
 							},
@@ -86,7 +86,7 @@ func TestServerDefaultCollections(t *testing.T) {
 					func() *istats.View { return RPCServerResponseCountView },
 					[]*istats.Row{
 						{
-							[]tags.Tag{
+							[]tag.Tag{
 								{Key: keyMethod, Value: []byte("method")},
 								{Key: keyService, Value: []byte("package.service")},
 							},
@@ -98,7 +98,7 @@ func TestServerDefaultCollections(t *testing.T) {
 					func() *istats.View { return RPCServerRequestBytesView },
 					[]*istats.Row{
 						{
-							[]tags.Tag{
+							[]tag.Tag{
 								{Key: keyMethod, Value: []byte("method")},
 								{Key: keyService, Value: []byte("package.service")},
 							},
@@ -110,7 +110,7 @@ func TestServerDefaultCollections(t *testing.T) {
 					func() *istats.View { return RPCServerResponseBytesView },
 					[]*istats.Row{
 						{
-							[]tags.Tag{
+							[]tag.Tag{
 								{Key: keyMethod, Value: []byte("method")},
 								{Key: keyService, Value: []byte("package.service")},
 							},
@@ -155,7 +155,7 @@ func TestServerDefaultCollections(t *testing.T) {
 					func() *istats.View { return RPCServerErrorCountView },
 					[]*istats.Row{
 						{
-							[]tags.Tag{
+							[]tag.Tag{
 								{Key: keyMethod, Value: []byte("method")},
 								{Key: keyOpStatus, Value: []byte("someError")},
 								{Key: keyService, Value: []byte("package.service")},
@@ -168,7 +168,7 @@ func TestServerDefaultCollections(t *testing.T) {
 					func() *istats.View { return RPCServerRequestCountView },
 					[]*istats.Row{
 						{
-							[]tags.Tag{
+							[]tag.Tag{
 								{Key: keyMethod, Value: []byte("method")},
 								{Key: keyService, Value: []byte("package.service")},
 							},
@@ -180,7 +180,7 @@ func TestServerDefaultCollections(t *testing.T) {
 					func() *istats.View { return RPCServerResponseCountView },
 					[]*istats.Row{
 						{
-							[]tags.Tag{
+							[]tag.Tag{
 								{Key: keyMethod, Value: []byte("method")},
 								{Key: keyService, Value: []byte("package.service")},
 							},
@@ -238,7 +238,7 @@ func TestServerDefaultCollections(t *testing.T) {
 					func() *istats.View { return RPCServerErrorCountView },
 					[]*istats.Row{
 						{
-							[]tags.Tag{
+							[]tag.Tag{
 								{Key: keyMethod, Value: []byte("method")},
 								{Key: keyOpStatus, Value: []byte("someError1")},
 								{Key: keyService, Value: []byte("package.service")},
@@ -246,7 +246,7 @@ func TestServerDefaultCollections(t *testing.T) {
 							newCountAggregationValue(1),
 						},
 						{
-							[]tags.Tag{
+							[]tag.Tag{
 								{Key: keyMethod, Value: []byte("method")},
 								{Key: keyOpStatus, Value: []byte("someError2")},
 								{Key: keyService, Value: []byte("package.service")},
@@ -259,7 +259,7 @@ func TestServerDefaultCollections(t *testing.T) {
 					func() *istats.View { return RPCServerRequestCountView },
 					[]*istats.Row{
 						{
-							[]tags.Tag{
+							[]tag.Tag{
 								{Key: keyMethod, Value: []byte("method")},
 								{Key: keyService, Value: []byte("package.service")},
 							},
@@ -271,7 +271,7 @@ func TestServerDefaultCollections(t *testing.T) {
 					func() *istats.View { return RPCServerResponseCountView },
 					[]*istats.Row{
 						{
-							[]tags.Tag{
+							[]tag.Tag{
 								{Key: keyMethod, Value: []byte("method")},
 								{Key: keyService, Value: []byte("package.service")},
 							},
@@ -283,7 +283,7 @@ func TestServerDefaultCollections(t *testing.T) {
 					func() *istats.View { return RPCServerRequestBytesView },
 					[]*istats.Row{
 						{
-							[]tags.Tag{
+							[]tag.Tag{
 								{Key: keyMethod, Value: []byte("method")},
 								{Key: keyService, Value: []byte("package.service")},
 							},
@@ -295,7 +295,7 @@ func TestServerDefaultCollections(t *testing.T) {
 					func() *istats.View { return RPCServerResponseBytesView },
 					[]*istats.Row{
 						{
-							[]tags.Tag{
+							[]tag.Tag{
 								{Key: keyMethod, Value: []byte("method")},
 								{Key: keyService, Value: []byte("package.service")},
 							},
@@ -313,12 +313,12 @@ func TestServerDefaultCollections(t *testing.T) {
 
 		h := NewServerHandler()
 		for _, rpc := range tc.rpcs {
-			mods := []tags.Mutator{}
+			mods := []tag.Mutator{}
 			for _, t := range rpc.tags {
-				mods = append(mods, tags.UpsertString(t.k, t.v))
+				mods = append(mods, tag.UpsertString(t.k, t.v))
 			}
-			ts := tags.NewMap(nil, mods...)
-			encoded := tags.Encode(ts)
+			ts := tag.NewMap(nil, mods...)
+			encoded := tag.Encode(ts)
 			ctx := stats.SetTags(context.Background(), encoded)
 
 			ctx = h.TagRPC(ctx, rpc.tagInfo)

--- a/plugins/grpc/stats/server_metrics.go
+++ b/plugins/grpc/stats/server_metrics.go
@@ -20,7 +20,7 @@ import (
 	"log"
 
 	istats "github.com/census-instrumentation/opencensus-go/stats"
-	"github.com/census-instrumentation/opencensus-go/tags"
+	"github.com/census-instrumentation/opencensus-go/tag"
 )
 
 // These variables define the default hard-coded metrics to collect for a GRPC
@@ -100,51 +100,51 @@ func createDefaultMeasuresServer() {
 func registerDefaultViewsServer() {
 	var views []*istats.View
 
-	RPCServerErrorCountView = istats.NewView("grpc.io/server/error_count/distribution_cumulative", "RPC Errors", []tags.Key{keyMethod, keyOpStatus, keyService}, RPCServerErrorCount, aggCount, windowCumulative)
+	RPCServerErrorCountView = istats.NewView("grpc.io/server/error_count/distribution_cumulative", "RPC Errors", []tag.Key{keyMethod, keyOpStatus, keyService}, RPCServerErrorCount, aggCount, windowCumulative)
 	views = append(views, RPCServerErrorCountView)
-	RPCServerServerElapsedTimeView = istats.NewView("grpc.io/server/server_elapsed_time/distribution_cumulative", "Server elapsed time in msecs", []tags.Key{keyService, keyMethod}, RPCServerServerElapsedTime, aggDistMillis, windowCumulative)
+	RPCServerServerElapsedTimeView = istats.NewView("grpc.io/server/server_elapsed_time/distribution_cumulative", "Server elapsed time in msecs", []tag.Key{keyService, keyMethod}, RPCServerServerElapsedTime, aggDistMillis, windowCumulative)
 	views = append(views, RPCServerServerElapsedTimeView)
-	RPCServerRequestBytesView = istats.NewView("grpc.io/server/request_bytes/distribution_cumulative", "Request bytes", []tags.Key{keyService, keyMethod}, RPCServerRequestBytes, aggDistBytes, windowCumulative)
+	RPCServerRequestBytesView = istats.NewView("grpc.io/server/request_bytes/distribution_cumulative", "Request bytes", []tag.Key{keyService, keyMethod}, RPCServerRequestBytes, aggDistBytes, windowCumulative)
 	views = append(views, RPCServerRequestBytesView)
-	RPCServerResponseBytesView = istats.NewView("grpc.io/server/response_bytes/distribution_cumulative", "Response bytes", []tags.Key{keyService, keyMethod}, RPCServerResponseBytes, aggDistBytes, windowCumulative)
+	RPCServerResponseBytesView = istats.NewView("grpc.io/server/response_bytes/distribution_cumulative", "Response bytes", []tag.Key{keyService, keyMethod}, RPCServerResponseBytes, aggDistBytes, windowCumulative)
 	views = append(views, RPCServerResponseBytesView)
-	RPCServerRequestCountView = istats.NewView("grpc.io/server/request_count/distribution_cumulative", "Count of request messages per server RPC", []tags.Key{keyService, keyMethod}, RPCServerRequestCount, aggDistCounts, windowCumulative)
+	RPCServerRequestCountView = istats.NewView("grpc.io/server/request_count/distribution_cumulative", "Count of request messages per server RPC", []tag.Key{keyService, keyMethod}, RPCServerRequestCount, aggDistCounts, windowCumulative)
 	views = append(views, RPCServerRequestCountView)
-	RPCServerResponseCountView = istats.NewView("grpc.io/server/response_count/distribution_cumulative", "Count of response messages per server RPC", []tags.Key{keyService, keyMethod}, RPCServerResponseCount, aggDistCounts, windowCumulative)
+	RPCServerResponseCountView = istats.NewView("grpc.io/server/response_count/distribution_cumulative", "Count of response messages per server RPC", []tag.Key{keyService, keyMethod}, RPCServerResponseCount, aggDistCounts, windowCumulative)
 	views = append(views, RPCServerResponseCountView)
 
-	RPCServerServerElapsedTimeMinuteView = istats.NewView("grpc.io/server/server_elapsed_time/minute_interval", "Minute stats for server elapsed time in msecs", []tags.Key{keyService, keyMethod}, RPCServerServerElapsedTime, aggDistMillis, windowSlidingMinute)
+	RPCServerServerElapsedTimeMinuteView = istats.NewView("grpc.io/server/server_elapsed_time/minute_interval", "Minute stats for server elapsed time in msecs", []tag.Key{keyService, keyMethod}, RPCServerServerElapsedTime, aggDistMillis, windowSlidingMinute)
 	views = append(views, RPCServerServerElapsedTimeMinuteView)
-	RPCServerRequestBytesMinuteView = istats.NewView("grpc.io/server/request_bytes/minute_interval", "Minute stats for request size in bytes", []tags.Key{keyService, keyMethod}, RPCServerRequestBytes, aggCount, windowSlidingMinute)
+	RPCServerRequestBytesMinuteView = istats.NewView("grpc.io/server/request_bytes/minute_interval", "Minute stats for request size in bytes", []tag.Key{keyService, keyMethod}, RPCServerRequestBytes, aggCount, windowSlidingMinute)
 	views = append(views, RPCServerRequestBytesMinuteView)
-	RPCServerResponseBytesMinuteView = istats.NewView("grpc.io/server/response_bytes/minute_interval", "Minute stats for response size in bytes", []tags.Key{keyService, keyMethod}, RPCServerResponseBytes, aggCount, windowSlidingMinute)
+	RPCServerResponseBytesMinuteView = istats.NewView("grpc.io/server/response_bytes/minute_interval", "Minute stats for response size in bytes", []tag.Key{keyService, keyMethod}, RPCServerResponseBytes, aggCount, windowSlidingMinute)
 	views = append(views, RPCServerResponseBytesMinuteView)
-	RPCServerErrorCountMinuteView = istats.NewView("grpc.io/server/error_count/minute_interval", "Minute stats for rpc errors", []tags.Key{keyService, keyMethod}, RPCServerErrorCount, aggCount, windowSlidingMinute)
+	RPCServerErrorCountMinuteView = istats.NewView("grpc.io/server/error_count/minute_interval", "Minute stats for rpc errors", []tag.Key{keyService, keyMethod}, RPCServerErrorCount, aggCount, windowSlidingMinute)
 	views = append(views, RPCServerErrorCountMinuteView)
-	RPCServerStartedCountMinuteView = istats.NewView("grpc.io/server/started_count/minute_interval", "Minute stats on the number of server RPCs started", []tags.Key{keyService, keyMethod}, RPCServerStartedCount, aggCount, windowSlidingMinute)
+	RPCServerStartedCountMinuteView = istats.NewView("grpc.io/server/started_count/minute_interval", "Minute stats on the number of server RPCs started", []tag.Key{keyService, keyMethod}, RPCServerStartedCount, aggCount, windowSlidingMinute)
 	views = append(views, RPCServerStartedCountMinuteView)
-	RPCServerFinishedCountMinuteView = istats.NewView("grpc.io/server/finished_count/minute_interval", "Minute stats on the number of server RPCs finished", []tags.Key{keyService, keyMethod}, RPCServerFinishedCount, aggCount, windowSlidingMinute)
+	RPCServerFinishedCountMinuteView = istats.NewView("grpc.io/server/finished_count/minute_interval", "Minute stats on the number of server RPCs finished", []tag.Key{keyService, keyMethod}, RPCServerFinishedCount, aggCount, windowSlidingMinute)
 	views = append(views, RPCServerFinishedCountMinuteView)
-	RPCServerRequestCountMinuteView = istats.NewView("grpc.io/server/request_count/minute_interval", "Minute stats on the count of request messages per server RPC", []tags.Key{keyService, keyMethod}, RPCServerRequestCount, aggCount, windowSlidingMinute)
+	RPCServerRequestCountMinuteView = istats.NewView("grpc.io/server/request_count/minute_interval", "Minute stats on the count of request messages per server RPC", []tag.Key{keyService, keyMethod}, RPCServerRequestCount, aggCount, windowSlidingMinute)
 	views = append(views, RPCServerRequestCountMinuteView)
-	RPCServerResponseCountMinuteView = istats.NewView("grpc.io/server/response_count/minute_interval", "Minute stats on the count of response messages per server RPC", []tags.Key{keyService, keyMethod}, RPCServerResponseCount, aggCount, windowSlidingMinute)
+	RPCServerResponseCountMinuteView = istats.NewView("grpc.io/server/response_count/minute_interval", "Minute stats on the count of response messages per server RPC", []tag.Key{keyService, keyMethod}, RPCServerResponseCount, aggCount, windowSlidingMinute)
 	views = append(views, RPCServerResponseCountMinuteView)
 
-	RPCServerServerElapsedTimeHourView = istats.NewView("grpc.io/server/server_elapsed_time/hour_interval", "Hour stats for server elapsed time in msecs", []tags.Key{keyService, keyMethod}, RPCServerServerElapsedTime, aggDistMillis, windowSlidingHour)
+	RPCServerServerElapsedTimeHourView = istats.NewView("grpc.io/server/server_elapsed_time/hour_interval", "Hour stats for server elapsed time in msecs", []tag.Key{keyService, keyMethod}, RPCServerServerElapsedTime, aggDistMillis, windowSlidingHour)
 	views = append(views, RPCServerServerElapsedTimeHourView)
-	RPCServerRequestBytesHourView = istats.NewView("grpc.io/server/request_bytes/hour_interval", "Hour stats for request size in bytes", []tags.Key{keyService, keyMethod}, RPCServerRequestBytes, aggCount, windowSlidingHour)
+	RPCServerRequestBytesHourView = istats.NewView("grpc.io/server/request_bytes/hour_interval", "Hour stats for request size in bytes", []tag.Key{keyService, keyMethod}, RPCServerRequestBytes, aggCount, windowSlidingHour)
 	views = append(views, RPCServerRequestBytesHourView)
-	RPCServerResponseBytesHourView = istats.NewView("grpc.io/server/response_bytes/hour_interval", "Hour stats for response size in bytes", []tags.Key{keyService, keyMethod}, RPCServerResponseBytes, aggCount, windowSlidingHour)
+	RPCServerResponseBytesHourView = istats.NewView("grpc.io/server/response_bytes/hour_interval", "Hour stats for response size in bytes", []tag.Key{keyService, keyMethod}, RPCServerResponseBytes, aggCount, windowSlidingHour)
 	views = append(views, RPCServerResponseBytesHourView)
-	RPCServerErrorCountHourView = istats.NewView("grpc.io/server/error_count/hour_interval", "Hour stats for rpc errors", []tags.Key{keyService, keyMethod}, RPCServerErrorCount, aggCount, windowSlidingHour)
+	RPCServerErrorCountHourView = istats.NewView("grpc.io/server/error_count/hour_interval", "Hour stats for rpc errors", []tag.Key{keyService, keyMethod}, RPCServerErrorCount, aggCount, windowSlidingHour)
 	views = append(views, RPCServerErrorCountHourView)
-	RPCServerStartedCountHourView = istats.NewView("grpc.io/server/started_count/hour_interval", "Hour stats on the number of server RPCs started", []tags.Key{keyService, keyMethod}, RPCServerStartedCount, aggCount, windowSlidingHour)
+	RPCServerStartedCountHourView = istats.NewView("grpc.io/server/started_count/hour_interval", "Hour stats on the number of server RPCs started", []tag.Key{keyService, keyMethod}, RPCServerStartedCount, aggCount, windowSlidingHour)
 	views = append(views, RPCServerStartedCountHourView)
-	RPCServerFinishedCountHourView = istats.NewView("grpc.io/server/finished_count/hour_interval", "Hour stats on the number of server RPCs finished", []tags.Key{keyService, keyMethod}, RPCServerFinishedCount, aggCount, windowSlidingHour)
+	RPCServerFinishedCountHourView = istats.NewView("grpc.io/server/finished_count/hour_interval", "Hour stats on the number of server RPCs finished", []tag.Key{keyService, keyMethod}, RPCServerFinishedCount, aggCount, windowSlidingHour)
 	views = append(views, RPCServerFinishedCountHourView)
-	RPCServerRequestCountHourView = istats.NewView("grpc.io/server/request_count/hour_interval", "Hour stats on the count of request messages per server RPC", []tags.Key{keyService, keyMethod}, RPCServerRequestCount, aggCount, windowSlidingHour)
+	RPCServerRequestCountHourView = istats.NewView("grpc.io/server/request_count/hour_interval", "Hour stats on the count of request messages per server RPC", []tag.Key{keyService, keyMethod}, RPCServerRequestCount, aggCount, windowSlidingHour)
 	views = append(views, RPCServerRequestCountHourView)
-	RPCServerResponseCountHourView = istats.NewView("grpc.io/server/response_count/hour_interval", "Hour stats on the count of response messages per server RPC", []tags.Key{keyService, keyMethod}, RPCServerResponseCount, aggCount, windowSlidingHour)
+	RPCServerResponseCountHourView = istats.NewView("grpc.io/server/response_count/hour_interval", "Hour stats on the count of response messages per server RPC", []tag.Key{keyService, keyMethod}, RPCServerResponseCount, aggCount, windowSlidingHour)
 	views = append(views, RPCServerResponseCountHourView)
 
 	// Registering views

--- a/plugins/grpc/stats/types.go
+++ b/plugins/grpc/stats/types.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	istats "github.com/census-instrumentation/opencensus-go/stats"
-	"github.com/census-instrumentation/opencensus-go/tags"
+	"github.com/census-instrumentation/opencensus-go/tag"
 )
 
 type grpcInstrumentationKey struct{}
@@ -68,24 +68,24 @@ var (
 	windowSlidingHour   = istats.SlidingTimeWindow{Duration: 1 * time.Hour, Intervals: 6}
 	windowSlidingMinute = istats.SlidingTimeWindow{Duration: 1 * time.Minute, Intervals: 6}
 
-	keyService  tags.StringKey
-	keyMethod   tags.StringKey
-	keyOpStatus tags.StringKey
+	keyService  tag.StringKey
+	keyMethod   tag.StringKey
+	keyOpStatus tag.StringKey
 )
 
 func createDefaultKeys() {
 	// Initializing keys
 	var err error
-	if keyService, err = tags.NewStringKey("grpc.service"); err != nil {
-		log.Fatalf("tags.NewStringKey(\"grpc.service\") failed to create/retrieve keyService. %v", err)
+	if keyService, err = tag.NewStringKey("grpc.service"); err != nil {
+		log.Fatalf("tag.NewStringKey(\"grpc.service\") failed to create/retrieve keyService. %v", err)
 	}
 
-	if keyMethod, err = tags.NewStringKey("grpc.method"); err != nil {
-		log.Fatalf("tags.NewStringKey(\"grpc.method\") failed to create/retrieve keyMethod. %v", err)
+	if keyMethod, err = tag.NewStringKey("grpc.method"); err != nil {
+		log.Fatalf("tag.NewStringKey(\"grpc.method\") failed to create/retrieve keyMethod. %v", err)
 	}
 
-	if keyOpStatus, err = tags.NewStringKey("grpc.opstatus"); err != nil {
-		log.Fatalf("tags.NewStringKey(\"grpc.opstatus\") failed to create/retrieve keyOpStatus. %v", err)
+	if keyOpStatus, err = tag.NewStringKey("grpc.opstatus"); err != nil {
+		log.Fatalf("tag.NewStringKey(\"grpc.opstatus\") failed to create/retrieve keyOpStatus. %v", err)
 	}
 }
 

--- a/stats/collector.go
+++ b/stats/collector.go
@@ -18,7 +18,7 @@ package stats
 import (
 	"time"
 
-	"github.com/census-instrumentation/opencensus-go/tags"
+	"github.com/census-instrumentation/opencensus-go/tag"
 )
 
 type collector struct {
@@ -42,10 +42,10 @@ func (c *collector) addSample(s string, v interface{}, now time.Time) {
 	aggregator.addSample(v, now)
 }
 
-func (c *collector) collectedRows(keys []tags.Key, now time.Time) []*Row {
+func (c *collector) collectedRows(keys []tag.Key, now time.Time) []*Row {
 	var rows []*Row
 	for sig, aggregator := range c.signatures {
-		tags := tags.ToOrderedTagsSlice(sig, keys)
+		tags := tag.ToOrderedTagsSlice(sig, keys)
 		row := &Row{tags, aggregator.retrieveCollected(now)}
 		rows = append(rows, row)
 	}

--- a/stats/view.go
+++ b/stats/view.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/census-instrumentation/opencensus-go/tags"
+	"github.com/census-instrumentation/opencensus-go/tag"
 )
 
 // View allows users to filter and aggregate the recorded events
@@ -33,7 +33,7 @@ type View struct {
 	description string
 
 	// tagKeys to perform the aggregation on.
-	tagKeys []tags.Key
+	tagKeys []tag.Key
 
 	// Examples of measures are cpu:tickCount, diskio:time...
 	m Measure
@@ -61,8 +61,8 @@ type subscription struct {
 
 // NewView creates a new view. Views need to be registered
 // via RegisterView to enable data collection.
-func NewView(name, description string, keys []tags.Key, measure Measure, agg Aggregation, window Window) *View {
-	var keysCopy []tags.Key
+func NewView(name, description string, keys []tag.Key, measure Measure, agg Aggregation, window Window) *View {
+	var keysCopy []tag.Key
 	for _, k := range keys {
 		keysCopy = append(keysCopy, k)
 	}
@@ -151,11 +151,11 @@ func (v *View) collectedRows(now time.Time) []*Row {
 	return v.c.collectedRows(v.tagKeys, now)
 }
 
-func (v *View) addSample(ts *tags.Map, val interface{}, now time.Time) {
+func (v *View) addSample(ts *tag.Map, val interface{}, now time.Time) {
 	if !v.isCollecting() {
 		return
 	}
-	sig := tags.ToValuesString(ts, v.tagKeys)
+	sig := tag.ToValuesString(ts, v.tagKeys)
 	v.c.addSample(sig, val, now)
 }
 
@@ -170,7 +170,7 @@ type ViewData struct {
 
 // Row is the collected value for a specific set of key value pairs a.k.a tags.
 type Row struct {
-	Tags             []tags.Tag
+	Tags             []tag.Tag
 	AggregationValue AggregationValue
 }
 

--- a/stats/view_test.go
+++ b/stats/view_test.go
@@ -19,18 +19,18 @@ import (
 	"testing"
 	"time"
 
-	"github.com/census-instrumentation/opencensus-go/tags"
+	"github.com/census-instrumentation/opencensus-go/tag"
 )
 
 func Test_View_MeasureFloat64_AggregationDistribution_WindowCumulative(t *testing.T) {
-	k1, _ := tags.NewStringKey("k1")
-	k2, _ := tags.NewStringKey("k2")
-	k3, _ := tags.NewStringKey("k3")
+	k1, _ := tag.NewStringKey("k1")
+	k2, _ := tag.NewStringKey("k2")
+	k3, _ := tag.NewStringKey("k3")
 	agg1 := DistributionAggregation([]float64{2})
-	vw1 := NewView("VF1", "desc VF1", []tags.Key{k1, k2}, nil, agg1, CumulativeWindow{})
+	vw1 := NewView("VF1", "desc VF1", []tag.Key{k1, k2}, nil, agg1, CumulativeWindow{})
 
 	type tagString struct {
-		k tags.StringKey
+		k tag.StringKey
 		v string
 	}
 	type record struct {
@@ -53,7 +53,7 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowCumulative(t *testin
 			},
 			[]*Row{
 				{
-					[]tags.Tag{{Key: k1, Value: []byte("v1")}},
+					[]tag.Tag{{Key: k1, Value: []byte("v1")}},
 					&DistributionAggregationValue{
 						2, 1, 5, 3, 8, []int64{1, 1}, agg1,
 					},
@@ -68,13 +68,13 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowCumulative(t *testin
 			},
 			[]*Row{
 				{
-					[]tags.Tag{{Key: k1, Value: []byte("v1")}},
+					[]tag.Tag{{Key: k1, Value: []byte("v1")}},
 					&DistributionAggregationValue{
 						1, 1, 1, 1, 0, []int64{1, 0}, agg1,
 					},
 				},
 				{
-					[]tags.Tag{{Key: k2, Value: []byte("v2")}},
+					[]tag.Tag{{Key: k2, Value: []byte("v2")}},
 					&DistributionAggregationValue{
 						1, 5, 5, 5, 0, []int64{0, 1}, agg1,
 					},
@@ -92,25 +92,25 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowCumulative(t *testin
 			},
 			[]*Row{
 				{
-					[]tags.Tag{{Key: k1, Value: []byte("v1")}},
+					[]tag.Tag{{Key: k1, Value: []byte("v1")}},
 					&DistributionAggregationValue{
 						2, 1, 5, 3, 8, []int64{1, 1}, agg1,
 					},
 				},
 				{
-					[]tags.Tag{{Key: k1, Value: []byte("v1 other")}},
+					[]tag.Tag{{Key: k1, Value: []byte("v1 other")}},
 					&DistributionAggregationValue{
 						1, 1, 1, 1, 0, []int64{1, 0}, agg1,
 					},
 				},
 				{
-					[]tags.Tag{{Key: k2, Value: []byte("v2")}},
+					[]tag.Tag{{Key: k2, Value: []byte("v2")}},
 					&DistributionAggregationValue{
 						1, 5, 5, 5, 0, []int64{0, 1}, agg1,
 					},
 				},
 				{
-					[]tags.Tag{{Key: k1, Value: []byte("v1")}, {Key: k2, Value: []byte("v2")}},
+					[]tag.Tag{{Key: k1, Value: []byte("v1")}, {Key: k2, Value: []byte("v2")}},
 					&DistributionAggregationValue{
 						1, 5, 5, 5, 0, []int64{0, 1}, agg1,
 					},
@@ -130,19 +130,19 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowCumulative(t *testin
 			},
 			[]*Row{
 				{
-					[]tags.Tag{{Key: k1, Value: []byte("v1 is a very long value key")}},
+					[]tag.Tag{{Key: k1, Value: []byte("v1 is a very long value key")}},
 					&DistributionAggregationValue{
 						2, 1, 5, 3, 8, []int64{1, 1}, agg1,
 					},
 				},
 				{
-					[]tags.Tag{{Key: k1, Value: []byte("v1 is another very long value key")}},
+					[]tag.Tag{{Key: k1, Value: []byte("v1 is another very long value key")}},
 					&DistributionAggregationValue{
 						1, 1, 1, 1, 0, []int64{1, 0}, agg1,
 					},
 				},
 				{
-					[]tags.Tag{{Key: k1, Value: []byte("v1 is a very long value key")}, {Key: k2, Value: []byte("v2 is a very long value key")}},
+					[]tag.Tag{{Key: k1, Value: []byte("v1 is a very long value key")}, {Key: k2, Value: []byte("v2 is a very long value key")}},
 					&DistributionAggregationValue{
 						4, 1, 5, 3, 2.66666666666667 * 3, []int64{1, 3}, agg1,
 					},
@@ -155,11 +155,11 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowCumulative(t *testin
 		vw1.clearRows()
 		vw1.startForcedCollection()
 		for _, r := range tc.records {
-			mods := []tags.Mutator{}
-			for _, tag := range r.tags {
-				mods = append(mods, tags.InsertString(tag.k, tag.v))
+			mods := []tag.Mutator{}
+			for _, t := range r.tags {
+				mods = append(mods, tag.InsertString(t.k, t.v))
 			}
-			ts := tags.NewMap(nil, mods...)
+			ts := tag.NewMap(nil, mods...)
 			vw1.addSample(ts, r.f, time.Now())
 		}
 
@@ -184,13 +184,13 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowCumulative(t *testin
 func Test_View_MeasureFloat64_AggregationDistribution_WindowSlidingTime(t *testing.T) {
 	startTime := time.Date(2010, 1, 1, 0, 0, 0, 0, time.UTC)
 
-	k1, _ := tags.NewStringKey("k1")
-	k2, _ := tags.NewStringKey("k2")
+	k1, _ := tag.NewStringKey("k1")
+	k2, _ := tag.NewStringKey("k2")
 	agg1 := DistributionAggregation([]float64{2})
-	vw1 := NewView("VF1", "desc VF1", []tags.Key{k1, k2}, nil, agg1, SlidingTimeWindow{10 * time.Second, 5})
+	vw1 := NewView("VF1", "desc VF1", []tag.Key{k1, k2}, nil, agg1, SlidingTimeWindow{10 * time.Second, 5})
 
 	type tagString struct {
-		k tags.StringKey
+		k tag.StringKey
 		v string
 	}
 	type record struct {
@@ -229,7 +229,7 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowSlidingTime(t *testi
 					startTime.Add(14 * time.Second),
 					[]*Row{
 						{
-							[]tags.Tag{{Key: k1, Value: []byte("v1")}},
+							[]tag.Tag{{Key: k1, Value: []byte("v1")}},
 							&DistributionAggregationValue{
 								6, 2, 5, 3.8333333333, 1.3666666667 * 5, []int64{0, 6}, agg1,
 							},
@@ -241,7 +241,7 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowSlidingTime(t *testi
 					startTime.Add(18 * time.Second),
 					[]*Row{
 						{
-							[]tags.Tag{{Key: k1, Value: []byte("v1")}},
+							[]tag.Tag{{Key: k1, Value: []byte("v1")}},
 							&DistributionAggregationValue{
 								4, 3, 5, 4, 0.6666666667 * 3, []int64{0, 4}, agg1,
 							},
@@ -253,7 +253,7 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowSlidingTime(t *testi
 					startTime.Add(22 * time.Second),
 					[]*Row{
 						{
-							[]tags.Tag{{Key: k1, Value: []byte("v1")}},
+							[]tag.Tag{{Key: k1, Value: []byte("v1")}},
 							&DistributionAggregationValue{
 								2, 3, 4, 3.5, 0.5, []int64{0, 2}, agg1,
 							},
@@ -279,7 +279,7 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowSlidingTime(t *testi
 					startTime.Add(10 * time.Second),
 					[]*Row{
 						{
-							[]tags.Tag{{Key: k1, Value: []byte("v1")}},
+							[]tag.Tag{{Key: k1, Value: []byte("v1")}},
 							&DistributionAggregationValue{
 								7, 1, 5, 3.57142857142857, 2.61904761904762 * 6, []int64{1, 6}, agg1,
 							},
@@ -291,7 +291,7 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowSlidingTime(t *testi
 					startTime.Add(12 * time.Second),
 					[]*Row{
 						{
-							[]tags.Tag{{Key: k1, Value: []byte("v1")}},
+							[]tag.Tag{{Key: k1, Value: []byte("v1")}},
 							&DistributionAggregationValue{
 								7, 1, 5, 3.57142857142857, 2.61904761904762 * 6, []int64{1, 6}, agg1,
 							},
@@ -303,7 +303,7 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowSlidingTime(t *testi
 					startTime.Add(15 * time.Second),
 					[]*Row{
 						{
-							[]tags.Tag{{Key: k1, Value: []byte("v1")}},
+							[]tag.Tag{{Key: k1, Value: []byte("v1")}},
 							&DistributionAggregationValue{
 								6, 2, 5, 4, 1.6 * 5, []int64{0, 6}, agg1,
 							},
@@ -315,7 +315,7 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowSlidingTime(t *testi
 					startTime.Add(17*time.Second - 1*time.Millisecond),
 					[]*Row{
 						{
-							[]tags.Tag{{Key: k1, Value: []byte("v1")}},
+							[]tag.Tag{{Key: k1, Value: []byte("v1")}},
 							&DistributionAggregationValue{
 								6, 2, 5, 4, 1.6 * 5, []int64{0, 6}, agg1,
 							},
@@ -327,7 +327,7 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowSlidingTime(t *testi
 					startTime.Add(18 * time.Second),
 					[]*Row{
 						{
-							[]tags.Tag{{Key: k1, Value: []byte("v1")}},
+							[]tag.Tag{{Key: k1, Value: []byte("v1")}},
 							&DistributionAggregationValue{
 								4, 4, 5, 4.75, 0.25 * 3, []int64{0, 4}, agg1,
 							},
@@ -342,11 +342,11 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowSlidingTime(t *testi
 		vw1.clearRows()
 		vw1.startForcedCollection()
 		for _, r := range tc.records {
-			mods := []tags.Mutator{}
+			mods := []tag.Mutator{}
 			for _, t := range r.tags {
-				mods = append(mods, tags.InsertString(t.k, t.v))
+				mods = append(mods, tag.InsertString(t.k, t.v))
 			}
-			ts := tags.NewMap(nil, mods...)
+			ts := tag.NewMap(nil, mods...)
 			vw1.addSample(ts, r.f, r.now)
 		}
 
@@ -374,13 +374,13 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowSlidingTime(t *testi
 func Test_View_MeasureFloat64_AggregationCount_WindowSlidingTime(t *testing.T) {
 	startTime := time.Date(2010, 1, 1, 0, 0, 0, 0, time.UTC)
 
-	k1, _ := tags.NewStringKey("k1")
-	k2, _ := tags.NewStringKey("k2")
+	k1, _ := tag.NewStringKey("k1")
+	k2, _ := tag.NewStringKey("k2")
 	agg1 := CountAggregation{}
-	vw1 := NewView("VF1", "desc VF1", []tags.Key{k1, k2}, nil, agg1, SlidingTimeWindow{10 * time.Second, 5})
+	vw1 := NewView("VF1", "desc VF1", []tag.Key{k1, k2}, nil, agg1, SlidingTimeWindow{10 * time.Second, 5})
 
 	type tagString struct {
-		k tags.StringKey
+		k tag.StringKey
 		v string
 	}
 	type record struct {
@@ -419,7 +419,7 @@ func Test_View_MeasureFloat64_AggregationCount_WindowSlidingTime(t *testing.T) {
 					startTime.Add(14 * time.Second),
 					[]*Row{
 						{
-							[]tags.Tag{{Key: k1, Value: []byte("v1")}},
+							[]tag.Tag{{Key: k1, Value: []byte("v1")}},
 							newCountAggregationValue(6),
 						},
 					},
@@ -429,7 +429,7 @@ func Test_View_MeasureFloat64_AggregationCount_WindowSlidingTime(t *testing.T) {
 					startTime.Add(18 * time.Second),
 					[]*Row{
 						{
-							[]tags.Tag{{Key: k1, Value: []byte("v1")}},
+							[]tag.Tag{{Key: k1, Value: []byte("v1")}},
 							newCountAggregationValue(4),
 						},
 					},
@@ -439,7 +439,7 @@ func Test_View_MeasureFloat64_AggregationCount_WindowSlidingTime(t *testing.T) {
 					startTime.Add(22 * time.Second),
 					[]*Row{
 						{
-							[]tags.Tag{{Key: k1, Value: []byte("v1")}},
+							[]tag.Tag{{Key: k1, Value: []byte("v1")}},
 							newCountAggregationValue(2),
 						},
 					},
@@ -463,7 +463,7 @@ func Test_View_MeasureFloat64_AggregationCount_WindowSlidingTime(t *testing.T) {
 					startTime.Add(10 * time.Second),
 					[]*Row{
 						{
-							[]tags.Tag{{Key: k1, Value: []byte("v1")}},
+							[]tag.Tag{{Key: k1, Value: []byte("v1")}},
 							newCountAggregationValue(7),
 						},
 					},
@@ -473,7 +473,7 @@ func Test_View_MeasureFloat64_AggregationCount_WindowSlidingTime(t *testing.T) {
 					startTime.Add(12 * time.Second),
 					[]*Row{
 						{
-							[]tags.Tag{{Key: k1, Value: []byte("v1")}},
+							[]tag.Tag{{Key: k1, Value: []byte("v1")}},
 							newCountAggregationValue(7),
 						},
 					},
@@ -483,7 +483,7 @@ func Test_View_MeasureFloat64_AggregationCount_WindowSlidingTime(t *testing.T) {
 					startTime.Add(12 * time.Second),
 					[]*Row{
 						{
-							[]tags.Tag{{Key: k1, Value: []byte("v1")}},
+							[]tag.Tag{{Key: k1, Value: []byte("v1")}},
 							newCountAggregationValue(7),
 						},
 					},
@@ -493,7 +493,7 @@ func Test_View_MeasureFloat64_AggregationCount_WindowSlidingTime(t *testing.T) {
 					startTime.Add(15*time.Second + 400*time.Millisecond),
 					[]*Row{
 						{
-							[]tags.Tag{{Key: k1, Value: []byte("v1")}},
+							[]tag.Tag{{Key: k1, Value: []byte("v1")}},
 							newCountAggregationValue(6),
 						},
 					},
@@ -503,7 +503,7 @@ func Test_View_MeasureFloat64_AggregationCount_WindowSlidingTime(t *testing.T) {
 					startTime.Add(16 * time.Second),
 					[]*Row{
 						{
-							[]tags.Tag{{Key: k1, Value: []byte("v1")}},
+							[]tag.Tag{{Key: k1, Value: []byte("v1")}},
 							newCountAggregationValue(5),
 						},
 					},
@@ -513,7 +513,7 @@ func Test_View_MeasureFloat64_AggregationCount_WindowSlidingTime(t *testing.T) {
 					startTime.Add(17*time.Second + 200*time.Millisecond),
 					[]*Row{
 						{
-							[]tags.Tag{{Key: k1, Value: []byte("v1")}},
+							[]tag.Tag{{Key: k1, Value: []byte("v1")}},
 							newCountAggregationValue(4),
 						},
 					},
@@ -523,7 +523,7 @@ func Test_View_MeasureFloat64_AggregationCount_WindowSlidingTime(t *testing.T) {
 					startTime.Add(18 * time.Second),
 					[]*Row{
 						{
-							[]tags.Tag{{Key: k1, Value: []byte("v1")}},
+							[]tag.Tag{{Key: k1, Value: []byte("v1")}},
 							newCountAggregationValue(3),
 						},
 					},
@@ -533,7 +533,7 @@ func Test_View_MeasureFloat64_AggregationCount_WindowSlidingTime(t *testing.T) {
 					startTime.Add(18*time.Second + 600*time.Millisecond),
 					[]*Row{
 						{
-							[]tags.Tag{{Key: k1, Value: []byte("v1")}},
+							[]tag.Tag{{Key: k1, Value: []byte("v1")}},
 							newCountAggregationValue(2),
 						},
 					},
@@ -546,11 +546,11 @@ func Test_View_MeasureFloat64_AggregationCount_WindowSlidingTime(t *testing.T) {
 		vw1.clearRows()
 		vw1.startForcedCollection()
 		for _, r := range tc.records {
-			mods := []tags.Mutator{}
+			mods := []tag.Mutator{}
 			for _, t := range r.tags {
-				mods = append(mods, tags.InsertString(t.k, t.v))
+				mods = append(mods, tag.InsertString(t.k, t.v))
 			}
-			ts := tags.NewMap(nil, mods...)
+			ts := tag.NewMap(nil, mods...)
 			vw1.addSample(ts, r.f, r.now)
 		}
 
@@ -576,13 +576,13 @@ func Test_View_MeasureFloat64_AggregationCount_WindowSlidingTime(t *testing.T) {
 }
 
 func Test_View_MeasureFloat64_AggregationDistribution_WindowSlidingCount(t *testing.T) {
-	k1, _ := tags.NewStringKey("k1")
-	k2, _ := tags.NewStringKey("k2")
+	k1, _ := tag.NewStringKey("k1")
+	k2, _ := tag.NewStringKey("k2")
 	agg1 := DistributionAggregation([]float64{2})
-	vw1 := NewView("VF1", "desc VF1", []tags.Key{k1, k2}, nil, agg1, SlidingCountWindow{12, 4})
+	vw1 := NewView("VF1", "desc VF1", []tag.Key{k1, k2}, nil, agg1, SlidingCountWindow{12, 4})
 
 	type tagString struct {
-		k tags.StringKey
+		k tag.StringKey
 		v string
 	}
 	type record struct {
@@ -607,7 +607,7 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowSlidingCount(t *test
 			},
 			[]*Row{
 				{
-					[]tags.Tag{{Key: k1, Value: []byte("v1")}},
+					[]tag.Tag{{Key: k1, Value: []byte("v1")}},
 					&DistributionAggregationValue{
 						4, 1, 4, 2.5, 1.6666666667 * 3, []int64{1, 3}, agg1,
 					},
@@ -635,7 +635,7 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowSlidingCount(t *test
 			},
 			[]*Row{
 				{
-					[]tags.Tag{{Key: k1, Value: []byte("v1")}},
+					[]tag.Tag{{Key: k1, Value: []byte("v1")}},
 					&DistributionAggregationValue{
 						15, 1, 15, 8, 20 * 14, []int64{1, 14}, agg1,
 					},
@@ -661,7 +661,7 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowSlidingCount(t *test
 			},
 			[]*Row{
 				{
-					[]tags.Tag{{Key: k1, Value: []byte("v1")}},
+					[]tag.Tag{{Key: k1, Value: []byte("v1")}},
 					&DistributionAggregationValue{
 						13, 1, 13, 7, 15.1666666667 * 12, []int64{1, 12}, agg1,
 					},
@@ -674,11 +674,11 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowSlidingCount(t *test
 		vw1.clearRows()
 		vw1.startForcedCollection()
 		for _, r := range tc.records {
-			mods := []tags.Mutator{}
-			for _, tag := range r.tags {
-				mods = append(mods, tags.InsertString(tag.k, tag.v))
+			mods := []tag.Mutator{}
+			for _, t := range r.tags {
+				mods = append(mods, tag.InsertString(t.k, t.v))
 			}
-			ts := tags.NewMap(nil, mods...)
+			ts := tag.NewMap(nil, mods...)
 			vw1.addSample(ts, r.f, time.Now())
 		}
 

--- a/stats/worker.go
+++ b/stats/worker.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/census-instrumentation/opencensus-go/tags"
+	"github.com/census-instrumentation/opencensus-go/tag"
 )
 
 func init() {
@@ -217,7 +217,7 @@ func (v *View) RetrieveData() ([]*Row, error) {
 func Record(ctx context.Context, ms ...Measurement) {
 	req := &recordReq{
 		now: time.Now(),
-		tm:  tags.FromContext(ctx),
+		tm:  tag.FromContext(ctx),
 		ms:  ms,
 	}
 	defaultWorker.c <- req

--- a/stats/worker_commands.go
+++ b/stats/worker_commands.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/census-instrumentation/opencensus-go/tags"
+	"github.com/census-instrumentation/opencensus-go/tag"
 )
 
 type command interface {
@@ -266,7 +266,7 @@ func (cmd *retrieveDataReq) handleCommand(w *worker) {
 // recordFloat64Req is the command to record data related to a measure.
 type recordFloat64Req struct {
 	now time.Time
-	tm  *tags.Map
+	tm  *tag.Map
 	mf  *MeasureFloat64
 	v   float64
 }
@@ -283,7 +283,7 @@ func (cmd *recordFloat64Req) handleCommand(w *worker) {
 // recordInt64Req is the command to record data related to a measure.
 type recordInt64Req struct {
 	now time.Time
-	tm  *tags.Map
+	tm  *tag.Map
 	mi  *MeasureInt64
 	v   int64
 }
@@ -301,7 +301,7 @@ func (cmd *recordInt64Req) handleCommand(w *worker) {
 // at once.
 type recordReq struct {
 	now time.Time
-	tm  *tags.Map
+	tm  *tag.Map
 	ms  []Measurement
 }
 

--- a/stats/worker_test.go
+++ b/stats/worker_test.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"testing"
 
-	"golang.org/x/net/context"
+	"github.com/census-instrumentation/opencensus-go/tag"
 
-	"github.com/census-instrumentation/opencensus-go/tags"
+	"golang.org/x/net/context"
 )
 
 func Test_Worker_MeasureCreation(t *testing.T) {
@@ -478,16 +478,16 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 		t.Errorf("NewMeasureFloat64(\"MF1\", \"desc MF1\") got error '%v', want no error", err)
 	}
 
-	k1, _ := tags.NewStringKey("k1")
-	k2, _ := tags.NewStringKey("k2")
-	ts := tags.NewMap(nil,
-		tags.InsertString(k1, "v1"),
-		tags.InsertString(k2, "v2"),
+	k1, _ := tag.NewStringKey("k1")
+	k2, _ := tag.NewStringKey("k2")
+	ts := tag.NewMap(nil,
+		tag.InsertString(k1, "v1"),
+		tag.InsertString(k2, "v2"),
 	)
-	ctx := tags.NewContext(context.Background(), ts)
+	ctx := tag.NewContext(context.Background(), ts)
 
-	v1 := NewView("VF1", "desc VF1", []tags.Key{k1, k2}, m, CountAggregation{}, CumulativeWindow{})
-	v2 := NewView("VF2", "desc VF2", []tags.Key{k1, k2}, m, CountAggregation{}, CumulativeWindow{})
+	v1 := NewView("VF1", "desc VF1", []tag.Key{k1, k2}, m, CountAggregation{}, CumulativeWindow{})
+	v2 := NewView("VF2", "desc VF2", []tag.Key{k1, k2}, m, CountAggregation{}, CumulativeWindow{})
 
 	c1 := make(chan *ViewData)
 	type subscription struct {
@@ -528,7 +528,7 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 					v1,
 					[]*Row{
 						{
-							[]tags.Tag{{Key: k1, Value: []byte("v1")}, {Key: k2, Value: []byte("v2")}},
+							[]tag.Tag{{Key: k1, Value: []byte("v1")}, {Key: k2, Value: []byte("v2")}},
 							newCountAggregationValue(2),
 						},
 					},
@@ -548,7 +548,7 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 					v1,
 					[]*Row{
 						{
-							[]tags.Tag{{Key: k1, Value: []byte("v1")}, {Key: k2, Value: []byte("v2")}},
+							[]tag.Tag{{Key: k1, Value: []byte("v1")}, {Key: k2, Value: []byte("v2")}},
 							newCountAggregationValue(2),
 						},
 					},
@@ -558,7 +558,7 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 					v2,
 					[]*Row{
 						{
-							[]tags.Tag{{Key: k1, Value: []byte("v1")}, {Key: k2, Value: []byte("v2")}},
+							[]tag.Tag{{Key: k1, Value: []byte("v1")}, {Key: k2, Value: []byte("v2")}},
 							newCountAggregationValue(2),
 						},
 					},
@@ -577,7 +577,7 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 					v1,
 					[]*Row{
 						{
-							[]tags.Tag{{Key: k1, Value: []byte("v1")}, {Key: k2, Value: []byte("v2")}},
+							[]tag.Tag{{Key: k1, Value: []byte("v1")}, {Key: k2, Value: []byte("v2")}},
 							newCountAggregationValue(2),
 						},
 					},
@@ -597,7 +597,7 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 					v1,
 					[]*Row{
 						{
-							[]tags.Tag{{Key: k1, Value: []byte("v1")}, {Key: k2, Value: []byte("v2")}},
+							[]tag.Tag{{Key: k1, Value: []byte("v1")}, {Key: k2, Value: []byte("v2")}},
 							newCountAggregationValue(2),
 						},
 					},
@@ -607,7 +607,7 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 					v2,
 					[]*Row{
 						{
-							[]tags.Tag{{Key: k1, Value: []byte("v1")}, {Key: k2, Value: []byte("v2")}},
+							[]tag.Tag{{Key: k1, Value: []byte("v1")}, {Key: k2, Value: []byte("v2")}},
 							newCountAggregationValue(2),
 						},
 					},
@@ -626,7 +626,7 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 					v1,
 					[]*Row{
 						{
-							[]tags.Tag{{Key: k1, Value: []byte("v1")}, {Key: k2, Value: []byte("v2")}},
+							[]tag.Tag{{Key: k1, Value: []byte("v1")}, {Key: k2, Value: []byte("v2")}},
 							newCountAggregationValue(3),
 						},
 					},
@@ -636,7 +636,7 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 					v2,
 					[]*Row{
 						{
-							[]tags.Tag{{Key: k1, Value: []byte("v1")}, {Key: k2, Value: []byte("v2")}},
+							[]tag.Tag{{Key: k1, Value: []byte("v1")}, {Key: k2, Value: []byte("v2")}},
 							newCountAggregationValue(3),
 						},
 					},

--- a/tag/context.go
+++ b/tag/context.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-package tags
+package tag
 
 import "golang.org/x/net/context"
 

--- a/tag/doc.go
+++ b/tag/doc.go
@@ -14,4 +14,4 @@
 //
 
 // Package tags contains the OpenCensus tags APIs.
-package tags
+package tag

--- a/tag/example_test.go
+++ b/tag/example_test.go
@@ -13,25 +13,26 @@
 // limitations under the License.
 //
 
-package tags_test
+package tag_test
 
 import (
 	"log"
 
-	"golang.org/x/net/context"
+	"github.com/census-instrumentation/opencensus-go/tag"
+	"github.com/rakyll/census/tags"
 
-	"github.com/census-instrumentation/opencensus-go/tags"
+	"golang.org/x/net/context"
 )
 
 var (
-	tagMap *tags.Map
+	tagMap *tag.Map
 	ctx    context.Context
-	key    tags.StringKey
+	key    tag.StringKey
 )
 
 func ExampleNewStringKey() {
 	// Get a key to represent user OS.
-	key, err := tags.NewStringKey("/my/namespace/user-os")
+	key, err := tag.NewStringKey("/my/namespace/user-os")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -39,36 +40,36 @@ func ExampleNewStringKey() {
 }
 
 func ExampleNewMap() {
-	osKey, err := tags.NewStringKey("/my/namespace/user-os")
+	osKey, err := tag.NewStringKey("/my/namespace/user-os")
 	if err != nil {
 		log.Fatal(err)
 	}
-	userIDKey, err := tags.NewStringKey("/my/namespace/user-id")
+	userIDKey, err := tag.NewStringKey("/my/namespace/user-id")
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	tagMap := tags.NewMap(nil,
-		tags.InsertString(osKey, "macOS-10.12.5"),
-		tags.UpsertString(userIDKey, "cde36753ed"),
+	tagMap := tag.NewMap(nil,
+		tag.InsertString(osKey, "macOS-10.12.5"),
+		tag.UpsertString(userIDKey, "cde36753ed"),
 	)
 	_ = tagMap // use the tag map
 }
 
 func ExampleNewMap_replace() {
-	oldTagMap := tags.FromContext(ctx)
-	tagMap := tags.NewMap(oldTagMap,
-		tags.InsertString(key, "macOS-10.12.5"),
-		tags.UpsertString(key, "macOS-10.12.7"),
+	oldTagMap := tag.FromContext(ctx)
+	tagMap := tag.NewMap(oldTagMap,
+		tag.InsertString(key, "macOS-10.12.5"),
+		tag.UpsertString(key, "macOS-10.12.7"),
 	)
-	ctx = tags.NewContext(ctx, tagMap)
+	ctx = tag.NewContext(ctx, tagMap)
 
 	_ = ctx // use context
 }
 
 func ExampleNewContext() {
 	// Propagate the tag map in the current context.
-	ctx := tags.NewContext(context.Background(), tagMap)
+	ctx := tag.NewContext(context.Background(), tagMap)
 
 	_ = ctx // use context
 }

--- a/tag/key.go
+++ b/tag/key.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-package tags
+package tag
 
 // Mutator modifies a tag map.
 type Mutator interface {

--- a/tag/keys_manager.go
+++ b/tag/keys_manager.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-package tags
+package tag
 
 import (
 	"fmt"

--- a/tag/keys_manager_test.go
+++ b/tag/keys_manager_test.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-package tags
+package tag
 
 import "testing"
 

--- a/tag/map.go
+++ b/tag/map.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-package tags
+package tag
 
 import (
 	"bytes"

--- a/tag/map_codec.go
+++ b/tag/map_codec.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-package tags
+package tag
 
 import (
 	"encoding/binary"

--- a/tag/map_codec_test.go
+++ b/tag/map_codec_test.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-package tags
+package tag
 
 import (
 	"reflect"

--- a/tag/map_test.go
+++ b/tag/map_test.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-package tags
+package tag
 
 import (
 	"context"

--- a/tag/values_bytes.go
+++ b/tag/values_bytes.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-package tags
+package tag
 
 import (
 	"sort"

--- a/tag/values_bytes_test.go
+++ b/tag/values_bytes_test.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-package tags
+package tag
 
 import (
 	"reflect"


### PR DESCRIPTION
In Go, we don't prefer pluralized package names given the full name always includes [package-name].[type-name]. Without pluralization package name represents the scope and acts as a prefix:

```
var m *tag.Map
```

This is a follow up from the conversation at https://github.com/census-instrumentation/opencensus-go/pull/51.