### PR TITLE
Adjust tag map APIs to return errors

### DIFF
--- a/internal/readme/tags.go
+++ b/internal/readme/tags.go
@@ -43,10 +43,13 @@ func tagsExamples() {
 		log.Fatal(err)
 	}
 
-	tagMap := tag.NewMap(nil,
+	tagMap, err := tag.NewMap(nil,
 		tag.Insert(osKey, "macOS-10.12.5"),
 		tag.Upsert(userIDKey, "cde36753ed"),
 	)
+	if err != nil {
+		log.Fatal(err)
+	}
 	// END tagMap
 
 	// START newContext
@@ -55,11 +58,14 @@ func tagsExamples() {
 
 	// START replaceTagMap
 	oldTagMap := tag.FromContext(ctx)
-	tagMap = tag.NewMap(oldTagMap,
+	tagMap, err = tag.NewMap(oldTagMap,
 		tag.Insert(key, "macOS-10.12.5"),
 		tag.Upsert(key, "macOS-10.12.7"),
 		tag.Upsert(userIDKey, "fff0989878"),
 	)
+	if err != nil {
+		log.Fatal(err)
+	}
 	ctx = tag.NewContext(ctx, tagMap)
 	// END replaceTagMap
 

--- a/plugins/grpc/grpcstats/client_handler_test.go
+++ b/plugins/grpc/grpcstats/client_handler_test.go
@@ -321,7 +321,10 @@ func TestClientDefaultCollections(t *testing.T) {
 			for _, t := range rpc.tags {
 				mods = append(mods, tag.Upsert(t.k, t.v))
 			}
-			tm := tag.NewMap(nil, mods...)
+			tm, err := tag.NewMap(nil, mods...)
+			if err != nil {
+				t.Errorf("%q: NewMap = %v", tc.label, err)
+			}
 			encoded := tag.Encode(tm)
 			ctx := stats.SetTags(context.Background(), encoded)
 

--- a/plugins/grpc/grpcstats/server_handler.go
+++ b/plugins/grpc/grpcstats/server_handler.go
@@ -163,10 +163,12 @@ func (sh serverHandler) handleRPCEnd(ctx context.Context, s *stats.End) {
 	measurements = append(measurements, RPCServerServerElapsedTime.M(float64(elapsedTime)/float64(time.Millisecond)))
 	if s.Error != nil {
 		errorCode := s.Error.Error()
-		tm := tag.NewMap(tag.FromContext(ctx),
+		tm, err := tag.NewMap(tag.FromContext(ctx),
 			tag.Upsert(keyOpStatus, errorCode),
 		)
-		ctx = tag.NewContext(ctx, tm)
+		if err == nil {
+			ctx = tag.NewContext(ctx, tm)
+		}
 		measurements = append(measurements, RPCServerErrorCount.M(1))
 	}
 
@@ -185,7 +187,7 @@ func (sh serverHandler) createTagMap(ctx context.Context, serviceName, methodNam
 		if err != nil {
 			return nil, fmt.Errorf("serverHandler.createTagMap failed to decode tagsBin %v: %v", tagsBin, err)
 		}
-		return tag.NewMap(old, mods...), nil
+		return tag.NewMap(old, mods...)
 	}
-	return tag.NewMap(nil, mods...), nil
+	return tag.NewMap(nil, mods...)
 }

--- a/plugins/grpc/grpcstats/server_handler_test.go
+++ b/plugins/grpc/grpcstats/server_handler_test.go
@@ -320,7 +320,10 @@ func TestServerDefaultCollections(t *testing.T) {
 			for _, t := range rpc.tags {
 				mods = append(mods, tag.Upsert(t.k, t.v))
 			}
-			ts := tag.NewMap(nil, mods...)
+			ts, err := tag.NewMap(nil, mods...)
+			if err != nil {
+				t.Errorf("%q: NewMap = %v", tc.label, err)
+			}
 			encoded := tag.Encode(ts)
 			ctx := stats.SetTags(context.Background(), encoded)
 

--- a/stats/tags_test.go
+++ b/stats/tags_test.go
@@ -40,38 +40,43 @@ func TestEncodeDecodeTags(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	m1, _ := tag.NewMap(nil)
+	m2, _ := tag.NewMap(nil, tag.Insert(k2, "v2"))
+	m3, _ := tag.NewMap(nil, tag.Insert(k1, "v1"), tag.Insert(k2, "v2"))
+	m4, _ := tag.NewMap(nil, tag.Insert(k1, "v1"), tag.Insert(k2, "v2"), tag.Insert(k3, "v3"))
+
 	tests := []testData{
 		{
-			tag.NewMap(nil),
+			m1,
 			[]tag.Key{k1},
 			nil,
 		},
 		{
-			tag.NewMap(nil, tag.Insert(k2, "v2")),
+			m2,
 			[]tag.Key{},
 			nil,
 		},
 		{
-			tag.NewMap(nil, tag.Insert(k2, "v2")),
+			m2,
 			[]tag.Key{k1},
 			nil,
 		},
 		{
-			tag.NewMap(nil, tag.Insert(k2, "v2")),
+			m2,
 			[]tag.Key{k2},
 			map[tag.Key][]byte{
 				k2: []byte("v2"),
 			},
 		},
 		{
-			tag.NewMap(nil, tag.Insert(k1, "v1"), tag.Insert(k2, "v2")),
+			m3,
 			[]tag.Key{k1},
 			map[tag.Key][]byte{
 				k1: []byte("v1"),
 			},
 		},
 		{
-			tag.NewMap(nil, tag.Insert(k1, "v1"), tag.Insert(k2, "v2")),
+			m3,
 			[]tag.Key{k1, k2},
 			map[tag.Key][]byte{
 				k1: []byte("v1"),
@@ -79,7 +84,7 @@ func TestEncodeDecodeTags(t *testing.T) {
 			},
 		},
 		{
-			tag.NewMap(nil, tag.Insert(k1, "v1"), tag.Insert(k2, "v2"), tag.Insert(k3, "v3")),
+			m4,
 			[]tag.Key{k3, k1},
 			map[tag.Key][]byte{
 				k1: []byte("v1"),

--- a/stats/view_test.go
+++ b/stats/view_test.go
@@ -159,7 +159,10 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowCumulative(t *testin
 			for _, t := range r.tags {
 				mods = append(mods, tag.Insert(t.k, t.v))
 			}
-			ts := tag.NewMap(nil, mods...)
+			ts, err := tag.NewMap(nil, mods...)
+			if err != nil {
+				t.Errorf("%v: NewMap = %v", tc.label, err)
+			}
 			vw1.addSample(ts, r.f, time.Now())
 		}
 
@@ -345,7 +348,10 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowSlidingTime(t *testi
 			for _, t := range r.tags {
 				mods = append(mods, tag.Insert(t.k, t.v))
 			}
-			ts := tag.NewMap(nil, mods...)
+			ts, err := tag.NewMap(nil, mods...)
+			if err != nil {
+				t.Errorf("%v: NewMap = %v", tc.label, err)
+			}
 			vw1.addSample(ts, r.f, r.now)
 		}
 
@@ -549,7 +555,10 @@ func Test_View_MeasureFloat64_AggregationCount_WindowSlidingTime(t *testing.T) {
 			for _, t := range r.tags {
 				mods = append(mods, tag.Insert(t.k, t.v))
 			}
-			ts := tag.NewMap(nil, mods...)
+			ts, err := tag.NewMap(nil, mods...)
+			if err != nil {
+				t.Errorf("%v: NewMap = %v", tc.label, err)
+			}
 			vw1.addSample(ts, r.f, r.now)
 		}
 
@@ -677,7 +686,10 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowSlidingCount(t *test
 			for _, t := range r.tags {
 				mods = append(mods, tag.Insert(t.k, t.v))
 			}
-			ts := tag.NewMap(nil, mods...)
+			ts, err := tag.NewMap(nil, mods...)
+			if err != nil {
+				t.Logf("%v: NewMap failed with %v", tc.label, err)
+			}
 			vw1.addSample(ts, r.f, time.Now())
 		}
 

--- a/stats/worker_test.go
+++ b/stats/worker_test.go
@@ -473,10 +473,13 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 
 	k1, _ := tag.NewKey("k1")
 	k2, _ := tag.NewKey("k2")
-	ts := tag.NewMap(nil,
+	ts, err := tag.NewMap(nil,
 		tag.Insert(k1, "v1"),
 		tag.Insert(k2, "v2"),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ctx := tag.NewContext(context.Background(), ts)
 
 	v1 := NewView("VF1", "desc VF1", []tag.Key{k1, k2}, m, CountAggregation{}, CumulativeWindow{})

--- a/tag/example_test.go
+++ b/tag/example_test.go
@@ -47,19 +47,25 @@ func ExampleNewMap() {
 		log.Fatal(err)
 	}
 
-	tagMap := tag.NewMap(nil,
+	tagMap, err := tag.NewMap(nil,
 		tag.Insert(osKey, "macOS-10.12.5"),
 		tag.Upsert(userIDKey, "cde36753ed"),
 	)
+	if err != nil {
+		log.Fatal(err)
+	}
 	_ = tagMap // use the tag map
 }
 
 func ExampleNewMap_replace() {
 	oldTagMap := tag.FromContext(ctx)
-	tagMap := tag.NewMap(oldTagMap,
+	tagMap, err := tag.NewMap(oldTagMap,
 		tag.Insert(key, "macOS-10.12.5"),
 		tag.Upsert(key, "macOS-10.12.7"),
 	)
+	if err != nil {
+		log.Fatal(err)
+	}
 	ctx = tag.NewContext(ctx, tagMap)
 
 	_ = ctx // use context

--- a/tag/map_codec_test.go
+++ b/tag/map_codec_test.go
@@ -79,7 +79,10 @@ func Test_EncodeDecode_Set(t *testing.T) {
 		for i, pair := range tc.pairs {
 			mods[i] = Upsert(pair.k, pair.v)
 		}
-		ts := NewMap(nil, mods...)
+		ts, err := NewMap(nil, mods...)
+		if err != nil {
+			t.Errorf("%v: NewMap = %v", tc.label, err)
+		}
 		encoded := Encode(ts)
 		decoded, err := Decode(encoded)
 

--- a/tag/map_test.go
+++ b/tag/map_test.go
@@ -26,7 +26,7 @@ func TestContext(t *testing.T) {
 	k1, _ := NewKey("k1")
 	k2, _ := NewKey("k2")
 
-	want := NewMap(nil,
+	want, _ := NewMap(nil,
 		Insert(k1, "v1"),
 		Insert(k2, "v2"),
 	)
@@ -114,7 +114,10 @@ func TestNewMap(t *testing.T) {
 			Delete(k1),
 		}
 		mods = append(mods, tt.mods...)
-		got := NewMap(tt.initial, mods...)
+		got, err := NewMap(tt.initial, mods...)
+		if err != nil {
+			t.Errorf("%v: NewMap = %v", tt.name, err)
+		}
 
 		if !reflect.DeepEqual(got, tt.want) {
 			t.Errorf("%v: got %v; want %v", tt.name, got, tt.want)


### PR DESCRIPTION
The validation checks will require NewMap to be able to
return errors. Adjust the APIs to return an error. Validation
will be implemented in an follow up change.

Fixes #107.