### PR TITLE
Remove force collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,40 +257,6 @@ func (e *exporter) Export(vd *stats.ViewData) {
 
 ```
 
-### Force collecting data on demand
-
-Even if a view is registered, if it has no subscriber no data
-for it is collected. In order to retrieve data on demand from a
-view, library can be instructed explicitly to collect
-data for the desired view.
-
-[embedmd]:# (stats.go forceCollect)
-```go
-// To explicitly instruct the library to collect the view data for an on-demand
-// retrieval, force collect. When done, stop force collection.
-if err := view.ForceCollect(); err != nil {
-	log.Fatal(err)
-}
-
-// Use RetrieveData to pull collected data synchronously from the library. This
-// assumes that a subscription to the view exists or force collection is enabled.
-rows, err := view.RetrieveData()
-if err != nil {
-	log.Fatal(err)
-}
-for _, r := range rows {
-	// process a single row of type *stats.Row
-	log.Println(r)
-}
-
-// To explicitly instruct the library to stop collecting the view data for the
-// on-demand retrieval, StopForceCollection should be used. This call has no
-// impact on the view's subscription status.
-if err := view.StopForceCollection(); err != nil {
-	log.Fatal(err)
-}
-```
-
 ## Tracing
 
 Coming soon.

--- a/internal/readme/source.md
+++ b/internal/readme/source.md
@@ -140,15 +140,6 @@ An example logger exporter is below:
 
 [embedmd]:# (stats.go exporter)
 
-### Force collecting data on demand
-
-Even if a view is registered, if it has no subscriber no data
-for it is collected. In order to retrieve data on demand from a
-view, library can be instructed explicitly to collect
-data for the desired view.
-
-[embedmd]:# (stats.go forceCollect)
-
 ## Tracing
 
 Coming soon.

--- a/internal/readme/stats.go
+++ b/internal/readme/stats.go
@@ -122,33 +122,6 @@ func statsExamples() {
 	// the data from the subscribed views.
 	stats.RegisterExporter(&exporter{})
 	// END registerExporter
-
-	// START forceCollect
-	// To explicitly instruct the library to collect the view data for an on-demand
-	// retrieval, force collect. When done, stop force collection.
-	if err := view.ForceCollect(); err != nil {
-		log.Fatal(err)
-	}
-
-	// Use RetrieveData to pull collected data synchronously from the library. This
-	// assumes that a subscription to the view exists or force collection is enabled.
-	rows, err := view.RetrieveData()
-	if err != nil {
-		log.Fatal(err)
-	}
-	for _, r := range rows {
-		// process a single row of type *stats.Row
-		log.Println(r)
-	}
-
-	// To explicitly instruct the library to stop collecting the view data for the
-	// on-demand retrieval, StopForceCollection should be used. This call has no
-	// impact on the view's subscription status.
-	if err := view.StopForceCollection(); err != nil {
-		log.Fatal(err)
-	}
-	// END forceCollect
-
 }
 
 // START exporter

--- a/plugins/grpc/grpcstats/client_handler_test.go
+++ b/plugins/grpc/grpcstats/client_handler_test.go
@@ -310,10 +310,7 @@ func TestClientDefaultCollections(t *testing.T) {
 	for _, tc := range tcs {
 		// Register views.
 		for _, v := range clientViews {
-			if err := istats.RegisterView(v); err != nil {
-				t.Error(err)
-			}
-			if err := v.ForceCollect(); err != nil {
+			if err := v.Subscribe(); err != nil {
 				t.Error(err)
 			}
 		}
@@ -365,10 +362,7 @@ func TestClientDefaultCollections(t *testing.T) {
 
 		// Unregister views to cleanup.
 		for _, v := range clientViews {
-			if err := v.StopForceCollection(); err != nil {
-				t.Error(err)
-			}
-			if err := v.Unregister(); err != nil {
+			if err := v.Unsubscribe(); err != nil {
 				t.Error(err)
 			}
 		}

--- a/plugins/grpc/grpcstats/server_handler_test.go
+++ b/plugins/grpc/grpcstats/server_handler_test.go
@@ -309,10 +309,7 @@ func TestServerDefaultCollections(t *testing.T) {
 
 	for _, tc := range tcs {
 		for _, v := range serverViews {
-			if err := istats.RegisterView(v); err != nil {
-				t.Error(err)
-			}
-			if err := v.ForceCollect(); err != nil {
+			if err := v.Subscribe(); err != nil {
 				t.Error(err)
 			}
 		}
@@ -364,10 +361,7 @@ func TestServerDefaultCollections(t *testing.T) {
 
 		// Unregister views to cleanup.
 		for _, v := range serverViews {
-			if err := v.StopForceCollection(); err != nil {
-				t.Error(err)
-			}
-			if err := v.Unregister(); err != nil {
+			if err := v.Unsubscribe(); err != nil {
 				t.Error(err)
 			}
 		}

--- a/stats/aggregation_data.go
+++ b/stats/aggregation_data.go
@@ -20,8 +20,8 @@ import (
 )
 
 // AggregationData represents an aggregated value from a collection.
-// They are reported on the view data during exporting or force
-// collection. Mosts users won't directly access aggregration data.
+// They are reported on the view data during exporting.
+// Mosts users won't directly access aggregration data.
 type AggregationData interface {
 	equal(other AggregationData) bool
 	isAggregate() bool

--- a/stats/example_test.go
+++ b/stats/example_test.go
@@ -46,6 +46,5 @@ func Example_view() {
 		log.Fatal(err)
 	}
 
-	// Use stats.RegisterExporter to export collected
-	// data or force collect.
+	// Use stats.RegisterExporter to export collected data.
 }

--- a/stats/view.go
+++ b/stats/view.go
@@ -42,7 +42,6 @@ type View struct {
 	// start is time when view collection was started originally.
 	start time.Time
 
-	forced     uint32 // 1 if view should collect data if no one is subscribed, use atomic to access
 	subscribed uint32 // 1 if someone is subscribed and data need to be exported, use atomic to access
 
 	collector *collector
@@ -55,8 +54,7 @@ type View struct {
 // Collected data will be processed by the given aggregation algorithm for
 // the given time window.
 //
-// Views need to be subscribed to, or need to be force
-// collected to retrieve collection data.
+// Views need to be subscribed toin order to retrieve collection data.
 //
 // Once the view is no longer required, the view can be unregistered.
 func NewView(name, description string, keys []tag.Key, measure Measure, agg Aggregation, window Window) *View {
@@ -80,26 +78,12 @@ func (v *View) Description() string {
 	return v.description
 }
 
-func (v *View) startForcedCollection() {
-	atomic.StoreUint32(&v.forced, 1)
-}
-
-func (v *View) stopForcedCollection() {
-	atomic.StoreUint32(&v.forced, 0)
-}
-
 func (v *View) subscribe() {
 	atomic.StoreUint32(&v.subscribed, 1)
 }
 
 func (v *View) unsubscribe() {
 	atomic.StoreUint32(&v.subscribed, 0)
-}
-
-// isCollecting returns true if the view is exporting data
-// by subscription or enabled for force collection.
-func (v *View) isCollecting() bool {
-	return atomic.LoadUint32(&v.subscribed) == 1 || atomic.LoadUint32(&v.forced) == 1
 }
 
 // isSubscribed returns true if the view is exporting
@@ -134,7 +118,7 @@ func (v *View) collectedRows(now time.Time) []*Row {
 }
 
 func (v *View) addSample(m *tag.Map, val interface{}, now time.Time) {
-	if !v.isCollecting() {
+	if !v.isSubscribed() {
 		return
 	}
 	sig := string(encodeWithKeys(m, v.tagKeys))

--- a/stats/view_test.go
+++ b/stats/view_test.go
@@ -153,7 +153,7 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowCumulative(t *testin
 
 	for _, tc := range tcs {
 		vw1.clearRows()
-		vw1.startForcedCollection()
+		vw1.subscribe()
 		for _, r := range tc.records {
 			mods := []tag.Mutator{}
 			for _, t := range r.tags {
@@ -339,7 +339,7 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowSlidingTime(t *testi
 
 	for _, tc := range tcs {
 		vw1.clearRows()
-		vw1.startForcedCollection()
+		vw1.subscribe()
 		for _, r := range tc.records {
 			mods := []tag.Mutator{}
 			for _, t := range r.tags {
@@ -543,7 +543,7 @@ func Test_View_MeasureFloat64_AggregationCount_WindowSlidingTime(t *testing.T) {
 
 	for _, tc := range tcs {
 		vw1.clearRows()
-		vw1.startForcedCollection()
+		vw1.subscribe()
 		for _, r := range tc.records {
 			mods := []tag.Mutator{}
 			for _, t := range r.tags {
@@ -671,7 +671,7 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowSlidingCount(t *test
 
 	for _, tc := range tcs {
 		vw1.clearRows()
-		vw1.startForcedCollection()
+		vw1.subscribe()
 		for _, r := range tc.records {
 			mods := []tag.Mutator{}
 			for _, t := range r.tags {

--- a/stats/worker.go
+++ b/stats/worker.go
@@ -102,16 +102,12 @@ func FindView(name string) (v *View, ok bool) {
 
 // RegisterView registers view. It returns an error if the view is already registered.
 //
-// Subscription and force collection automatically registers a view.
-// Most users will not register directly but register via subscription or force
-// collection. Registeration can be used by libraries to claim a view name.
+// Subscription automatically registers a view.
+// Most users will not register directly but register via subscription.
+// Registeration can be used by libraries to claim a view name.
 //
 // Unregister the view once the view is not required anymore.
 func RegisterView(v *View) error {
-	if v == nil {
-		return errors.New("cannot RegisterView for nil view")
-	}
-
 	req := &registerViewReq{
 		v:   v,
 		err: make(chan error),
@@ -124,9 +120,6 @@ func RegisterView(v *View) error {
 // if the view wasn't registered. All data collected and not reported for the
 // corresponding view will be lost. The view is automatically be unsubscribed.
 func (v *View) Unregister() error {
-	if v == nil {
-		return errors.New("cannot UnregisterView for nil view")
-	}
 	req := &unregisterViewReq{
 		v:   v,
 		err: make(chan error),
@@ -156,34 +149,6 @@ func (v *View) Subscribe() error {
 // view.
 func (v *View) Unsubscribe() error {
 	req := &unsubscribeFromViewReq{
-		v:   v,
-		err: make(chan error),
-	}
-	defaultWorker.c <- req
-	return <-req.err
-}
-
-// ForceCollect starts data collection for this view even if it is
-// not subscribed to. The view will be automatically registered.
-func (v *View) ForceCollect() error {
-	if v == nil {
-		return errors.New("cannot for collect nil view")
-	}
-	req := &startForcedCollectionReq{
-		v:   v,
-		err: make(chan error),
-	}
-	defaultWorker.c <- req
-	return <-req.err
-}
-
-// StopForceCollection stops data collection for this
-// view if view is not subscribed to.
-func (v *View) StopForceCollection() error {
-	if v == nil {
-		return errors.New("cannot stop force collection for nil view")
-	}
-	req := &stopForcedCollectionReq{
 		v:   v,
 		err: make(chan error),
 	}

--- a/stats/worker_test.go
+++ b/stats/worker_test.go
@@ -268,9 +268,8 @@ func Test_Worker_ViewRegistration(t *testing.T) {
 	sc1 := make(chan *ViewData)
 
 	type registerWant struct {
-		vID                string
-		err                error
-		isForcedCollection bool
+		vID string
+		err error
 	}
 	type unregisterWant struct {
 		vID string
@@ -296,12 +295,11 @@ func Test_Worker_ViewRegistration(t *testing.T) {
 	}
 	tcs := []testCase{
 		{
-			"0",
+			"register and subscribe to v1ID",
 			[]registerWant{
 				{
 					"v1ID",
 					nil,
-					true,
 				},
 			},
 			[]subscription{
@@ -331,17 +329,15 @@ func Test_Worker_ViewRegistration(t *testing.T) {
 			},
 		},
 		{
-			"1",
+			"register v1ID+v2ID, susbsribe to v1ID",
 			[]registerWant{
 				{
 					"v1ID",
 					nil,
-					false,
 				},
 				{
 					"v2ID",
 					nil,
-					true,
 				},
 			},
 			[]subscription{
@@ -375,12 +371,11 @@ func Test_Worker_ViewRegistration(t *testing.T) {
 			},
 		},
 		{
-			"2",
+			"register to v1ID; subscribe to v1ID and view with same ID",
 			[]registerWant{
 				{
 					"v1ID",
 					nil,
-					true,
 				},
 			},
 			[]subscription{
@@ -434,7 +429,7 @@ func Test_Worker_ViewRegistration(t *testing.T) {
 			if (err != nil) != (reg.err != nil) {
 				t.Errorf("RegisterView. got error %v, want %v. Test case: %v", err, reg.err, tc.label)
 			}
-			v.ForceCollect()
+			v.subscribe()
 		}
 
 		for _, s := range tc.subscriptions {
@@ -487,30 +482,23 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 	v1 := NewView("VF1", "desc VF1", []tag.Key{k1, k2}, m, CountAggregation{}, CumulativeWindow{})
 	v2 := NewView("VF2", "desc VF2", []tag.Key{k1, k2}, m, CountAggregation{}, CumulativeWindow{})
 
-	c1 := make(chan *ViewData)
-	type subscription struct {
-		v *View
-		c chan *ViewData
-	}
 	type want struct {
 		v    *View
 		rows []*Row
 		err  error
 	}
 	type testCase struct {
-		label           string
-		registrations   []*View
-		subscriptions   []subscription
-		forcedCollected []*View
-		records         []float64
-		wants           []want
+		label         string
+		registrations []*View
+		subscriptions []*View
+		records       []float64
+		wants         []want
 	}
 
 	tcs := []testCase{
 		{
 			"0",
 			[]*View{v1, v2},
-			[]subscription{},
 			[]*View{},
 			[]float64{1, 1},
 			[]want{{v1, nil, someError}, {v2, nil, someError}},
@@ -518,7 +506,6 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 		{
 			"1",
 			[]*View{v1, v2},
-			[]subscription{},
 			[]*View{v1},
 			[]float64{1, 1},
 			[]want{
@@ -538,7 +525,6 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 		{
 			"2",
 			[]*View{v1, v2},
-			[]subscription{},
 			[]*View{v1, v2},
 			[]float64{1, 1},
 			[]want{
@@ -558,84 +544,6 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 						{
 							[]tag.Tag{{Key: k1, Value: "v1"}, {Key: k2, Value: "v2"}},
 							newCountData(2),
-						},
-					},
-					nil,
-				},
-			},
-		},
-		{
-			"3",
-			[]*View{v1, v2},
-			[]subscription{{v1, c1}},
-			[]*View{},
-			[]float64{1, 1},
-			[]want{
-				{
-					v1,
-					[]*Row{
-						{
-							[]tag.Tag{{Key: k1, Value: "v1"}, {Key: k2, Value: "v2"}},
-							newCountData(2),
-						},
-					},
-					nil,
-				},
-				{v2, nil, someError},
-			},
-		},
-		{
-			"4",
-			[]*View{v1, v2},
-			[]subscription{{v1, c1}, {v2, c1}},
-			[]*View{},
-			[]float64{1, 1},
-			[]want{
-				{
-					v1,
-					[]*Row{
-						{
-							[]tag.Tag{{Key: k1, Value: "v1"}, {Key: k2, Value: "v2"}},
-							newCountData(2),
-						},
-					},
-					nil,
-				},
-				{
-					v2,
-					[]*Row{
-						{
-							[]tag.Tag{{Key: k1, Value: "v1"}, {Key: k2, Value: "v2"}},
-							newCountData(2),
-						},
-					},
-					nil,
-				},
-			},
-		},
-		{
-			"5",
-			[]*View{v1, v2},
-			[]subscription{{v1, c1}},
-			[]*View{v2},
-			[]float64{1, 1, 10},
-			[]want{
-				{
-					v1,
-					[]*Row{
-						{
-							[]tag.Tag{{Key: k1, Value: "v1"}, {Key: k2, Value: "v2"}},
-							newCountData(3),
-						},
-					},
-					nil,
-				},
-				{
-					v2,
-					[]*Row{
-						{
-							[]tag.Tag{{Key: k1, Value: "v1"}, {Key: k2, Value: "v2"}},
-							newCountData(3),
 						},
 					},
 					nil,
@@ -647,19 +555,13 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 	for _, tc := range tcs {
 		for _, v := range tc.registrations {
 			if err := RegisterView(v); err != nil {
-				t.Fatalf("RegisterView '%v' got error '%v', want no error for test case: '%v'", v.Name(), err, tc.label)
+				t.Fatalf("%v: RegisterView(%v) = %v; want no errors", tc.label, v.Name(), err)
 			}
 		}
 
-		for _, s := range tc.subscriptions {
-			if err := s.v.Subscribe(); err != nil {
-				t.Fatalf("Subscribe '%v' got error '%v', want no error for test case: '%v'", s.v.Name(), err, tc.label)
-			}
-		}
-
-		for _, v := range tc.forcedCollected {
-			if err := v.ForceCollect(); err != nil {
-				t.Fatalf("ForceCollect '%v' got error '%v', want no error for test case: '%v'", v.Name(), err, tc.label)
+		for _, v := range tc.subscriptions {
+			if err := v.Subscribe(); err != nil {
+				t.Fatalf("%v: Subscribe(%v) = %v; want no errors", tc.label, v.Name(), err)
 			}
 		}
 
@@ -670,33 +572,26 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 		for _, w := range tc.wants {
 			gotRows, err := w.v.RetrieveData()
 			if (err != nil) != (w.err != nil) {
-				t.Fatalf("RetrieveData '%v' got error '%v', want no error for test case: '%v'", w.v.Name(), err, tc.label)
+				t.Fatalf("%v: RetrieveData(%v) = %v; want no errors", tc.label, w.v.Name(), err)
 			}
-			for _, gotRow := range gotRows {
-				if !ContainsRow(w.rows, gotRow) {
-					t.Errorf("got unexpected row '%v' for test case: '%v'", gotRow, tc.label)
+			for _, got := range gotRows {
+				if !ContainsRow(w.rows, got) {
+					t.Errorf("%v: got row %v; want none", tc.label, got)
 					break
 				}
 			}
-
-			for _, wantRow := range w.rows {
-				if !ContainsRow(gotRows, wantRow) {
-					t.Errorf("want row '%v' for test case: '%v'. Not received", wantRow, tc.label)
+			for _, want := range w.rows {
+				if !ContainsRow(gotRows, want) {
+					t.Errorf("%v: got none; want %v'", tc.label, want)
 					break
 				}
 			}
 		}
 
 		// cleaning up
-		for _, v := range tc.forcedCollected {
-			if err := v.StopForceCollection(); err != nil {
-				t.Fatalf("%v: StopForceCollection for %v = %v; want no errors", tc.label, v.Name(), err)
-			}
-		}
-
-		for _, s := range tc.subscriptions {
-			if err := s.v.Unsubscribe(); err != nil {
-				t.Fatalf("%v: Unsubscribing from view %v errored with %v; want no error", tc.label, s.v.Name(), err)
+		for _, v := range tc.subscriptions {
+			if err := v.Unsubscribe(); err != nil {
+				t.Fatalf("%v: Unsubscribing from view %v errored with %v; want no error", tc.label, v.Name(), err)
 			}
 		}
 


### PR DESCRIPTION
With the new subscription model, force collection and subscription
became the same behaviors with different API names. Remove force collection.

Also fixes the race at isCollecting by removing it.

Fixes #97.