### PR TITLE
Only allow string keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Other types will be supported in the future.
 [embedmd]:# (tags.go stringKey)
 ```go
 // Get a key to represent user OS.
-key, err := tag.NewStringKey("my.org/keys/user-os")
+key, err := tag.NewKey("my.org/keys/user-os")
 if err != nil {
 	log.Fatal(err)
 }
@@ -54,18 +54,18 @@ tag.Map is a map of tags. Package tags provide a builder to create tag maps.
 
 [embedmd]:# (tags.go tagMap)
 ```go
-osKey, err := tag.NewStringKey("my.org/keys/user-os")
+osKey, err := tag.NewKey("my.org/keys/user-os")
 if err != nil {
 	log.Fatal(err)
 }
-userIDKey, err := tag.NewStringKey("my.org/keys/user-id")
+userIDKey, err := tag.NewKey("my.org/keys/user-id")
 if err != nil {
 	log.Fatal(err)
 }
 
 tagMap := tag.NewMap(nil,
-	tag.InsertString(osKey, "macOS-10.12.5"),
-	tag.UpsertString(userIDKey, "cde36753ed"),
+	tag.Insert(osKey, "macOS-10.12.5"),
+	tag.Upsert(userIDKey, "cde36753ed"),
 )
 ```
 
@@ -88,9 +88,9 @@ use NewMap and put the new tag map back to the context.
 ```go
 oldTagMap := tag.FromContext(ctx)
 tagMap = tag.NewMap(oldTagMap,
-	tag.InsertString(key, "macOS-10.12.5"),
-	tag.UpsertString(key, "macOS-10.12.7"),
-	tag.UpsertString(userIDKey, "fff0989878"),
+	tag.Insert(key, "macOS-10.12.5"),
+	tag.Upsert(key, "macOS-10.12.7"),
+	tag.Upsert(userIDKey, "fff0989878"),
 )
 ctx = tag.NewContext(ctx, tagMap)
 ```

--- a/internal/readme/tags.go
+++ b/internal/readme/tags.go
@@ -26,7 +26,7 @@ func tagsExamples() {
 
 	// START stringKey
 	// Get a key to represent user OS.
-	key, err := tag.NewStringKey("my.org/keys/user-os")
+	key, err := tag.NewKey("my.org/keys/user-os")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -34,18 +34,18 @@ func tagsExamples() {
 	_ = key
 
 	// START tagMap
-	osKey, err := tag.NewStringKey("my.org/keys/user-os")
+	osKey, err := tag.NewKey("my.org/keys/user-os")
 	if err != nil {
 		log.Fatal(err)
 	}
-	userIDKey, err := tag.NewStringKey("my.org/keys/user-id")
+	userIDKey, err := tag.NewKey("my.org/keys/user-id")
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	tagMap := tag.NewMap(nil,
-		tag.InsertString(osKey, "macOS-10.12.5"),
-		tag.UpsertString(userIDKey, "cde36753ed"),
+		tag.Insert(osKey, "macOS-10.12.5"),
+		tag.Upsert(userIDKey, "cde36753ed"),
 	)
 	// END tagMap
 
@@ -56,9 +56,9 @@ func tagsExamples() {
 	// START replaceTagMap
 	oldTagMap := tag.FromContext(ctx)
 	tagMap = tag.NewMap(oldTagMap,
-		tag.InsertString(key, "macOS-10.12.5"),
-		tag.UpsertString(key, "macOS-10.12.7"),
-		tag.UpsertString(userIDKey, "fff0989878"),
+		tag.Insert(key, "macOS-10.12.5"),
+		tag.Upsert(key, "macOS-10.12.7"),
+		tag.Upsert(userIDKey, "fff0989878"),
 	)
 	ctx = tag.NewContext(ctx, tagMap)
 	// END replaceTagMap

--- a/plugins/grpc/grpcstats/client_handler.go
+++ b/plugins/grpc/grpcstats/client_handler.go
@@ -86,8 +86,8 @@ func (ch clientHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) cont
 	ctx = stats.SetTags(ctx, encoded)
 
 	tagMap := tag.NewMap(ts,
-		tag.UpsertString(keyService, serviceName),
-		tag.UpsertString(keyMethod, methodName),
+		tag.Upsert(keyService, serviceName),
+		tag.Upsert(keyMethod, methodName),
 	)
 	// TODO(acetechnologist): should we be recording this later? What is the
 	// point of updating d.reqLen & d.reqCount if we update now?
@@ -158,7 +158,7 @@ func (ch clientHandler) handleRPCEnd(ctx context.Context, s *stats.End) {
 	if s.Error != nil {
 		errorCode := s.Error.Error()
 		newTagMap := tag.NewMap(tag.FromContext(ctx),
-			tag.UpsertString(keyOpStatus, errorCode),
+			tag.Upsert(keyOpStatus, errorCode),
 		)
 		ctx = tag.NewContext(ctx, newTagMap)
 		measurements = append(measurements, RPCClientErrorCount.M(1))

--- a/plugins/grpc/grpcstats/client_handler_test.go
+++ b/plugins/grpc/grpcstats/client_handler_test.go
@@ -28,11 +28,11 @@ import (
 )
 
 func TestClientDefaultCollections(t *testing.T) {
-	k1, _ := tag.NewStringKey("k1")
-	k2, _ := tag.NewStringKey("k2")
+	k1, _ := tag.NewKey("k1")
+	k2, _ := tag.NewKey("k2")
 
 	type tagPair struct {
-		k tag.StringKey
+		k tag.Key
 		v string
 	}
 
@@ -75,8 +75,8 @@ func TestClientDefaultCollections(t *testing.T) {
 					[]*istats.Row{
 						{
 							[]tag.Tag{
-								{Key: keyMethod, Value: []byte("method")},
-								{Key: keyService, Value: []byte("package.service")},
+								{Key: keyMethod, Value: "method"},
+								{Key: keyService, Value: "package.service"},
 							},
 							newDistributionAggregationValue(rpcCountBucketBoundaries, []int64{0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 1, 1, 1, 1, 0),
 						},
@@ -87,8 +87,8 @@ func TestClientDefaultCollections(t *testing.T) {
 					[]*istats.Row{
 						{
 							[]tag.Tag{
-								{Key: keyMethod, Value: []byte("method")},
-								{Key: keyService, Value: []byte("package.service")},
+								{Key: keyMethod, Value: "method"},
+								{Key: keyService, Value: "package.service"},
 							},
 							newDistributionAggregationValue(rpcCountBucketBoundaries, []int64{0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 1, 1, 1, 1, 0),
 						},
@@ -99,8 +99,8 @@ func TestClientDefaultCollections(t *testing.T) {
 					[]*istats.Row{
 						{
 							[]tag.Tag{
-								{Key: keyMethod, Value: []byte("method")},
-								{Key: keyService, Value: []byte("package.service")},
+								{Key: keyMethod, Value: "method"},
+								{Key: keyService, Value: "package.service"},
 							},
 							newDistributionAggregationValue(rpcBytesBucketBoundaries, []int64{0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 1, 10, 10, 10, 0),
 						},
@@ -111,8 +111,8 @@ func TestClientDefaultCollections(t *testing.T) {
 					[]*istats.Row{
 						{
 							[]tag.Tag{
-								{Key: keyMethod, Value: []byte("method")},
-								{Key: keyService, Value: []byte("package.service")},
+								{Key: keyMethod, Value: "method"},
+								{Key: keyService, Value: "package.service"},
 							},
 							newDistributionAggregationValue(rpcBytesBucketBoundaries, []int64{0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 1, 10, 10, 10, 0),
 						},
@@ -156,9 +156,9 @@ func TestClientDefaultCollections(t *testing.T) {
 					[]*istats.Row{
 						{
 							[]tag.Tag{
-								{Key: keyMethod, Value: []byte("method")},
-								{Key: keyOpStatus, Value: []byte("someError")},
-								{Key: keyService, Value: []byte("package.service")},
+								{Key: keyMethod, Value: "method"},
+								{Key: keyOpStatus, Value: "someError"},
+								{Key: keyService, Value: "package.service"},
 							},
 							newCountAggregationValue(1),
 						},
@@ -169,8 +169,8 @@ func TestClientDefaultCollections(t *testing.T) {
 					[]*istats.Row{
 						{
 							[]tag.Tag{
-								{Key: keyMethod, Value: []byte("method")},
-								{Key: keyService, Value: []byte("package.service")},
+								{Key: keyMethod, Value: "method"},
+								{Key: keyService, Value: "package.service"},
 							},
 							newDistributionAggregationValue(rpcCountBucketBoundaries, []int64{0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 2, 2, 3, 2.5, 0.5),
 						},
@@ -181,8 +181,8 @@ func TestClientDefaultCollections(t *testing.T) {
 					[]*istats.Row{
 						{
 							[]tag.Tag{
-								{Key: keyMethod, Value: []byte("method")},
-								{Key: keyService, Value: []byte("package.service")},
+								{Key: keyMethod, Value: "method"},
+								{Key: keyService, Value: "package.service"},
 							},
 							newDistributionAggregationValue(rpcCountBucketBoundaries, []int64{0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 2, 1, 2, 1.5, 0.5),
 						},
@@ -239,17 +239,17 @@ func TestClientDefaultCollections(t *testing.T) {
 					[]*istats.Row{
 						{
 							[]tag.Tag{
-								{Key: keyMethod, Value: []byte("method")},
-								{Key: keyOpStatus, Value: []byte("someError1")},
-								{Key: keyService, Value: []byte("package.service")},
+								{Key: keyMethod, Value: "method"},
+								{Key: keyOpStatus, Value: "someError1"},
+								{Key: keyService, Value: "package.service"},
 							},
 							newCountAggregationValue(1),
 						},
 						{
 							[]tag.Tag{
-								{Key: keyMethod, Value: []byte("method")},
-								{Key: keyOpStatus, Value: []byte("someError2")},
-								{Key: keyService, Value: []byte("package.service")},
+								{Key: keyMethod, Value: "method"},
+								{Key: keyOpStatus, Value: "someError2"},
+								{Key: keyService, Value: "package.service"},
 							},
 							newCountAggregationValue(1),
 						},
@@ -260,8 +260,8 @@ func TestClientDefaultCollections(t *testing.T) {
 					[]*istats.Row{
 						{
 							[]tag.Tag{
-								{Key: keyMethod, Value: []byte("method")},
-								{Key: keyService, Value: []byte("package.service")},
+								{Key: keyMethod, Value: "method"},
+								{Key: keyService, Value: "package.service"},
 							},
 							newDistributionAggregationValue(rpcCountBucketBoundaries, []int64{0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 3, 2, 3, 2.666666666, 0.333333333*2),
 						},
@@ -272,8 +272,8 @@ func TestClientDefaultCollections(t *testing.T) {
 					[]*istats.Row{
 						{
 							[]tag.Tag{
-								{Key: keyMethod, Value: []byte("method")},
-								{Key: keyService, Value: []byte("package.service")},
+								{Key: keyMethod, Value: "method"},
+								{Key: keyService, Value: "package.service"},
 							},
 							newDistributionAggregationValue(rpcCountBucketBoundaries, []int64{0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 3, 1, 2, 1.333333333, 0.333333333*2),
 						},
@@ -284,8 +284,8 @@ func TestClientDefaultCollections(t *testing.T) {
 					[]*istats.Row{
 						{
 							[]tag.Tag{
-								{Key: keyMethod, Value: []byte("method")},
-								{Key: keyService, Value: []byte("package.service")},
+								{Key: keyMethod, Value: "method"},
+								{Key: keyService, Value: "package.service"},
 							},
 							newDistributionAggregationValue(rpcBytesBucketBoundaries, []int64{0, 1, 1, 1, 2, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0}, 8, 1, 65536, 13696.125, 481423542.982143*7),
 						},
@@ -296,8 +296,8 @@ func TestClientDefaultCollections(t *testing.T) {
 					[]*istats.Row{
 						{
 							[]tag.Tag{
-								{Key: keyMethod, Value: []byte("method")},
-								{Key: keyService, Value: []byte("package.service")},
+								{Key: keyMethod, Value: "method"},
+								{Key: keyService, Value: "package.service"},
 							},
 							newDistributionAggregationValue(rpcBytesBucketBoundaries, []int64{0, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 4, 1, 16384, 4864.25, 59678208.25*3),
 						},
@@ -322,7 +322,7 @@ func TestClientDefaultCollections(t *testing.T) {
 		for _, rpc := range tc.rpcs {
 			mods := []tag.Mutator{}
 			for _, t := range rpc.tags {
-				mods = append(mods, tag.UpsertString(t.k, t.v))
+				mods = append(mods, tag.Upsert(t.k, t.v))
 			}
 			tm := tag.NewMap(nil, mods...)
 			encoded := tag.Encode(tm)

--- a/plugins/grpc/grpcstats/grpcstats.go
+++ b/plugins/grpc/grpcstats/grpcstats.go
@@ -64,20 +64,20 @@ var (
 	windowSlidingHour   = istats.SlidingTimeWindow{Duration: 1 * time.Hour, Intervals: 6}
 	windowSlidingMinute = istats.SlidingTimeWindow{Duration: 1 * time.Minute, Intervals: 6}
 
-	keyService  tag.StringKey
-	keyMethod   tag.StringKey
-	keyOpStatus tag.StringKey
+	keyService  tag.Key
+	keyMethod   tag.Key
+	keyOpStatus tag.Key
 )
 
 func init() {
 	var err error
-	if keyService, err = tag.NewStringKey("grpc.service"); err != nil {
+	if keyService, err = tag.NewKey("grpc.service"); err != nil {
 		log.Fatalf("Cannot create grpc.service key: %v", err)
 	}
-	if keyMethod, err = tag.NewStringKey("grpc.method"); err != nil {
+	if keyMethod, err = tag.NewKey("grpc.method"); err != nil {
 		log.Fatalf("Cannot create grpc.method key: %v", err)
 	}
-	if keyOpStatus, err = tag.NewStringKey("grpc.opstatus"); err != nil {
+	if keyOpStatus, err = tag.NewKey("grpc.opstatus"); err != nil {
 		log.Fatalf("Cannot create grpc.opstatus key: %v", err)
 	}
 	initServer()

--- a/plugins/grpc/grpcstats/server_handler.go
+++ b/plugins/grpc/grpcstats/server_handler.go
@@ -164,7 +164,7 @@ func (sh serverHandler) handleRPCEnd(ctx context.Context, s *stats.End) {
 	if s.Error != nil {
 		errorCode := s.Error.Error()
 		tm := tag.NewMap(tag.FromContext(ctx),
-			tag.UpsertString(keyOpStatus, errorCode),
+			tag.Upsert(keyOpStatus, errorCode),
 		)
 		ctx = tag.NewContext(ctx, tm)
 		measurements = append(measurements, RPCServerErrorCount.M(1))
@@ -177,8 +177,8 @@ func (sh serverHandler) handleRPCEnd(ctx context.Context, s *stats.End) {
 // gRPC metadata.
 func (sh serverHandler) createTagMap(ctx context.Context, serviceName, methodName string) (*tag.Map, error) {
 	mods := []tag.Mutator{
-		tag.UpsertString(keyService, serviceName),
-		tag.UpsertString(keyMethod, methodName),
+		tag.Upsert(keyService, serviceName),
+		tag.Upsert(keyMethod, methodName),
 	}
 	if tagsBin := stats.Tags(ctx); tagsBin != nil {
 		old, err := tag.Decode([]byte(tagsBin))

--- a/plugins/grpc/grpcstats/server_handler_test.go
+++ b/plugins/grpc/grpcstats/server_handler_test.go
@@ -28,11 +28,11 @@ import (
 )
 
 func TestServerDefaultCollections(t *testing.T) {
-	k1, _ := tag.NewStringKey("k1")
-	k2, _ := tag.NewStringKey("k2")
+	k1, _ := tag.NewKey("k1")
+	k2, _ := tag.NewKey("k2")
 
 	type tagPair struct {
-		k tag.StringKey
+		k tag.Key
 		v string
 	}
 
@@ -75,8 +75,8 @@ func TestServerDefaultCollections(t *testing.T) {
 					[]*istats.Row{
 						{
 							[]tag.Tag{
-								{Key: keyMethod, Value: []byte("method")},
-								{Key: keyService, Value: []byte("package.service")},
+								{Key: keyMethod, Value: "method"},
+								{Key: keyService, Value: "package.service"},
 							},
 							newDistributionAggregationValue(rpcCountBucketBoundaries, []int64{0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 1, 1, 1, 1, 0),
 						},
@@ -87,8 +87,8 @@ func TestServerDefaultCollections(t *testing.T) {
 					[]*istats.Row{
 						{
 							[]tag.Tag{
-								{Key: keyMethod, Value: []byte("method")},
-								{Key: keyService, Value: []byte("package.service")},
+								{Key: keyMethod, Value: "method"},
+								{Key: keyService, Value: "package.service"},
 							},
 							newDistributionAggregationValue(rpcCountBucketBoundaries, []int64{0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 1, 1, 1, 1, 0),
 						},
@@ -99,8 +99,8 @@ func TestServerDefaultCollections(t *testing.T) {
 					[]*istats.Row{
 						{
 							[]tag.Tag{
-								{Key: keyMethod, Value: []byte("method")},
-								{Key: keyService, Value: []byte("package.service")},
+								{Key: keyMethod, Value: "method"},
+								{Key: keyService, Value: "package.service"},
 							},
 							newDistributionAggregationValue(rpcBytesBucketBoundaries, []int64{0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 1, 10, 10, 10, 0),
 						},
@@ -111,8 +111,8 @@ func TestServerDefaultCollections(t *testing.T) {
 					[]*istats.Row{
 						{
 							[]tag.Tag{
-								{Key: keyMethod, Value: []byte("method")},
-								{Key: keyService, Value: []byte("package.service")},
+								{Key: keyMethod, Value: "method"},
+								{Key: keyService, Value: "package.service"},
 							},
 							newDistributionAggregationValue(rpcBytesBucketBoundaries, []int64{0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 1, 10, 10, 10, 0),
 						},
@@ -156,9 +156,9 @@ func TestServerDefaultCollections(t *testing.T) {
 					[]*istats.Row{
 						{
 							[]tag.Tag{
-								{Key: keyMethod, Value: []byte("method")},
-								{Key: keyOpStatus, Value: []byte("someError")},
-								{Key: keyService, Value: []byte("package.service")},
+								{Key: keyMethod, Value: "method"},
+								{Key: keyOpStatus, Value: "someError"},
+								{Key: keyService, Value: "package.service"},
 							},
 							newCountAggregationValue(1),
 						},
@@ -169,8 +169,8 @@ func TestServerDefaultCollections(t *testing.T) {
 					[]*istats.Row{
 						{
 							[]tag.Tag{
-								{Key: keyMethod, Value: []byte("method")},
-								{Key: keyService, Value: []byte("package.service")},
+								{Key: keyMethod, Value: "method"},
+								{Key: keyService, Value: "package.service"},
 							},
 							newDistributionAggregationValue(rpcCountBucketBoundaries, []int64{0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 2, 1, 2, 1.5, 0.5),
 						},
@@ -181,8 +181,8 @@ func TestServerDefaultCollections(t *testing.T) {
 					[]*istats.Row{
 						{
 							[]tag.Tag{
-								{Key: keyMethod, Value: []byte("method")},
-								{Key: keyService, Value: []byte("package.service")},
+								{Key: keyMethod, Value: "method"},
+								{Key: keyService, Value: "package.service"},
 							},
 							newDistributionAggregationValue(rpcCountBucketBoundaries, []int64{0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 2, 2, 3, 2.5, 0.5),
 						},
@@ -239,17 +239,17 @@ func TestServerDefaultCollections(t *testing.T) {
 					[]*istats.Row{
 						{
 							[]tag.Tag{
-								{Key: keyMethod, Value: []byte("method")},
-								{Key: keyOpStatus, Value: []byte("someError1")},
-								{Key: keyService, Value: []byte("package.service")},
+								{Key: keyMethod, Value: "method"},
+								{Key: keyOpStatus, Value: "someError1"},
+								{Key: keyService, Value: "package.service"},
 							},
 							newCountAggregationValue(1),
 						},
 						{
 							[]tag.Tag{
-								{Key: keyMethod, Value: []byte("method")},
-								{Key: keyOpStatus, Value: []byte("someError2")},
-								{Key: keyService, Value: []byte("package.service")},
+								{Key: keyMethod, Value: "method"},
+								{Key: keyOpStatus, Value: "someError2"},
+								{Key: keyService, Value: "package.service"},
 							},
 							newCountAggregationValue(1),
 						},
@@ -260,8 +260,8 @@ func TestServerDefaultCollections(t *testing.T) {
 					[]*istats.Row{
 						{
 							[]tag.Tag{
-								{Key: keyMethod, Value: []byte("method")},
-								{Key: keyService, Value: []byte("package.service")},
+								{Key: keyMethod, Value: "method"},
+								{Key: keyService, Value: "package.service"},
 							},
 							newDistributionAggregationValue(rpcCountBucketBoundaries, []int64{0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 3, 1, 2, 1.333333333, 0.333333333*2),
 						},
@@ -272,8 +272,8 @@ func TestServerDefaultCollections(t *testing.T) {
 					[]*istats.Row{
 						{
 							[]tag.Tag{
-								{Key: keyMethod, Value: []byte("method")},
-								{Key: keyService, Value: []byte("package.service")},
+								{Key: keyMethod, Value: "method"},
+								{Key: keyService, Value: "package.service"},
 							},
 							newDistributionAggregationValue(rpcCountBucketBoundaries, []int64{0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 3, 2, 3, 2.666666666, 0.333333333*2),
 						},
@@ -284,8 +284,8 @@ func TestServerDefaultCollections(t *testing.T) {
 					[]*istats.Row{
 						{
 							[]tag.Tag{
-								{Key: keyMethod, Value: []byte("method")},
-								{Key: keyService, Value: []byte("package.service")},
+								{Key: keyMethod, Value: "method"},
+								{Key: keyService, Value: "package.service"},
 							},
 							newDistributionAggregationValue(rpcBytesBucketBoundaries, []int64{0, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 4, 1, 16384, 4864.25, 59678208.25*3),
 						},
@@ -296,8 +296,8 @@ func TestServerDefaultCollections(t *testing.T) {
 					[]*istats.Row{
 						{
 							[]tag.Tag{
-								{Key: keyMethod, Value: []byte("method")},
-								{Key: keyService, Value: []byte("package.service")},
+								{Key: keyMethod, Value: "method"},
+								{Key: keyService, Value: "package.service"},
 							},
 							newDistributionAggregationValue(rpcBytesBucketBoundaries, []int64{0, 1, 1, 1, 2, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0}, 8, 1, 65536, 13696.125, 481423542.982143*7),
 						},
@@ -321,7 +321,7 @@ func TestServerDefaultCollections(t *testing.T) {
 		for _, rpc := range tc.rpcs {
 			mods := []tag.Mutator{}
 			for _, t := range rpc.tags {
-				mods = append(mods, tag.UpsertString(t.k, t.v))
+				mods = append(mods, tag.Upsert(t.k, t.v))
 			}
 			ts := tag.NewMap(nil, mods...)
 			encoded := tag.Encode(ts)

--- a/stats/view.go
+++ b/stats/view.go
@@ -160,7 +160,7 @@ func (r *Row) String() string {
 	buffer.WriteString("{ ")
 	buffer.WriteString("{ ")
 	for _, t := range r.Tags {
-		buffer.WriteString(fmt.Sprintf("{%v %v}", t.Key.Name(), t.Key.ValueToString(t.Value)))
+		buffer.WriteString(fmt.Sprintf("{%v %v}", t.Key.Name(), t.Value))
 	}
 	buffer.WriteString(" }")
 	buffer.WriteString(fmt.Sprintf("%v", r.AggregationValue))

--- a/stats/worker_test.go
+++ b/stats/worker_test.go
@@ -478,11 +478,11 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 		t.Errorf("NewMeasureFloat64(\"MF1\", \"desc MF1\") got error '%v', want no error", err)
 	}
 
-	k1, _ := tag.NewStringKey("k1")
-	k2, _ := tag.NewStringKey("k2")
+	k1, _ := tag.NewKey("k1")
+	k2, _ := tag.NewKey("k2")
 	ts := tag.NewMap(nil,
-		tag.InsertString(k1, "v1"),
-		tag.InsertString(k2, "v2"),
+		tag.Insert(k1, "v1"),
+		tag.Insert(k2, "v2"),
 	)
 	ctx := tag.NewContext(context.Background(), ts)
 
@@ -528,7 +528,7 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 					v1,
 					[]*Row{
 						{
-							[]tag.Tag{{Key: k1, Value: []byte("v1")}, {Key: k2, Value: []byte("v2")}},
+							[]tag.Tag{{Key: k1, Value: "v1"}, {Key: k2, Value: "v2"}},
 							newCountAggregationValue(2),
 						},
 					},
@@ -548,7 +548,7 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 					v1,
 					[]*Row{
 						{
-							[]tag.Tag{{Key: k1, Value: []byte("v1")}, {Key: k2, Value: []byte("v2")}},
+							[]tag.Tag{{Key: k1, Value: "v1"}, {Key: k2, Value: "v2"}},
 							newCountAggregationValue(2),
 						},
 					},
@@ -558,7 +558,7 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 					v2,
 					[]*Row{
 						{
-							[]tag.Tag{{Key: k1, Value: []byte("v1")}, {Key: k2, Value: []byte("v2")}},
+							[]tag.Tag{{Key: k1, Value: "v1"}, {Key: k2, Value: "v2"}},
 							newCountAggregationValue(2),
 						},
 					},
@@ -577,7 +577,7 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 					v1,
 					[]*Row{
 						{
-							[]tag.Tag{{Key: k1, Value: []byte("v1")}, {Key: k2, Value: []byte("v2")}},
+							[]tag.Tag{{Key: k1, Value: "v1"}, {Key: k2, Value: "v2"}},
 							newCountAggregationValue(2),
 						},
 					},
@@ -597,7 +597,7 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 					v1,
 					[]*Row{
 						{
-							[]tag.Tag{{Key: k1, Value: []byte("v1")}, {Key: k2, Value: []byte("v2")}},
+							[]tag.Tag{{Key: k1, Value: "v1"}, {Key: k2, Value: "v2"}},
 							newCountAggregationValue(2),
 						},
 					},
@@ -607,7 +607,7 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 					v2,
 					[]*Row{
 						{
-							[]tag.Tag{{Key: k1, Value: []byte("v1")}, {Key: k2, Value: []byte("v2")}},
+							[]tag.Tag{{Key: k1, Value: "v1"}, {Key: k2, Value: "v2"}},
 							newCountAggregationValue(2),
 						},
 					},
@@ -626,7 +626,7 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 					v1,
 					[]*Row{
 						{
-							[]tag.Tag{{Key: k1, Value: []byte("v1")}, {Key: k2, Value: []byte("v2")}},
+							[]tag.Tag{{Key: k1, Value: "v1"}, {Key: k2, Value: "v2"}},
 							newCountAggregationValue(3),
 						},
 					},
@@ -636,7 +636,7 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 					v2,
 					[]*Row{
 						{
-							[]tag.Tag{{Key: k1, Value: []byte("v1")}, {Key: k2, Value: []byte("v2")}},
+							[]tag.Tag{{Key: k1, Value: "v1"}, {Key: k2, Value: "v2"}},
 							newCountAggregationValue(3),
 						},
 					},

--- a/tag/example_test.go
+++ b/tag/example_test.go
@@ -16,22 +16,21 @@
 package tag_test
 
 import (
+	"context"
 	"log"
 
 	"go.opencensus.io/tag"
-
-	"golang.org/x/net/context"
 )
 
 var (
 	tagMap *tag.Map
 	ctx    context.Context
-	key    tag.StringKey
+	key    tag.Key
 )
 
-func ExampleNewStringKey() {
+func ExampleNewKey() {
 	// Get a key to represent user OS.
-	key, err := tag.NewStringKey("/my/namespace/user-os")
+	key, err := tag.NewKey("my.org/keys/user-os")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -39,18 +38,18 @@ func ExampleNewStringKey() {
 }
 
 func ExampleNewMap() {
-	osKey, err := tag.NewStringKey("/my/namespace/user-os")
+	osKey, err := tag.NewKey("my.org/keys/user-os")
 	if err != nil {
 		log.Fatal(err)
 	}
-	userIDKey, err := tag.NewStringKey("/my/namespace/user-id")
+	userIDKey, err := tag.NewKey("my.org/keys/user-id")
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	tagMap := tag.NewMap(nil,
-		tag.InsertString(osKey, "macOS-10.12.5"),
-		tag.UpsertString(userIDKey, "cde36753ed"),
+		tag.Insert(osKey, "macOS-10.12.5"),
+		tag.Upsert(userIDKey, "cde36753ed"),
 	)
 	_ = tagMap // use the tag map
 }
@@ -58,8 +57,8 @@ func ExampleNewMap() {
 func ExampleNewMap_replace() {
 	oldTagMap := tag.FromContext(ctx)
 	tagMap := tag.NewMap(oldTagMap,
-		tag.InsertString(key, "macOS-10.12.5"),
-		tag.UpsertString(key, "macOS-10.12.7"),
+		tag.Insert(key, "macOS-10.12.5"),
+		tag.Upsert(key, "macOS-10.12.7"),
 	)
 	ctx = tag.NewContext(ctx, tagMap)
 

--- a/tag/key.go
+++ b/tag/key.go
@@ -22,36 +22,20 @@ type Mutator interface {
 
 // Key represents a tag key. Keys with the same name will return
 // true when compared with the == operator.
-type Key interface {
-	// Name returns the name of the key.
-	Name() string
-
-	// ValueToString represents the binary value of the key as string.
-	// It is used for pretty printing.
-	ValueToString(v []byte) string
-}
-
-// StringKey is a Key and represents string keys.
-type StringKey struct {
+type Key struct {
 	id   uint16
 	name string
 }
 
-// NewStringKey creates or retrieves a string key identified by name.
-// Calling NewStringKey consequently with the same name returns the same key.
-func NewStringKey(name string) (StringKey, error) {
+// NewKey creates or retrieves a string key identified by name.
+// Calling NewKey consequently with the same name returns the same key.
+func NewKey(name string) (Key, error) {
 	return km.newStringKey(name)
 }
 
 // Name returns the name of the key.
-func (k StringKey) Name() string {
+func (k Key) Name() string {
 	return k.name
-}
-
-// ValueToString represents the binary value of the key as string.
-// It is used for pretty printing.
-func (k StringKey) ValueToString(v []byte) string {
-	return string(v)
 }
 
 type mutator struct {
@@ -62,38 +46,38 @@ func (m *mutator) Mutate(t *Map) *Map {
 	return m.fn(t)
 }
 
-// InsertString returns a mutator that inserts a
+// Insert returns a mutator that inserts a
 // value associated with k. If k already exists in the tag map,
 // mutator doesn't update the value.
-func InsertString(k StringKey, v string) Mutator {
+func Insert(k Key, v string) Mutator {
 	return &mutator{
 		fn: func(m *Map) *Map {
-			m.insert(k, []byte(v))
+			m.insert(k, v)
 			return m
 		},
 	}
 }
 
-// UpdateString returns a mutator that updates the
+// Update returns a mutator that updates the
 // value of the tag associated with k with v. If k doesn't
 // exists in the tag map, the mutator doesn't insert the value.
-func UpdateString(k StringKey, v string) Mutator {
+func Update(k Key, v string) Mutator {
 	return &mutator{
 		fn: func(m *Map) *Map {
-			m.update(k, []byte(v))
+			m.update(k, v)
 			return m
 		},
 	}
 }
 
-// UpsertString returns a mutator that upserts the
+// Upsert returns a mutator that upserts the
 // value of the tag associated with k with v. It inserts the
 // value if k doesn't exist already. It mutates the value
 // if k already exists.
-func UpsertString(k StringKey, v string) Mutator {
+func Upsert(k Key, v string) Mutator {
 	return &mutator{
 		fn: func(m *Map) *Map {
-			m.upsert(k, []byte(v))
+			m.upsert(k, v)
 			return m
 		},
 	}

--- a/tag/keys_manager.go
+++ b/tag/keys_manager.go
@@ -51,23 +51,19 @@ func newKeysManager() *keysManager {
 // newStringKey creates or retrieves a key of type keyString with name/ID
 // set to the input argument name. Returns an error if a key with the same name
 // exists and is of a different type.
-func (km *keysManager) newStringKey(name string) (StringKey, error) {
+func (km *keysManager) newStringKey(name string) (Key, error) {
 	if !validateKeyName(name) {
-		return StringKey{}, fmt.Errorf("key name %v is invalid", name)
+		return Key{}, fmt.Errorf("key name %v is invalid", name)
 	}
 	km.Lock()
 	defer km.Unlock()
 
 	k, ok := km.keys[name]
 	if ok {
-		ks, ok := k.(StringKey)
-		if !ok {
-			return StringKey{}, fmt.Errorf("key with name %v cannot be created/retrieved as type *keyString. It was already registered as type %T", name, k)
-		}
-		return ks, nil
+		return k, nil
 	}
 
-	ks := StringKey{
+	ks := Key{
 		name: name,
 		id:   km.nextKeyID,
 	}

--- a/tag/map.go
+++ b/tag/map.go
@@ -24,23 +24,12 @@ import (
 // Tag is a key value pair that can be propagated on wire.
 type Tag struct {
 	Key   Key
-	Value []byte
+	Value string
 }
 
 // Map is a map of tags. Use NewMap to build tag maps.
 type Map struct {
-	m map[Key][]byte
-}
-
-// ValueToString represents the binary value of the key as string.
-// It is used for pretty printing.
-// If key is not found in the map, it ok is returned as false.
-func (m *Map) ValueToString(k Key) (s string, ok bool) {
-	b, ok := m.m[k]
-	if !ok {
-		return "", false
-	}
-	return k.ValueToString(b), true
+	m map[Key]string
 }
 
 func (m *Map) String() string {
@@ -53,26 +42,26 @@ func (m *Map) String() string {
 	var buffer bytes.Buffer
 	buffer.WriteString("{ ")
 	for _, k := range keys {
-		buffer.WriteString(fmt.Sprintf("{%v %v}", k.Name(), k.ValueToString(m.m[k])))
+		buffer.WriteString(fmt.Sprintf("{%v %v}", k.name, m.m[k]))
 	}
 	buffer.WriteString(" }")
 	return buffer.String()
 }
 
-func (m *Map) insert(k Key, v []byte) {
+func (m *Map) insert(k Key, v string) {
 	if _, ok := m.m[k]; ok {
 		return
 	}
 	m.m[k] = v
 }
 
-func (m *Map) update(k Key, v []byte) {
+func (m *Map) update(k Key, v string) {
 	if _, ok := m.m[k]; ok {
 		m.m[k] = v
 	}
 }
 
-func (m *Map) upsert(k Key, v []byte) {
+func (m *Map) upsert(k Key, v string) {
 	m.m[k] = v
 }
 
@@ -81,5 +70,5 @@ func (m *Map) delete(k Key) {
 }
 
 func newMap(sizeHint int) *Map {
-	return &Map{m: make(map[Key][]byte, sizeHint)}
+	return &Map{m: make(map[Key]string, sizeHint)}
 }

--- a/tag/map_codec.go
+++ b/tag/map_codec.go
@@ -169,8 +169,8 @@ func Encode(m *Map) []byte {
 	eg.writeByte(byte(tagsVersionID))
 	for k, v := range m.m {
 		eg.writeByte(byte(keyTypeString))
-		eg.writeStringWithVarintLen(k.Name())
-		eg.writeBytesWithVarintLen(v)
+		eg.writeStringWithVarintLen(k.name)
+		eg.writeBytesWithVarintLen([]byte(v))
 	}
 
 	return eg.bytes()
@@ -212,12 +212,12 @@ func Decode(bytes []byte) (*Map, error) {
 			return nil, err
 		}
 
-		key, err := NewStringKey(string(k))
+		key, err := NewKey(string(k))
 		if err != nil {
 			// TODO(acetechnologist): log that key received on the wire and its value was ignored
 			continue
 		}
-		ts.upsert(key, v)
+		ts.upsert(key, string(v))
 	}
 
 	return ts, nil

--- a/tag/map_codec_test.go
+++ b/tag/map_codec_test.go
@@ -22,13 +22,13 @@ import (
 )
 
 func Test_EncodeDecode_Set(t *testing.T) {
-	k1, _ := NewStringKey("k1")
-	k2, _ := NewStringKey("k2")
-	k3, _ := NewStringKey("k3 is very weird <>.,?/'\";:`~!@#$%^&*()_-+={[}]|\\")
-	k4, _ := NewStringKey("k4")
+	k1, _ := NewKey("k1")
+	k2, _ := NewKey("k2")
+	k3, _ := NewKey("k3 is very weird <>.,?/'\";:`~!@#$%^&*()_-+={[}]|\\")
+	k4, _ := NewKey("k4")
 
 	type pair struct {
-		k StringKey
+		k Key
 		v string
 	}
 
