### PR TITLE
Enforce measures to return their descriptions and units

### DIFF
--- a/stats/measure.go
+++ b/stats/measure.go
@@ -24,8 +24,12 @@ package stats
 // NewMeasureFloat64 automatically registers the measure
 // by the given name.
 // Each registered measure needs to be unique by name.
+// Measures also have units that represent the unit of the
+// metric they are representing.
 type Measure interface {
 	Name() string
+	Description() string
+	Unit() string
 
 	addView(v *View)
 	removeView(v *View)

--- a/stats/measure_float64.go
+++ b/stats/measure_float64.go
@@ -28,6 +28,11 @@ func (m *MeasureFloat64) Name() string {
 	return m.name
 }
 
+// Description returns the description of the measure.
+func (m *MeasureFloat64) Description() string {
+	return m.description
+}
+
 // Unit returns the unit of the measure.
 func (m *MeasureFloat64) Unit() string {
 	return m.unit

--- a/stats/measure_int64.go
+++ b/stats/measure_int64.go
@@ -28,6 +28,11 @@ func (m *MeasureInt64) Name() string {
 	return m.name
 }
 
+// Description returns the description of the measure.
+func (m *MeasureInt64) Description() string {
+	return m.description
+}
+
 // Unit returns the unit of the measure.
 func (m *MeasureInt64) Unit() string {
 	return m.unit


### PR DESCRIPTION
The data model already expects all measures to have
descriptions and unit although it is not represented in
the Go interface.

Fixes #64.