### PR TITLE
Improve ViewData and SlidingCountWindow field names

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ slidingTimeWindow := stats.SlidingTimeWindow{
 }
 
 slidingCountWindow := stats.SlidingCountWindow{
-	N:       100,
+	Count:   100,
 	Subsets: 10,
 }
 

--- a/internal/readme/stats.go
+++ b/internal/readme/stats.go
@@ -65,7 +65,7 @@ func statsExamples() {
 	}
 
 	slidingCountWindow := stats.SlidingCountWindow{
-		N:       100,
+		Count:   100,
 		Subsets: 10,
 	}
 

--- a/stats/view.go
+++ b/stats/view.go
@@ -144,7 +144,7 @@ func (v *View) addSample(m *tag.Map, val interface{}, now time.Time) {
 // with the given view during a particular window. Each row is specific to a
 // unique set of tags.
 type ViewData struct {
-	V          *View
+	View       *View
 	Start, End time.Time
 	Rows       []*Row
 }

--- a/stats/window.go
+++ b/stats/window.go
@@ -50,12 +50,12 @@ func (w SlidingTimeWindow) newAggregator(now time.Time, aggregationValueConstruc
 // SlidingCountWindow indicates that the aggregation
 // occurs over a sliding number of samples.
 type SlidingCountWindow struct {
-	N       uint64
+	Count   uint64
 	Subsets int
 }
 
 func (w SlidingCountWindow) isWindow() {}
 
 func (w SlidingCountWindow) newAggregator(now time.Time, aggregationValueConstructor func() AggregationValue) aggregator {
-	return newAggregatorSlidingCount(now, w.N, w.Subsets, aggregationValueConstructor)
+	return newAggregatorSlidingCount(now, w.Count, w.Subsets, aggregationValueConstructor)
 }

--- a/stats/worker.go
+++ b/stats/worker.go
@@ -308,7 +308,7 @@ func (w *worker) reportUsage(now time.Time) {
 		}
 		rows := v.collectedRows(now)
 		viewData := &ViewData{
-			V:     v,
+			View:  v,
 			Start: now,
 			End:   time.Now(),
 			Rows:  rows,


### PR DESCRIPTION
- ViewData.View is more representative to refer to the window.
- Count is more represenative to represent the sliding count
  aggregation's count.