### PR TITLE
Never handle ctx == nil case

### DIFF
--- a/plugins/grpc/grpcstats/client_handler.go
+++ b/plugins/grpc/grpcstats/client_handler.go
@@ -54,13 +54,6 @@ func (ch clientHandler) HandleConn(ctx context.Context, s stats.ConnStats) {
 // its tags into the GRPC metadata in order to be sent to the server.
 func (ch clientHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
 	startTime := time.Now()
-	if ctx == nil {
-		if glog.V(2) {
-			glog.Infoln("clientHandler.TagRPC called with nil context")
-		}
-		return ctx
-	}
-
 	if info == nil {
 		if glog.V(2) {
 			glog.Infof("clientHandler.TagRPC called with nil info.", info.FullMethodName)

--- a/plugins/grpc/grpcstats/client_metrics.go
+++ b/plugins/grpc/grpcstats/client_metrics.go
@@ -16,7 +16,7 @@
 package grpcstats
 
 import (
-	"fmt"
+	"log"
 
 	"go.opencensus.io/stats"
 	"go.opencensus.io/tag"
@@ -71,29 +71,28 @@ func defaultClientMeasures() {
 
 	// Creating client measures
 	if RPCClientErrorCount, err = stats.NewMeasureInt64("/grpc.io/client/error_count", "RPC Errors", unitCount); err != nil {
-		panic(fmt.Sprintf("createDefaultMeasuresClient failed for measure grpc.io/client/error_count. %v", err))
+		log.Fatalf("Cannot create measure /grpc.io/client/error_count: %v", err)
 	}
 	if RPCClientRoundTripLatency, err = stats.NewMeasureFloat64("/grpc.io/client/roundtrip_latency", "RPC roundtrip latency in msecs", unitMillisecond); err != nil {
-		panic(fmt.Sprintf("createDefaultMeasuresClient failed for measure grpc.io/client/roundtrip_latency. %v", err))
+		log.Fatalf("Cannot create measure /grpc.io/client/roundtrip_latency: %v", err)
 	}
 	if RPCClientRequestBytes, err = stats.NewMeasureInt64("/grpc.io/client/request_bytes", "Request bytes", unitByte); err != nil {
-		panic(fmt.Sprintf("createDefaultMeasuresClient failed for measure grpc.io/client/request_bytes. %v", err))
+		log.Fatalf("Cannot create measure /grpc.io/client/request_bytes: %v", err)
 	}
 	if RPCClientResponseBytes, err = stats.NewMeasureInt64("/grpc.io/client/response_bytes", "Response bytes", unitByte); err != nil {
-		panic(fmt.Sprintf("createDefaultMeasuresClient failed for measure grpc.io/client/response_bytes. %v", err))
+		log.Fatalf("Cannot create measure /grpc.io/client/response_bytes: %v", err)
 	}
 	if RPCClientStartedCount, err = stats.NewMeasureInt64("/grpc.io/client/started_count", "Number of client RPCs (streams) started", unitCount); err != nil {
-		panic(fmt.Sprintf("createDefaultMeasuresClient failed for measure rpc/client/started_count. %v", err))
+		log.Fatalf("Cannot create measure /grpc.io/client/started_count: %v", err)
 	}
 	if RPCClientFinishedCount, err = stats.NewMeasureInt64("/grpc.io/client/finished_count", "Number of client RPCs (streams) finished", unitCount); err != nil {
-		panic(fmt.Sprintf("createDefaultMeasuresClient failed for measure /grpc.io/client/finished_count. %v", err))
+		log.Fatalf("Cannot create measure /grpc.io/client/finished_count: %v", err)
 	}
-
 	if RPCClientRequestCount, err = stats.NewMeasureInt64("/grpc.io/client/request_count", "Number of client RPC request messages", unitCount); err != nil {
-		panic(fmt.Sprintf("createDefaultMeasuresClient failed for measure rpc/client/request_count. %v", err))
+		log.Fatalf("Cannot create measure /grpc.io/client/request_count: %v", err)
 	}
 	if RPCClientResponseCount, err = stats.NewMeasureInt64("/grpc.io/client/response_count", "Number of client RPC response messages", unitCount); err != nil {
-		panic(fmt.Sprintf("createDefaultMeasuresClient failed for measure /grpc.io/client/response_count. %v", err))
+		log.Fatalf("Cannot create measure /grpc.io/client/response_count: %v", err)
 	}
 }
 

--- a/plugins/grpc/grpcstats/server_handler.go
+++ b/plugins/grpc/grpcstats/server_handler.go
@@ -59,12 +59,6 @@ func (sh serverHandler) HandleConn(ctx context.Context, s stats.ConnStats) {
 // returns the new ctx.
 func (sh serverHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
 	startTime := time.Now()
-	if ctx == nil {
-		if glog.V(2) {
-			glog.Infoln("serverHandler.TagRPC called with nil context")
-		}
-		return ctx
-	}
 	if info == nil {
 		if glog.V(2) {
 			glog.Infof("serverHandler.TagRPC called with nil info.", info.FullMethodName)

--- a/plugins/grpc/grpcstats/server_metrics.go
+++ b/plugins/grpc/grpcstats/server_metrics.go
@@ -16,7 +16,7 @@
 package grpcstats
 
 import (
-	"fmt"
+	"log"
 
 	"go.opencensus.io/stats"
 	"go.opencensus.io/tag"
@@ -71,29 +71,28 @@ func defaultServerMeasures() {
 
 	// Creating server measures
 	if RPCServerErrorCount, err = stats.NewMeasureInt64("/grpc.io/server/error_count", "RPC Errors", unitCount); err != nil {
-		panic(fmt.Sprintf("createDefaultMeasuresServer failed for measure /grpc.io/server/error_count. %v", err))
+		log.Fatalf("Cannot create measure /grpc.io/server/error_count: %v", err)
 	}
 	if RPCServerServerElapsedTime, err = stats.NewMeasureFloat64("/grpc.io/server/server_elapsed_time", "Server elapsed time in msecs", unitMillisecond); err != nil {
-		panic(fmt.Sprintf("createDefaultMeasuresServer failed for measure /grpc.io/server/server_elapsed_time. %v", err))
+		log.Fatalf("Cannot create measure /grpc.io/server/server_elapsed_time: %v", err)
 	}
 	if RPCServerRequestBytes, err = stats.NewMeasureInt64("/grpc.io/server/request_bytes", "Request bytes", unitByte); err != nil {
-		panic(fmt.Sprintf("createDefaultMeasuresServer failed for measure /grpc.io/server/request_bytes. %v", err))
+		log.Fatalf("Cannot create measure /grpc.io/server/request_bytes: %v", err)
 	}
 	if RPCServerResponseBytes, err = stats.NewMeasureInt64("/grpc.io/server/response_bytes", "Response bytes", unitByte); err != nil {
-		panic(fmt.Sprintf("createDefaultMeasuresServer failed for measure /grpc.io/server/response_bytes. %v", err))
+		log.Fatalf("Cannot create measure /grpc.io/server/response_bytes: %v", err)
 	}
 	if RPCServerStartedCount, err = stats.NewMeasureInt64("/grpc.io/server/started_count", "Number of server RPCs (streams) started", unitCount); err != nil {
-		panic(fmt.Sprintf("createDefaultMeasuresServer failed for measure rpc/server/started_count. %v", err))
+		log.Fatalf("Cannot create measure /grpc.io/server/started_count: %v", err)
 	}
 	if RPCServerFinishedCount, err = stats.NewMeasureInt64("/grpc.io/server/finished_count", "Number of server RPCs (streams) finished", unitCount); err != nil {
-		panic(fmt.Sprintf("createDefaultMeasuresServer failed for measure /grpc.io/server/finished_count. %v", err))
+		log.Fatalf("Cannot create measure /grpc.io/server/finished_count: %v", err)
 	}
-
 	if RPCServerRequestCount, err = stats.NewMeasureInt64("/grpc.io/server/request_count", "Number of server RPC request messages", unitCount); err != nil {
-		panic(fmt.Sprintf("createDefaultMeasuresServer failed for measure rpc/server/request_count. %v", err))
+		log.Fatalf("Cannot create measure /grpc.io/server/request_count: %v", err)
 	}
 	if RPCServerResponseCount, err = stats.NewMeasureInt64("/grpc.io/server/response_count", "Number of server RPC response messages", unitCount); err != nil {
-		panic(fmt.Sprintf("createDefaultMeasuresServer failed for measure /grpc.io/server/response_count. %v", err))
+		log.Fatalf("Cannot create measure /grpc.io/server/response_count: %v", err)
 	}
 }
 


### PR DESCRIPTION
context package documents that users should never pass
pass a nil context. Libraries do not need to handle this case.

Also replace panic(fmt.Sprintf) with log.Fatalf.