@@ -77,7 +77,7 @@ func Test_EncodeDecode_Set(t *testing.T) {
 	for _, tc := range testCases {
 		mods := make([]Mutator, len(tc.pairs))
 		for i, pair := range tc.pairs {
-			mods[i] = UpsertString(pair.k, pair.v)
+			mods[i] = Upsert(pair.k, pair.v)
 		}
 		ts := NewMap(nil, mods...)
 		encoded := Encode(ts)
@@ -89,16 +89,12 @@ func Test_EncodeDecode_Set(t *testing.T) {
 
 		got := make([]pair, 0)
 		for k, v := range decoded.m {
-			ks, ok := k.(StringKey)
-			if !ok {
-				t.Errorf("%v: wrong key type; got %T, want StringKey", tc.label, k)
-			}
-			got = append(got, pair{ks, string(v)})
+			got = append(got, pair{k, string(v)})
 		}
 		want := tc.pairs
 
-		sort.Slice(got, func(i, j int) bool { return got[i].k.Name() < got[j].k.Name() })
-		sort.Slice(want, func(i, j int) bool { return got[i].k.Name() < got[j].k.Name() })
+		sort.Slice(got, func(i, j int) bool { return got[i].k.name < got[j].k.name })
+		sort.Slice(want, func(i, j int) bool { return got[i].k.name < got[j].k.name })
 
 		if !reflect.DeepEqual(got, tc.pairs) {
 			t.Errorf("%v: decoded tag map = %#v; want %#v", tc.label, got, want)

--- a/tag/map_test.go
+++ b/tag/map_test.go
@@ -23,12 +23,12 @@ import (
 )
 
 func TestContext(t *testing.T) {
-	k1, _ := NewStringKey("k1")
-	k2, _ := NewStringKey("k2")
+	k1, _ := NewKey("k1")
+	k2, _ := NewKey("k2")
 
 	want := NewMap(nil,
-		InsertString(k1, "v1"),
-		InsertString(k2, "v2"),
+		Insert(k1, "v1"),
+		Insert(k2, "v2"),
 	)
 
 	ctx := NewContext(context.Background(), want)
@@ -40,11 +40,11 @@ func TestContext(t *testing.T) {
 }
 
 func TestNewMap(t *testing.T) {
-	k1, _ := NewStringKey("k1")
-	k2, _ := NewStringKey("k2")
-	k3, _ := NewStringKey("k3")
-	k4, _ := NewStringKey("k4")
-	k5, _ := NewStringKey("k5")
+	k1, _ := NewKey("k1")
+	k2, _ := NewKey("k2")
+	k3, _ := NewKey("k3")
+	k4, _ := NewKey("k4")
+	k5, _ := NewKey("k5")
 
 	initial := makeTestTagMap(5)
 
@@ -58,7 +58,7 @@ func TestNewMap(t *testing.T) {
 			name:    "from empty; insert",
 			initial: nil,
 			mods: []Mutator{
-				InsertString(k5, "v5"),
+				Insert(k5, "v5"),
 			},
 			want: makeTestTagMap(2, 4, 5),
 		},
@@ -66,7 +66,7 @@ func TestNewMap(t *testing.T) {
 			name:    "from empty; insert existing",
 			initial: nil,
 			mods: []Mutator{
-				InsertString(k1, "v1"),
+				Insert(k1, "v1"),
 			},
 			want: makeTestTagMap(1, 2, 4),
 		},
@@ -74,7 +74,7 @@ func TestNewMap(t *testing.T) {
 			name:    "from empty; update",
 			initial: nil,
 			mods: []Mutator{
-				UpdateString(k1, "v1"),
+				Update(k1, "v1"),
 			},
 			want: makeTestTagMap(2, 4),
 		},
@@ -82,7 +82,7 @@ func TestNewMap(t *testing.T) {
 			name:    "from empty; update unexisting",
 			initial: nil,
 			mods: []Mutator{
-				UpdateString(k5, "v5"),
+				Update(k5, "v5"),
 			},
 			want: makeTestTagMap(2, 4),
 		},
@@ -90,7 +90,7 @@ func TestNewMap(t *testing.T) {
 			name:    "from existing; upsert",
 			initial: initial,
 			mods: []Mutator{
-				UpsertString(k5, "v5"),
+				Upsert(k5, "v5"),
 			},
 			want: makeTestTagMap(2, 4, 5),
 		},
@@ -106,11 +106,11 @@ func TestNewMap(t *testing.T) {
 
 	for _, tt := range tests {
 		mods := []Mutator{
-			InsertString(k1, "v1"),
-			InsertString(k2, "v2"),
-			UpdateString(k3, "v3"),
-			UpsertString(k4, "v4"),
-			InsertString(k2, "v2"),
+			Insert(k1, "v1"),
+			Insert(k2, "v2"),
+			Update(k3, "v3"),
+			Upsert(k4, "v4"),
+			Insert(k2, "v2"),
 			Delete(k1),
 		}
 		mods = append(mods, tt.mods...)
@@ -125,8 +125,8 @@ func TestNewMap(t *testing.T) {
 func makeTestTagMap(ids ...int) *Map {
 	m := newMap(len(ids))
 	for _, v := range ids {
-		k, _ := NewStringKey(fmt.Sprintf("k%d", v))
-		m.m[k] = []byte(fmt.Sprintf("v%d", v))
+		k, _ := NewKey(fmt.Sprintf("k%d", v))
+		m.m[k] = fmt.Sprintf("v%d", v)
 	}
 	return m
 }

--- a/tag/values_bytes.go
+++ b/tag/values_bytes.go
@@ -92,7 +92,7 @@ func (vb *valuesBytes) toSlice(ks []Key) []Tag {
 	for _, k := range ks {
 		v := vb.readValue()
 		if v != nil {
-			tags = append(tags, Tag{k, v})
+			tags = append(tags, Tag{k, string(v)})
 		}
 	}
 	vb.rIdx = 0
@@ -109,7 +109,7 @@ func toValuesBytes(m *Map, ks []Key) *valuesBytes {
 	}
 	for _, k := range ks {
 		v := m.m[k]
-		vb.writeValue(v)
+		vb.writeValue([]byte(v))
 	}
 	return vb
 }
@@ -122,7 +122,7 @@ func EncodeOrderedTags(m *Map, keys []Key) []byte {
 	}
 	for _, k := range keys {
 		v := m.m[k]
-		vb.writeValue(v)
+		vb.writeValue([]byte(v))
 	}
 	return vb.bytes()
 }
@@ -132,6 +132,6 @@ func EncodeOrderedTags(m *Map, keys []Key) []byte {
 func DecodeOrderedTags(buf []byte, keys []Key) []Tag {
 	vb := &valuesBytes{buf: buf}
 	tags := vb.toSlice(keys)
-	sort.Slice(tags, func(i, j int) bool { return tags[i].Key.Name() < tags[j].Key.Name() })
+	sort.Slice(tags, func(i, j int) bool { return tags[i].Key.name < tags[j].Key.name })
 	return tags
 }

--- a/tag/values_bytes_test.go
+++ b/tag/values_bytes_test.go
@@ -37,7 +37,7 @@ func Test_EncodeDecode_ValuesBytes(t *testing.T) {
 		{
 			0,
 			&Map{
-				map[Key][]byte{},
+				map[Key]string{},
 			},
 			[]Key{k1},
 			nil,
@@ -45,7 +45,7 @@ func Test_EncodeDecode_ValuesBytes(t *testing.T) {
 		{
 			1,
 			&Map{
-				map[Key][]byte{k2: []byte("v2")},
+				map[Key]string{k2: "v2"},
 			},
 			[]Key{},
 			nil,
@@ -53,7 +53,7 @@ func Test_EncodeDecode_ValuesBytes(t *testing.T) {
 		{
 			3,
 			&Map{
-				map[Key][]byte{k2: []byte("v2")},
+				map[Key]string{k2: "v2"},
 			},
 			[]Key{k1},
 			nil,
@@ -61,7 +61,7 @@ func Test_EncodeDecode_ValuesBytes(t *testing.T) {
 		{
 			4,
 			&Map{
-				map[Key][]byte{k2: []byte("v2")},
+				map[Key]string{k2: "v2"},
 			},
 			[]Key{k2},
 			map[Key][]byte{
@@ -71,9 +71,9 @@ func Test_EncodeDecode_ValuesBytes(t *testing.T) {
 		{
 			5,
 			&Map{
-				map[Key][]byte{
-					k1: []byte("v1"),
-					k2: []byte("v2")},
+				map[Key]string{
+					k1: "v1",
+					k2: "v2"},
 			},
 			[]Key{k1},
 			map[Key][]byte{
@@ -83,9 +83,9 @@ func Test_EncodeDecode_ValuesBytes(t *testing.T) {
 		{
 			6,
 			&Map{
-				map[Key][]byte{
-					k2: []byte("v2"),
-					k1: []byte("v1")},
+				map[Key]string{
+					k2: "v2",
+					k1: "v1"},
 			},
 			[]Key{k1, k2},
 			map[Key][]byte{
@@ -96,10 +96,10 @@ func Test_EncodeDecode_ValuesBytes(t *testing.T) {
 		{
 			7,
 			&Map{
-				map[Key][]byte{
-					k1: []byte("v1"),
-					k2: []byte("v2"),
-					k3: []byte("v3")},
+				map[Key]string{
+					k1: "v1",
+					k2: "v2",
+					k3: "v3"},
 			},
 			[]Key{k3, k1},
 			map[Key][]byte{
@@ -121,7 +121,7 @@ func Test_EncodeDecode_ValuesBytes(t *testing.T) {
 		for wantK, wantV := range td.wantSlice {
 			v, ok := got[wantK]
 			if !ok {
-				t.Errorf("got key %v not found in decoded %v, want it found. Test case: %v", wantK.Name(), got, i)
+				t.Errorf("got key %v not found in decoded %v, want it found. Test case: %v", wantK.name, got, i)
 			}
 			if !reflect.DeepEqual(v, wantV) {
 				t.Errorf("got tag %v in decoded, want %v. Test case: %v", v, wantV, i)


### PR DESCRIPTION
This change is due to a data model change. OpenCensus won't no longer
support keys other than string keys.

Discontinue typed keys, allow string-only keys. Remove Key interface
and implementations and make Key a concrete type that represents
string keys.

Also the representation of the values are now string given we don't have
any values other than string.

Fixes #93.