### PR TITLE
FindMeasure and FindView should return boolean for existence check

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ Retrieve measure by name:
 
 [embedmd]:# (stats.go findMeasure)
 ```go
-m, err := stats.FindMeasure("my.org/video_size")
-if err != nil {
-	log.Fatal(err)
+m, ok := stats.FindMeasure("my.org/video_size")
+if !ok {
+	log.Fatalln("measure not found")
 }
 ```
 
@@ -189,9 +189,9 @@ Find view by name:
 
 [embedmd]:# (stats.go findView)
 ```go
-v, err := stats.FindView("my.org/video_size_distribution")
-if err != nil {
-	log.Fatal(err)
+v, ok := stats.FindView("my.org/video_size_distribution")
+if !ok {
+	log.Fatalln("view not found")
 }
 ```
 

--- a/internal/readme/stats.go
+++ b/internal/readme/stats.go
@@ -37,9 +37,9 @@ func statsExamples() {
 	_ = videoSize
 
 	// START findMeasure
-	m, err := stats.FindMeasure("my.org/video_size")
-	if err != nil {
-		log.Fatal(err)
+	m, ok := stats.FindMeasure("my.org/video_size")
+	if !ok {
+		log.Fatalln("measure not found")
 	}
 	// END findMeasure
 
@@ -89,9 +89,9 @@ func statsExamples() {
 	// END view
 
 	// START findView
-	v, err := stats.FindView("my.org/video_size_distribution")
-	if err != nil {
-		log.Fatal(err)
+	v, ok := stats.FindView("my.org/video_size_distribution")
+	if !ok {
+		log.Fatalln("view not found")
 	}
 	// END findView
 

--- a/stats/measure.go
+++ b/stats/measure.go
@@ -44,14 +44,15 @@ type Measurement interface {
 }
 
 // FindMeasure returns the registered measure associated with name.
-func FindMeasure(name string) (Measure, error) {
+// If no registered measure is not found, ok is false.
+func FindMeasure(name string) (m Measure, ok bool) {
 	req := &getMeasureByNameReq{
 		name: name,
 		c:    make(chan *getMeasureByNameResp),
 	}
 	defaultWorker.c <- req
 	resp := <-req.c
-	return resp.m, resp.err
+	return resp.m, resp.ok
 }
 
 // DeleteMeasure deletes an existing measure to allow for creation of a new

--- a/stats/worker.go
+++ b/stats/worker.go
@@ -89,14 +89,15 @@ func NewMeasureInt64(name, description, unit string) (*MeasureInt64, error) {
 }
 
 // FindView returns a registered view associated with this name.
-func FindView(name string) (*View, error) {
+// If no registered view is found, ok is false.
+func FindView(name string) (v *View, ok bool) {
 	req := &getViewByNameReq{
 		name: name,
 		c:    make(chan *getViewByNameResp),
 	}
 	defaultWorker.c <- req
 	resp := <-req.c
-	return resp.v, resp.err
+	return resp.v, resp.ok
 }
 
 // RegisterView registers view. It returns an error if the view cannot be

--- a/stats/worker_commands.go
+++ b/stats/worker_commands.go
@@ -33,16 +33,13 @@ type getMeasureByNameReq struct {
 }
 
 type getMeasureByNameResp struct {
-	m   Measure
-	err error
+	m  Measure
+	ok bool
 }
 
 func (cmd *getMeasureByNameReq) handleCommand(w *worker) {
-	if m, ok := w.measuresByName[cmd.name]; ok {
-		cmd.c <- &getMeasureByNameResp{m, nil}
-		return
-	}
-	cmd.c <- &getMeasureByNameResp{nil, fmt.Errorf("no registered measure %q", cmd.name)}
+	m, ok := w.measuresByName[cmd.name]
+	cmd.c <- &getMeasureByNameResp{m, ok}
 }
 
 // registerMeasureReq is the command to register a measure with the library.
@@ -90,19 +87,13 @@ type getViewByNameReq struct {
 }
 
 type getViewByNameResp struct {
-	v   *View
-	err error
+	v  *View
+	ok bool
 }
 
 func (cmd *getViewByNameReq) handleCommand(w *worker) {
-	if v, ok := w.viewsByName[cmd.name]; ok {
-		cmd.c <- &getViewByNameResp{v, nil}
-		return
-	}
-	cmd.c <- &getViewByNameResp{
-		nil,
-		fmt.Errorf("view %q is not registered", cmd.name),
-	}
+	v, ok := w.viewsByName[cmd.name]
+	cmd.c <- &getViewByNameResp{v, ok}
 }
 
 // registerViewReq is the command to register a view with the library.


### PR DESCRIPTION
Both existance checks need to return booleans because
there are no other cases for them to return another error.
Returning a boolean makes it easier for the user to handle
the case.

Fixes #104.