### PR TITLE
Rename the return value name

### DIFF
--- a/tag/map.go
+++ b/tag/map.go
@@ -35,7 +35,7 @@ type Map struct {
 // ValueToString represents the binary value of the key as string.
 // It is used for pretty printing.
 // If key is not found in the map, it ok is returned as false.
-func (m *Map) ValueToString(k Key) (encoded string, ok bool) {
+func (m *Map) ValueToString(k Key) (s string, ok bool) {
 	b, ok := m.m[k]
 	if !ok {
 		return "", false


### PR DESCRIPTION
ValueToString is used for pretty printing. Remove the encoding
related terminology from the godoc.