### PR TITLE
Rename IntAttribute to Int64Attribute

### DIFF
--- a/exporter/trace/stackdriver/proto_test.go
+++ b/exporter/trace/stackdriver/proto_test.go
@@ -76,7 +76,7 @@ func TestExportTrace(t *testing.T) {
 			trace.SetSpanAttributes(ctx2,
 				trace.StringAttribute{Key: "key1", Value: "value1"},
 				trace.StringAttribute{Key: "key2", Value: "value2"})
-			trace.SetSpanAttributes(ctx2, trace.IntAttribute{Key: "key1", Value: 100})
+			trace.SetSpanAttributes(ctx2, trace.Int64Attribute{Key: "key1", Value: 100})
 			trace.EndSpan(ctx2)
 		}
 		{

--- a/trace/basetypes.go
+++ b/trace/basetypes.go
@@ -57,13 +57,13 @@ type BoolAttribute struct {
 
 func (b BoolAttribute) isAttribute() {}
 
-// IntAttribute represents an int64-valued attribute.
-type IntAttribute struct {
+// Int64Attribute represents an int64-valued attribute.
+type Int64Attribute struct {
 	Key   string
 	Value int64
 }
 
-func (i IntAttribute) isAttribute() {}
+func (i Int64Attribute) isAttribute() {}
 
 // StringAttribute represents a string-valued attribute.
 type StringAttribute struct {

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -364,7 +364,7 @@ func copyAttributes(m map[string]interface{}, attributes []Attribute) {
 		switch a := a.(type) {
 		case BoolAttribute:
 			m[a.Key] = a.Value
-		case IntAttribute:
+		case Int64Attribute:
 			m[a.Key] = a.Value
 		case StringAttribute:
 			m[a.Key] = a.Value


### PR DESCRIPTION
To have more consistency with the stats package, name int64 specific
types with Int64 in the name.