### PR TITLE
Only escape the metric descriptor resource name

### DIFF
--- a/exporter/stats/stackdriver/stackdriver_test.go
+++ b/exporter/stats/stackdriver/stackdriver_test.go
@@ -60,7 +60,7 @@ func TestExporter_makeReq(t *testing.T) {
 				TimeSeries: []*monitoringpb.TimeSeries{
 					{
 						Metric: &metricpb.Metric{
-							Type: "custom.googleapis.com/opencensus%2Fcumview",
+							Type: "custom.googleapis.com/opencensus/cumview",
 						},
 						Resource: &monitoredrespb.MonitoredResource{
 							Type:   "global",
@@ -86,7 +86,7 @@ func TestExporter_makeReq(t *testing.T) {
 					},
 					{
 						Metric: &metricpb.Metric{
-							Type: "custom.googleapis.com/opencensus%2Fcumview",
+							Type: "custom.googleapis.com/opencensus/cumview",
 						},
 						Resource: &monitoredrespb.MonitoredResource{
 							Type:   "global",


### PR DESCRIPTION
Otherwise, UI also displays the escaped the name.