### PR TITLE
Enforce the new vanity import path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: go
 go:
   - 1.8.x
 
+go_import_path: go.opencensus.io
+
 # Don't email me the results of the test runs.
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ doc when it is available.
 ## Installation
 
 ```
-$ go get -u github.com/census-instrumentation/opencensus-go/...
+$ go get -u go.opencensus.io/...
 ```
 
 ## Prerequisites
@@ -301,11 +301,11 @@ Coming soon.
 [travis-url]: https://travis-ci.org/census-instrumentation/opencensus-go
 [appveyor-image]: https://ci.appveyor.com/api/projects/status/vgtt29ps1783ig38?svg=true
 [appveyor-url]: https://ci.appveyor.com/project/opencensusgoteam/opencensus-go/branch/master
-[godoc-image]: https://godoc.org/github.com/census-instrumentation/opencensus-go?status.svg
-[godoc-url]: https://godoc.org/github.com/census-instrumentation/opencensus-go
+[godoc-image]: https://godoc.org/go.opencensus.io?status.svg
+[godoc-url]: https://godoc.org/go.opencensus.io
 [gitter-image]: https://badges.gitter.im/census-instrumentation/lobby.svg
 [gitter-url]: https://gitter.im/census-instrumentation/lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
 
 
-[newtags-ex]: https://godoc.org/github.com/census-instrumentation/opencensus-go/tag#example-NewMap
-[newtags-replace-ex]: https://godoc.org/github.com/census-instrumentation/opencensus-go/tag#example-NewMap--Replace
+[newtags-ex]: https://godoc.org/go.opencensus.io/tag#example-NewMap
+[newtags-replace-ex]: https://godoc.org/go.opencensus.io/tag#example-NewMap--Replace

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: "{build}"
 
 platform: x64
 
-clone_folder: c:\gopath\src\github.com\census-instrumentation\opencensus-go
+clone_folder: c:\gopath\src\go.opencensus.io
 
 environment:
   GOPATH: c:\gopath

--- a/doc.go
+++ b/doc.go
@@ -11,10 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
-// Package stats contains the OpenCensus stats collection APIs.
-package stats // import "go.opencensus.io/stats"
-
-// TODO(acetechnologist): Add a link to the language independent OpenCensus
-// spec when it is available.
+// Package opencensus contains Go support for OpenCensus.
+package opencensus // import "go.opencensus.io"

--- a/examples/stats/main.go
+++ b/examples/stats/main.go
@@ -24,8 +24,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/census-instrumentation/opencensus-go/stats"
-	"github.com/census-instrumentation/opencensus-go/tag"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
 )
 
 func main() {

--- a/internal/readme/source.md
+++ b/internal/readme/source.md
@@ -20,7 +20,7 @@ doc when it is available.
 ## Installation
 
 ```
-$ go get -u github.com/census-instrumentation/opencensus-go/...
+$ go get -u go.opencensus.io/...
 ```
 
 ## Prerequisites
@@ -159,11 +159,11 @@ Coming soon.
 [travis-url]: https://travis-ci.org/census-instrumentation/opencensus-go
 [appveyor-image]: https://ci.appveyor.com/api/projects/status/vgtt29ps1783ig38?svg=true
 [appveyor-url]: https://ci.appveyor.com/project/opencensusgoteam/opencensus-go/branch/master
-[godoc-image]: https://godoc.org/github.com/census-instrumentation/opencensus-go?status.svg
-[godoc-url]: https://godoc.org/github.com/census-instrumentation/opencensus-go
+[godoc-image]: https://godoc.org/go.opencensus.io?status.svg
+[godoc-url]: https://godoc.org/go.opencensus.io
 [gitter-image]: https://badges.gitter.im/census-instrumentation/lobby.svg
 [gitter-url]: https://gitter.im/census-instrumentation/lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
 
 
-[newtags-ex]: https://godoc.org/github.com/census-instrumentation/opencensus-go/tag#example-NewMap
-[newtags-replace-ex]: https://godoc.org/github.com/census-instrumentation/opencensus-go/tag#example-NewMap--Replace
+[newtags-ex]: https://godoc.org/go.opencensus.io/tag#example-NewMap
+[newtags-replace-ex]: https://godoc.org/go.opencensus.io/tag#example-NewMap--Replace

--- a/internal/readme/stats.go
+++ b/internal/readme/stats.go
@@ -19,7 +19,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/census-instrumentation/opencensus-go/stats"
+	"go.opencensus.io/stats"
 )
 
 // README.md is generated with the examples here by using embedmd.

--- a/internal/readme/tags.go
+++ b/internal/readme/tags.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"log"
 
-	"github.com/census-instrumentation/opencensus-go/tag"
+	"go.opencensus.io/tag"
 )
 
 func tagsExamples() {

--- a/plugins/grpc/grpcstats/client_handler.go
+++ b/plugins/grpc/grpcstats/client_handler.go
@@ -20,9 +20,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	istats "github.com/census-instrumentation/opencensus-go/stats"
-	"github.com/census-instrumentation/opencensus-go/tag"
 	"github.com/golang/glog"
+	istats "go.opencensus.io/stats"
+	"go.opencensus.io/tag"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/stats"
 )

