### PR TITLE
Unexport ContainsRow

### DIFF
--- a/plugins/grpc/grpcstats/client_handler_test.go
+++ b/plugins/grpc/grpcstats/client_handler_test.go
@@ -349,14 +349,14 @@ func TestClientDefaultCollections(t *testing.T) {
 			}
 
 			for _, gotRow := range gotRows {
-				if !istats.ContainsRow(wantData.rows, gotRow) {
+				if !containsRow(wantData.rows, gotRow) {
 					t.Errorf("%q: unwanted row for view %q = %v", tc.label, wantData.v().Name(), gotRow)
 					break
 				}
 			}
 
 			for _, wantRow := range wantData.rows {
-				if !istats.ContainsRow(gotRows, wantRow) {
+				if !containsRow(gotRows, wantRow) {
 					t.Errorf("%q: row missing for view %q; want %v", tc.label, wantData.v().Name(), wantRow)
 					break
 				}
@@ -370,4 +370,14 @@ func TestClientDefaultCollections(t *testing.T) {
 			}
 		}
 	}
+}
+
+// containsRow returns true if rows contain r.
+func containsRow(rows []*istats.Row, r *istats.Row) bool {
+	for _, x := range rows {
+		if r.Equal(x) {
+			return true
+		}
+	}
+	return false
 }

--- a/plugins/grpc/grpcstats/server_handler_test.go
+++ b/plugins/grpc/grpcstats/server_handler_test.go
@@ -348,14 +348,14 @@ func TestServerDefaultCollections(t *testing.T) {
 			}
 
 			for _, gotRow := range gotRows {
-				if !istats.ContainsRow(wantData.rows, gotRow) {
+				if !containsRow(wantData.rows, gotRow) {
 					t.Errorf("%q: unwanted row for view %q: %v", tc.label, wantData.v().Name(), gotRow)
 					break
 				}
 			}
 
 			for _, wantRow := range wantData.rows {
-				if !istats.ContainsRow(gotRows, wantRow) {
+				if !containsRow(gotRows, wantRow) {
 					t.Errorf("%q: missing row for view %q: %v", tc.label, wantData.v().Name(), wantRow)
 					break
 				}

--- a/stats/view.go
+++ b/stats/view.go
@@ -163,13 +163,3 @@ func (r *Row) Equal(other *Row) bool {
 
 	return reflect.DeepEqual(r.Tags, other.Tags) && r.Data.equal(other.Data)
 }
-
-// ContainsRow returns true if rows contain r.
-func ContainsRow(rows []*Row, r *Row) bool {
-	for _, x := range rows {
-		if r.Equal(x) {
-			return true
-		}
-	}
-	return false
-}

--- a/stats/view_test.go
+++ b/stats/view_test.go
@@ -170,14 +170,14 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowCumulative(t *testin
 
 		gotRows := vw1.collectedRows(time.Now())
 		for i, got := range gotRows {
-			if !ContainsRow(tc.wantRows, got) {
+			if !containsRow(tc.wantRows, got) {
 				t.Errorf("%v-%d: got row %v; want none", tc.label, i, got)
 				break
 			}
 		}
 
 		for i, want := range tc.wantRows {
-			if !ContainsRow(gotRows, want) {
+			if !containsRow(gotRows, want) {
 				t.Errorf("%v-%d: got none; want row %v", tc.label, i, want)
 				break
 			}
@@ -361,14 +361,14 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowSlidingTime(t *testi
 			gotRows := vw1.collectedRows(wantRows.retrieveTime)
 
 			for _, gotRow := range gotRows {
-				if !ContainsRow(wantRows.rows, gotRow) {
+				if !containsRow(wantRows.rows, gotRow) {
 					t.Errorf("got unexpected row '%v' for test case: '%v' with label '%v'", gotRow, tc.label, wantRows.label)
 					break
 				}
 			}
 
 			for _, wantRow := range wantRows.rows {
-				if !ContainsRow(gotRows, wantRow) {
+				if !containsRow(gotRows, wantRow) {
 					t.Errorf("want row '%v' for test case: '%v' with label '%v'. Not received", wantRow, tc.label, wantRows.label)
 					break
 				}
@@ -568,14 +568,14 @@ func Test_View_MeasureFloat64_AggregationCount_WindowSlidingTime(t *testing.T) {
 			gotRows := vw1.collectedRows(wantRows.retrieveTime)
 
 			for _, gotRow := range gotRows {
-				if !ContainsRow(wantRows.rows, gotRow) {
+				if !containsRow(wantRows.rows, gotRow) {
 					t.Errorf("got unexpected row '%v' for test case: '%v' with label '%v'", gotRow, tc.label, wantRows.label)
 					break
 				}
 			}
 
 			for _, wantRow := range wantRows.rows {
-				if !ContainsRow(gotRows, wantRow) {
+				if !containsRow(gotRows, wantRow) {
 					t.Errorf("want row '%v' for test case: '%v' with label '%v'. Not received", wantRow, tc.label, wantRows.label)
 					break
 				}
@@ -583,4 +583,14 @@ func Test_View_MeasureFloat64_AggregationCount_WindowSlidingTime(t *testing.T) {
 		}
 
 	}
+}
+
+// containsRow returns true if rows contain r.
+func containsRow(rows []*Row, r *Row) bool {
+	for _, x := range rows {
+		if r.Equal(x) {
+			return true
+		}
+	}
+	return false
 }

--- a/stats/worker_test.go
+++ b/stats/worker_test.go
@@ -578,13 +578,13 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 				t.Fatalf("%v: RetrieveData(%v) = %v; want no errors", tc.label, w.v.Name(), err)
 			}
 			for _, got := range gotRows {
-				if !ContainsRow(w.rows, got) {
+				if !containsRow(w.rows, got) {
 					t.Errorf("%v: got row %v; want none", tc.label, got)
 					break
 				}
 			}
 			for _, want := range w.rows {
-				if !ContainsRow(gotRows, want) {
+				if !containsRow(gotRows, want) {
 					t.Errorf("%v: got none; want %v'", tc.label, want)
 					break
 				}


### PR DESCRIPTION
It is a testing utility and fairly easy to reimplement.
Remove it from the external APIs.