### PR TITLE
Access atomic variables always atomically

### DIFF
--- a/plugin/grpc/grpcstats/grpcstats.go
+++ b/plugin/grpc/grpcstats/grpcstats.go
@@ -34,7 +34,7 @@ type rpcData struct {
 	// beginning of an RPC. It is an appoximation of the time when the
 	// application code invoked GRPC code.
 	startTime           time.Time
-	reqCount, respCount uint64
+	reqCount, respCount int64 // access atomically
 }
 
 // The following variables define the default hard-coded auxiliary data used by


### PR DESCRIPTION
- Convert reqCount and respCount to int64 to match the measure type.
- Don't just write them atomically, also read them atomically.

Fixes #151.