### PR TITLE
stats: setReportingPeriodReq.handleCommand should never block

### DIFF
--- a/stats/worker_commands.go
+++ b/stats/worker_commands.go
@@ -235,10 +235,10 @@ type setReportingPeriodReq struct {
 
 func (cmd *setReportingPeriodReq) handleCommand(w *worker) {
 	w.timer.Stop()
-	if cmd.d <= 0*time.Second {
+	if cmd.d <= 0 {
 		w.timer = time.NewTicker(defaultReportingDuration)
-		return
+	} else {
+		w.timer = time.NewTicker(cmd.d)
 	}
-	w.timer = time.NewTicker(cmd.d)
 	cmd.c <- true
 }


### PR DESCRIPTION
Ensure that *setReportingPeriodReq.handleCommand always
sends to the command's channel, even when the worker's
duration <= 0.

Fixes #150