### PR TITLE
Introduce stats Stackdriver options and allow users to flush

### DIFF
--- a/examples/stats/stackdriver/main.go
+++ b/examples/stats/stackdriver/main.go
@@ -40,9 +40,13 @@ func main() {
 	// to setup the authorization.
 	// See https://developers.google.com/identity/protocols/application-default-credentials
 	// for more details.
-	stats.RegisterExporter(&stackdriver.Exporter{
+	exporter, err := stackdriver.NewExporter(stackdriver.Options{
 		ProjectID: "project-id", // Google Cloud Console project ID.
 	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	stats.RegisterExporter(exporter)
 
 	// Create measures. The program will record measures for the size of
 	// processed videos and the nubmer of videos marked as spam.

--- a/exporter/stats/stackdriver/stackdriver_test.go
+++ b/exporter/stats/stackdriver/stackdriver_test.go
@@ -169,9 +169,7 @@ func TestExporter_makeReq(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			e := &Exporter{
-				ProjectID: tt.projID,
-			}
+			e := &Exporter{o: Options{ProjectID: tt.projID}}
 			if got := e.makeReq([]*stats.ViewData{tt.vd}); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("%v: Exporter.makeReq() = %v, want %v", tt.name, got, tt.want)
 			}


### PR DESCRIPTION
Be consistent with the Stackdriver trace exporter by introducing
an options type, allowing users to flush, and returning an error
if client construction fails.