### PR TITLE
Do not repeat distribution bounds in the collected data

### DIFF
--- a/exporter/stats/stackdriver/stackdriver_test.go
+++ b/exporter/stats/stackdriver/stackdriver_test.go
@@ -38,7 +38,7 @@ func TestExporter_makeReq(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	distView := stats.NewView("distview", "desc", nil, m, stats.DistributionAggregation{}, stats.SlidingTimeWindow{})
+	distView := stats.NewView("distview", "desc", nil, m, stats.DistributionAggregation([]float64{2, 4, 7}), stats.SlidingTimeWindow{})
 	if err := stats.RegisterView(distView); err != nil {
 		t.Fatal(err)
 	}
@@ -204,7 +204,6 @@ func newTestDistViewData(v *stats.View, start, end time.Time) *stats.ViewData {
 				Mean:            3,
 				SumOfSquaredDev: 1.5,
 				CountPerBucket:  []int64{2, 2, 1},
-				Bounds:          []float64{2, 4, 7},
 			}},
 		},
 		Start: start,

--- a/plugins/grpc/grpcstats/server_handler_test.go
+++ b/plugins/grpc/grpcstats/server_handler_test.go
@@ -384,6 +384,5 @@ func newDistributionData(bounds []float64, countPerBucket []int64, count int64, 
 		Mean:            mean,
 		SumOfSquaredDev: sumOfSquaredDev,
 		CountPerBucket:  countPerBucket,
-		Bounds:          bounds,
 	}
 }

--- a/stats/aggregation_data.go
+++ b/stats/aggregation_data.go
@@ -85,13 +85,13 @@ type DistributionData struct {
 	Mean            float64   // mean of the distribution
 	SumOfSquaredDev float64   // sum of the squared deviation from the mean
 	CountPerBucket  []int64   // number of occurrences per bucket
-	Bounds          []float64 // histogram distribution of the values
+	bounds          []float64 // histogram distribution of the values
 }
 
 func newDistributionData(bounds []float64) *DistributionData {
 	return &DistributionData{
 		CountPerBucket: make([]int64, len(bounds)+1),
-		Bounds:         bounds,
+		bounds:         bounds,
 		Min:            math.MaxFloat64,
 		Max:            math.SmallestNonzeroFloat64,
 	}
@@ -142,18 +142,18 @@ func (a *DistributionData) addSample(v interface{}) {
 }
 
 func (a *DistributionData) incrementBucketCount(f float64) {
-	if len(a.Bounds) == 0 {
+	if len(a.bounds) == 0 {
 		a.CountPerBucket[0]++
 		return
 	}
 
-	for i, b := range a.Bounds {
+	for i, b := range a.bounds {
 		if f < b {
 			a.CountPerBucket[i]++
 			return
 		}
 	}
-	a.CountPerBucket[len(a.Bounds)]++
+	a.CountPerBucket[len(a.bounds)]++
 }
 
 // DistributionData will not multiply by the fraction for this type
@@ -164,7 +164,7 @@ func (a *DistributionData) incrementBucketCount(f float64) {
 // and will create inconsistencies between sumOfSquaredDev, min, max and the
 // various buckets of the histogram.
 func (a *DistributionData) multiplyByFraction(fraction float64) AggregationData {
-	ret := newDistributionData(a.Bounds)
+	ret := newDistributionData(a.bounds)
 	for i, c := range a.CountPerBucket {
 		ret.CountPerBucket[i] = c
 	}


### PR DESCRIPTION
Distribution aggrgation already contains the bounds information.
Bounds don't have be reported again as a part of the DistrubutionData.