### PR TITLE
Import the correct tag package

### DIFF
--- a/tag/example_test.go
+++ b/tag/example_test.go
@@ -19,7 +19,6 @@ import (
 	"log"
 
 	"github.com/census-instrumentation/opencensus-go/tag"
-	"github.com/rakyll/census/tags"
 
 	"golang.org/x/net/context"
 )
@@ -75,7 +74,7 @@ func ExampleNewContext() {
 }
 
 func ExampleFromContext() {
-	tagMap := tags.FromContext(ctx)
+	tagMap := tag.FromContext(ctx)
 
 	_ = tagMap // use the tag map
 }


### PR DESCRIPTION
goimports is not going a good job again and picked up
a package I didn't intent to import. Replace it with
the actual tag package import path.