### PR TITLE
NewMap should accept the incoming context

### DIFF
--- a/internal/readme/tags.go
+++ b/internal/readme/tags.go
@@ -43,7 +43,7 @@ func tagsExamples() {
 		log.Fatal(err)
 	}
 
-	tagMap, err := tag.NewMap(nil,
+	tagMap, err := tag.NewMap(ctx,
 		tag.Insert(osKey, "macOS-10.12.5"),
 		tag.Upsert(userIDKey, "cde36753ed"),
 	)
@@ -57,8 +57,7 @@ func tagsExamples() {
 	// END newContext
 
 	// START replaceTagMap
-	oldTagMap := tag.FromContext(ctx)
-	tagMap, err = tag.NewMap(oldTagMap,
+	tagMap, err = tag.NewMap(ctx,
 		tag.Insert(key, "macOS-10.12.5"),
 		tag.Upsert(key, "macOS-10.12.7"),
 		tag.Upsert(userIDKey, "fff0989878"),
@@ -68,7 +67,5 @@ func tagsExamples() {
 	}
 	ctx = tag.NewContext(ctx, tagMap)
 	// END replaceTagMap
-
-	_ = oldTagMap
 
 }

--- a/plugins/grpc/grpcstats/client_handler.go
+++ b/plugins/grpc/grpcstats/client_handler.go
@@ -85,7 +85,7 @@ func (ch clientHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) cont
 	encoded := tag.Encode(ts)
 	ctx = stats.SetTags(ctx, encoded)
 
-	tagMap, err := tag.NewMap(ts,
+	tagMap, err := tag.NewMap(ctx,
 		tag.Upsert(keyService, serviceName),
 		tag.Upsert(keyMethod, methodName),
 	)
@@ -159,7 +159,7 @@ func (ch clientHandler) handleRPCEnd(ctx context.Context, s *stats.End) {
 
 	if s.Error != nil {
 		errorCode := s.Error.Error()
-		newTagMap, err := tag.NewMap(tag.FromContext(ctx),
+		newTagMap, err := tag.NewMap(ctx,
 			tag.Upsert(keyOpStatus, errorCode),
 		)
 		if err == nil {

--- a/plugins/grpc/grpcstats/client_handler_test.go
+++ b/plugins/grpc/grpcstats/client_handler_test.go
@@ -321,7 +321,7 @@ func TestClientDefaultCollections(t *testing.T) {
 			for _, t := range rpc.tags {
 				mods = append(mods, tag.Upsert(t.k, t.v))
 			}
-			tm, err := tag.NewMap(nil, mods...)
+			tm, err := tag.NewMap(context.Background(), mods...)
 			if err != nil {
 				t.Errorf("%q: NewMap = %v", tc.label, err)
 			}

--- a/plugins/grpc/grpcstats/server_handler.go
+++ b/plugins/grpc/grpcstats/server_handler.go
@@ -163,7 +163,7 @@ func (sh serverHandler) handleRPCEnd(ctx context.Context, s *stats.End) {
 	measurements = append(measurements, RPCServerServerElapsedTime.M(float64(elapsedTime)/float64(time.Millisecond)))
 	if s.Error != nil {
 		errorCode := s.Error.Error()
-		tm, err := tag.NewMap(tag.FromContext(ctx),
+		tm, err := tag.NewMap(ctx,
 			tag.Upsert(keyOpStatus, errorCode),
 		)
 		if err == nil {
@@ -187,7 +187,7 @@ func (sh serverHandler) createTagMap(ctx context.Context, serviceName, methodNam
 		if err != nil {
 			return nil, fmt.Errorf("serverHandler.createTagMap failed to decode tagsBin %v: %v", tagsBin, err)
 		}
-		return tag.NewMap(old, mods...)
+		return tag.NewMap(tag.NewContext(ctx, old), mods...)
 	}
-	return tag.NewMap(nil, mods...)
+	return tag.NewMap(ctx, mods...)
 }

--- a/plugins/grpc/grpcstats/server_handler_test.go
+++ b/plugins/grpc/grpcstats/server_handler_test.go
@@ -320,7 +320,7 @@ func TestServerDefaultCollections(t *testing.T) {
 			for _, t := range rpc.tags {
 				mods = append(mods, tag.Upsert(t.k, t.v))
 			}
-			ts, err := tag.NewMap(nil, mods...)
+			ts, err := tag.NewMap(context.Background(), mods...)
 			if err != nil {
 				t.Errorf("%q: NewMap = %v", tc.label, err)
 			}

--- a/stats/tags_test.go
+++ b/stats/tags_test.go
@@ -17,10 +17,13 @@ package stats
 import (
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"go.opencensus.io/tag"
 )
 
 func TestEncodeDecodeTags(t *testing.T) {
+	ctx := context.Background()
 	type testData struct {
 		m    *tag.Map
 		keys []tag.Key
@@ -40,10 +43,10 @@ func TestEncodeDecodeTags(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m1, _ := tag.NewMap(nil)
-	m2, _ := tag.NewMap(nil, tag.Insert(k2, "v2"))
-	m3, _ := tag.NewMap(nil, tag.Insert(k1, "v1"), tag.Insert(k2, "v2"))
-	m4, _ := tag.NewMap(nil, tag.Insert(k1, "v1"), tag.Insert(k2, "v2"), tag.Insert(k3, "v3"))
+	m1, _ := tag.NewMap(ctx)
+	m2, _ := tag.NewMap(ctx, tag.Insert(k2, "v2"))
+	m3, _ := tag.NewMap(ctx, tag.Insert(k1, "v1"), tag.Insert(k2, "v2"))
+	m4, _ := tag.NewMap(ctx, tag.Insert(k1, "v1"), tag.Insert(k2, "v2"), tag.Insert(k3, "v3"))
 
 	tests := []testData{
 		{

--- a/stats/view_test.go
+++ b/stats/view_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"go.opencensus.io/tag"
 )
 
@@ -159,7 +161,7 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowCumulative(t *testin
 			for _, t := range r.tags {
 				mods = append(mods, tag.Insert(t.k, t.v))
 			}
-			ts, err := tag.NewMap(nil, mods...)
+			ts, err := tag.NewMap(context.Background(), mods...)
 			if err != nil {
 				t.Errorf("%v: NewMap = %v", tc.label, err)
 			}
@@ -348,7 +350,7 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowSlidingTime(t *testi
 			for _, t := range r.tags {
 				mods = append(mods, tag.Insert(t.k, t.v))
 			}
-			ts, err := tag.NewMap(nil, mods...)
+			ts, err := tag.NewMap(context.Background(), mods...)
 			if err != nil {
 				t.Errorf("%v: NewMap = %v", tc.label, err)
 			}
@@ -555,7 +557,7 @@ func Test_View_MeasureFloat64_AggregationCount_WindowSlidingTime(t *testing.T) {
 			for _, t := range r.tags {
 				mods = append(mods, tag.Insert(t.k, t.v))
 			}
-			ts, err := tag.NewMap(nil, mods...)
+			ts, err := tag.NewMap(context.Background(), mods...)
 			if err != nil {
 				t.Errorf("%v: NewMap = %v", tc.label, err)
 			}
@@ -686,7 +688,7 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowSlidingCount(t *test
 			for _, t := range r.tags {
 				mods = append(mods, tag.Insert(t.k, t.v))
 			}
-			ts, err := tag.NewMap(nil, mods...)
+			ts, err := tag.NewMap(context.Background(), mods...)
 			if err != nil {
 				t.Logf("%v: NewMap failed with %v", tc.label, err)
 			}

--- a/stats/worker_test.go
+++ b/stats/worker_test.go
@@ -473,7 +473,7 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 
 	k1, _ := tag.NewKey("k1")
 	k2, _ := tag.NewKey("k2")
-	ts, err := tag.NewMap(nil,
+	ts, err := tag.NewMap(context.Background(),
 		tag.Insert(k1, "v1"),
 		tag.Insert(k2, "v2"),
 	)

--- a/tag/example_test.go
+++ b/tag/example_test.go
@@ -47,7 +47,7 @@ func ExampleNewMap() {
 		log.Fatal(err)
 	}
 
-	tagMap, err := tag.NewMap(nil,
+	tagMap, err := tag.NewMap(ctx,
 		tag.Insert(osKey, "macOS-10.12.5"),
 		tag.Upsert(userIDKey, "cde36753ed"),
 	)
@@ -58,8 +58,7 @@ func ExampleNewMap() {
 }
 
 func ExampleNewMap_replace() {
-	oldTagMap := tag.FromContext(ctx)
-	tagMap, err := tag.NewMap(oldTagMap,
+	tagMap, err := tag.NewMap(ctx,
 		tag.Insert(key, "macOS-10.12.5"),
 		tag.Upsert(key, "macOS-10.12.7"),
 	)

--- a/tag/key.go
+++ b/tag/key.go
@@ -15,11 +15,6 @@
 
 package tag
 
-// Mutator modifies a tag map.
-type Mutator interface {
-	Mutate(t *Map) (*Map, error)
-}
-
 // Key represents a tag key. Keys with the same name will return
 // true when compared with the == operator.
 type Key struct {
@@ -36,83 +31,4 @@ func NewKey(name string) (Key, error) {
 // Name returns the name of the key.
 func (k Key) Name() string {
 	return k.name
-}
-
-type mutator struct {
-	fn func(t *Map) (*Map, error)
-}
-
-func (m *mutator) Mutate(t *Map) (*Map, error) {
-	return m.fn(t)
-}
-
-// Insert returns a mutator that inserts a
-// value associated with k. If k already exists in the tag map,
-// mutator doesn't update the value.
-func Insert(k Key, v string) Mutator {
-	return &mutator{
-		fn: func(m *Map) (*Map, error) {
-			m.insert(k, v)
-			return m, nil
-		},
-	}
-}
-
-// Update returns a mutator that updates the
-// value of the tag associated with k with v. If k doesn't
-// exists in the tag map, the mutator doesn't insert the value.
-func Update(k Key, v string) Mutator {
-	return &mutator{
-		fn: func(m *Map) (*Map, error) {
-			m.update(k, v)
-			return m, nil
-		},
-	}
-}
-
-// Upsert returns a mutator that upserts the
-// value of the tag associated with k with v. It inserts the
-// value if k doesn't exist already. It mutates the value
-// if k already exists.
-func Upsert(k Key, v string) Mutator {
-	return &mutator{
-		fn: func(m *Map) (*Map, error) {
-			m.upsert(k, v)
-			return m, nil
-		},
-	}
-}
-
-// Delete returns a mutator that deletes
-// the value associated with k.
-func Delete(k Key) Mutator {
-	return &mutator{
-		fn: func(m *Map) (*Map, error) {
-			m.delete(k)
-			return m, nil
-		},
-	}
-}
-
-// NewMap returns a new tag map originated from orig,
-// modified with the provided mutators.
-func NewMap(orig *Map, mutator ...Mutator) (*Map, error) {
-	// TODO(jbd): Implement validation of keys and values.
-	var m *Map
-	if orig == nil {
-		m = newMap(0)
-	} else {
-		m = newMap(len(orig.m))
-		for k, v := range orig.m {
-			m.insert(k, v)
-		}
-	}
-	var err error
-	for _, mod := range mutator {
-		m, err = mod.Mutate(m)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return m, nil
 }

--- a/tag/map_codec_test.go
+++ b/tag/map_codec_test.go
@@ -16,6 +16,7 @@
 package tag
 
 import (
+	"context"
 	"reflect"
 	"sort"
 	"testing"
@@ -79,7 +80,7 @@ func Test_EncodeDecode_Set(t *testing.T) {
 		for i, pair := range tc.pairs {
 			mods[i] = Upsert(pair.k, pair.v)
 		}
-		ts, err := NewMap(nil, mods...)
+		ts, err := NewMap(context.Background(), mods...)
 		if err != nil {
 			t.Errorf("%v: NewMap = %v", tc.label, err)
 		}

--- a/tag/map_test.go
+++ b/tag/map_test.go
@@ -26,7 +26,7 @@ func TestContext(t *testing.T) {
 	k1, _ := NewKey("k1")
 	k2, _ := NewKey("k2")
 
-	want, _ := NewMap(nil,
+	want, _ := NewMap(context.Background(),
 		Insert(k1, "v1"),
 		Insert(k2, "v2"),
 	)
@@ -114,7 +114,8 @@ func TestNewMap(t *testing.T) {
 			Delete(k1),
 		}
 		mods = append(mods, tt.mods...)
-		got, err := NewMap(tt.initial, mods...)
+		ctx := NewContext(context.Background(), tt.initial)
+		got, err := NewMap(ctx, mods...)
 		if err != nil {
 			t.Errorf("%v: NewMap = %v", tt.name, err)
 		}


### PR DESCRIPTION
In order to encourage users not to drop the tags from the
incoming context, adjust APIs to accept the incoming context
for convience.

Fixes #110.