--- a/plugins/grpc/grpcstats/client_handler_test.go
+++ b/plugins/grpc/grpcstats/client_handler_test.go
@@ -21,8 +21,8 @@ import (
 
 	"golang.org/x/net/context"
 
-	istats "github.com/census-instrumentation/opencensus-go/stats"
-	"github.com/census-instrumentation/opencensus-go/tag"
+	istats "go.opencensus.io/stats"
+	"go.opencensus.io/tag"
 
 	"google.golang.org/grpc/stats"
 )

--- a/plugins/grpc/grpcstats/client_metrics.go
+++ b/plugins/grpc/grpcstats/client_metrics.go
@@ -18,8 +18,8 @@ package grpcstats
 import (
 	"fmt"
 
-	"github.com/census-instrumentation/opencensus-go/stats"
-	"github.com/census-instrumentation/opencensus-go/tag"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
 )
 
 // The following variables are measures and views made available for gRPC clients.

--- a/plugins/grpc/grpcstats/grpcstats.go
+++ b/plugins/grpc/grpcstats/grpcstats.go
@@ -14,14 +14,14 @@
 //
 
 // Package grpcstats provides OpenCensus stats support for gRPC clients and servers.
-package grpcstats
+package grpcstats // import "go.opencensus.io/plugins/grpc/grpcstats"
 
 import (
 	"log"
 	"time"
 
-	istats "github.com/census-instrumentation/opencensus-go/stats"
-	"github.com/census-instrumentation/opencensus-go/tag"
+	istats "go.opencensus.io/stats"
+	"go.opencensus.io/tag"
 )
 
 type grpcInstrumentationKey struct{}

--- a/plugins/grpc/grpcstats/server_handler.go
+++ b/plugins/grpc/grpcstats/server_handler.go
@@ -23,9 +23,9 @@ import (
 
 	"golang.org/x/net/context"
 
-	istats "github.com/census-instrumentation/opencensus-go/stats"
-	"github.com/census-instrumentation/opencensus-go/tag"
 	"github.com/golang/glog"
+	istats "go.opencensus.io/stats"
+	"go.opencensus.io/tag"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/stats"
 )

--- a/plugins/grpc/grpcstats/server_handler_test.go
+++ b/plugins/grpc/grpcstats/server_handler_test.go
@@ -21,8 +21,8 @@ import (
 
 	"golang.org/x/net/context"
 
-	istats "github.com/census-instrumentation/opencensus-go/stats"
-	"github.com/census-instrumentation/opencensus-go/tag"
+	istats "go.opencensus.io/stats"
+	"go.opencensus.io/tag"
 
 	"google.golang.org/grpc/stats"
 )

--- a/plugins/grpc/grpcstats/server_metrics.go
+++ b/plugins/grpc/grpcstats/server_metrics.go
@@ -18,8 +18,8 @@ package grpcstats
 import (
 	"fmt"
 
-	"github.com/census-instrumentation/opencensus-go/stats"
-	"github.com/census-instrumentation/opencensus-go/tag"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
 )
 
 // The following variables are measures and views made available for gRPC clients.

--- a/stats/collector.go
+++ b/stats/collector.go
@@ -18,7 +18,7 @@ package stats
 import (
 	"time"
 
-	"github.com/census-instrumentation/opencensus-go/tag"
+	"go.opencensus.io/tag"
 )
 
 type collector struct {

--- a/stats/view.go
+++ b/stats/view.go
@@ -22,7 +22,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/census-instrumentation/opencensus-go/tag"
+	"go.opencensus.io/tag"
 )
 
 // View allows users to filter and aggregate the recorded events

--- a/stats/view_test.go
+++ b/stats/view_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/census-instrumentation/opencensus-go/tag"
+	"go.opencensus.io/tag"
 )
 
 func Test_View_MeasureFloat64_AggregationDistribution_WindowCumulative(t *testing.T) {

--- a/stats/worker.go
+++ b/stats/worker.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/census-instrumentation/opencensus-go/tag"
+	"go.opencensus.io/tag"
 )
 
 func init() {

--- a/stats/worker_commands.go
+++ b/stats/worker_commands.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/census-instrumentation/opencensus-go/tag"
+	"go.opencensus.io/tag"
 )
 
 type command interface {

--- a/stats/worker_test.go
+++ b/stats/worker_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/census-instrumentation/opencensus-go/tag"
+	"go.opencensus.io/tag"
 
 	"golang.org/x/net/context"
 )

--- a/tag/doc.go
+++ b/tag/doc.go
@@ -14,4 +14,4 @@
 //
 
 // Package tag contains the OpenCensus tags APIs.
-package tag
+package tag // import "go.opencensus.io/tag"

--- a/tag/example_test.go
+++ b/tag/example_test.go
@@ -18,7 +18,7 @@ package tag_test
 import (
 	"log"
 
-	"github.com/census-instrumentation/opencensus-go/tag"
+	"go.opencensus.io/tag"
 
 	"golang.org/x/net/context"
 )


### PR DESCRIPTION
By enforcing the vanity URL, users won't be able to go get from the github.com URL.

Updates #33.