### PR TITLE
Export ClientStatsHandler and ServerStatsHandler from grpcstats

### DIFF
--- a/plugin/grpc/example_test.go
+++ b/plugin/grpc/example_test.go
@@ -1,0 +1,50 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpc_test
+
+import (
+	"log"
+
+	ocgrpc "go.opencensus.io/plugin/grpc"
+	"go.opencensus.io/plugin/grpc/grpcstats"
+	"google.golang.org/grpc"
+)
+
+func ExampleNewClientStatsHandler() {
+	// Subscribe to collect client request count.
+	if err := grpcstats.RPCClientRequestCountView.Subscribe(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Set up a connection to the server with the OpenCensus
+	// stats handler to enable stats and tracing.
+	conn, err := grpc.Dial("address", grpc.WithStatsHandler(ocgrpc.NewClientStatsHandler()))
+	if err != nil {
+		log.Fatalf("did not connect: %v", err)
+	}
+	defer conn.Close()
+}
+
+func ExampleNewServerStatsHandler() {
+	// Subscribe to collect server request count.
+	if err := grpcstats.RPCServerRequestCountView.Subscribe(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Set up a new server with the OpenCensus
+	// stats handler to enable stats and tracing.
+	s := grpc.NewServer(grpc.StatsHandler(ocgrpc.NewServerStatsHandler()))
+	_ = s // use s
+}

--- a/plugin/grpc/grpc.go
+++ b/plugin/grpc/grpc.go
@@ -30,8 +30,8 @@ import (
 // on, see grpcstats and grpctrace packages.
 func NewClientStatsHandler() stats.Handler {
 	return handler{
-		grpcstats.NewClientStatsHandler(),
-		grpctrace.NewClientStatsHandler(),
+		&grpcstats.ClientStatsHandler{},
+		&grpctrace.ClientStatsHandler{},
 	}
 }
 
@@ -40,8 +40,8 @@ func NewClientStatsHandler() stats.Handler {
 // on, see grpcstats and grpctrace packages.
 func NewServerStatsHandler() stats.Handler {
 	return handler{
-		grpcstats.NewServerStatsHandler(),
-		grpctrace.NewServerStatsHandler(),
+		&grpcstats.ServerStatsHandler{},
+		&grpctrace.ServerStatsHandler{},
 	}
 }
 

--- a/plugin/grpc/grpcstats/client_handler_test.go
+++ b/plugin/grpc/grpcstats/client_handler_test.go
@@ -315,7 +315,7 @@ func TestClientDefaultCollections(t *testing.T) {
 			}
 		}
 
-		h := NewClientStatsHandler()
+		h := &ClientStatsHandler{}
 		for _, rpc := range tc.rpcs {
 			mods := []tag.Mutator{}
 			for _, t := range rpc.tags {

--- a/plugin/grpc/grpcstats/example_test.go
+++ b/plugin/grpc/grpcstats/example_test.go
@@ -1,0 +1,49 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpcstats_test
+
+import (
+	"log"
+
+	"go.opencensus.io/plugin/grpc/grpcstats"
+	"google.golang.org/grpc"
+)
+
+func ExampleNewClientStatsHandler() {
+	// Subscribe to collect client request count.
+	if err := grpcstats.RPCClientRequestCountView.Subscribe(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Set up a new client connection with the OpenCensus
+	// stats handler to enable stats collection from the views.
+	conn, err := grpc.Dial("address", grpc.WithStatsHandler(grpcstats.NewClientStatsHandler()))
+	if err != nil {
+		log.Fatalf("did not connect: %v", err)
+	}
+	defer conn.Close()
+}
+
+func ExampleNewServerStatsHandler() {
+	// Subscribe to collect server request count.
+	if err := grpcstats.RPCServerRequestCountView.Subscribe(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Set up a new server with the OpenCensus stats handler
+	// to enable stats collection from the views.
+	s := grpc.NewServer(grpc.StatsHandler(grpcstats.NewClientStatsHandler()))
+	_ = s // use s
+}

--- a/plugin/grpc/grpcstats/server_handler_test.go
+++ b/plugin/grpc/grpcstats/server_handler_test.go
@@ -314,7 +314,7 @@ func TestServerDefaultCollections(t *testing.T) {
 			}
 		}
 
-		h := NewServerStatsHandler()
+		h := &ServerStatsHandler{}
 		for _, rpc := range tc.rpcs {
 			mods := []tag.Mutator{}
 			for _, t := range rpc.tags {

--- a/plugin/grpc/grpctrace/example_test.go
+++ b/plugin/grpc/grpctrace/example_test.go
@@ -1,0 +1,39 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpctrace_test
+
+import (
+	"log"
+
+	"go.opencensus.io/plugin/grpc/grpctrace"
+	"google.golang.org/grpc"
+)
+
+func ExampleNewClientStatsHandler() {
+	// Set up a new client connection with the OpenCensus
+	// stats handler to enable tracing for the outgoing requests.
+	conn, err := grpc.Dial("address", grpc.WithStatsHandler(grpctrace.NewClientStatsHandler()))
+	if err != nil {
+		log.Fatalf("did not connect: %v", err)
+	}
+	defer conn.Close()
+}
+
+func ExampleNewServerStatsHandler() {
+	// Set up a new client connection with the OpenCensus
+	// stats handler to enable tracing for the incoming requests.
+	s := grpc.NewServer(grpc.StatsHandler(grpctrace.NewServerStatsHandler()))
+	_ = s // use s
+}

--- a/plugin/grpc/grpctrace/grpc.go
+++ b/plugin/grpc/grpctrace/grpc.go
@@ -26,17 +26,13 @@ import (
 	"google.golang.org/grpc/stats"
 )
 
-// ClientStatsHandler is a an implementation of grpc.StatsHandler.
-type ClientStatsHandler struct {
-}
+// ClientStatsHandler is a an implementation of grpc.StatsHandler
+// that can be passed to grpc.Dial
+// using grpc.WithStatsHandler to enable trace context propagation and
+// automatic span creation for outgoing gRPC requests.
+type ClientStatsHandler struct{}
 
 var _ stats.Handler = &ClientStatsHandler{}
-
-// ServerStatsHandler is a an implementation of grpc.StatsHandler.
-type ServerStatsHandler struct {
-}
-
-var _ stats.Handler = &ServerStatsHandler{}
 
 // NewClientStatsHandler returns a StatsHandler that can be passed to grpc.Dial
 // using grpc.WithStatsHandler to enable trace context propagation and
@@ -45,12 +41,23 @@ func NewClientStatsHandler() *ClientStatsHandler {
 	return &ClientStatsHandler{}
 }
 
+// TODO(jbd): Remove NewClientStatsHandler and NewServerStatsHandler
+// given they are not doing anything than returning a zero value pointer.
+
+// ServerStatsHandler is a an implementation of grpc.StatsHandler
+// that can be passed to grpc.NewServer using grpc.StatsHandler
+// to enable trace context propagation and automatic span creation
+// for incoming gRPC requests..
+type ServerStatsHandler struct{}
+
 // NewServerStatsHandler returns a StatsHandler that can be passed to
 // grpc.NewServer using grpc.StatsHandler to enable trace context propagation
 // and automatic span creation for incoming gRPC requests.
 func NewServerStatsHandler() *ServerStatsHandler {
 	return &ServerStatsHandler{}
 }
+
+var _ stats.Handler = &ServerStatsHandler{}
 
 const traceContextKey = "grpc-trace-bin"
 

--- a/plugin/grpc/grpctrace/grpc_test.go
+++ b/plugin/grpc/grpctrace/grpc_test.go
@@ -34,7 +34,6 @@ func (s *testServer) Single(ctx context.Context, in *testpb.FooRequest) (*testpb
 	if in.Fail {
 		return nil, fmt.Errorf("request failed")
 	}
-
 	return &testpb.FooResponse{}, nil
 }
 
@@ -62,12 +61,12 @@ func newTestClientAndServer() (client testpb.FooClient, server *grpc.Server, cle
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("net.Listen: %v", err)
 	}
-	server = grpc.NewServer(grpc.StatsHandler(grpctrace.NewServerStatsHandler()))
+	server = grpc.NewServer(grpc.StatsHandler(&grpctrace.ServerStatsHandler{}))
 	testpb.RegisterFooServer(server, &testServer{})
 	go server.Serve(listener)
 
 	// initialize client
-	clientConn, err := grpc.Dial(listener.Addr().String(), grpc.WithInsecure(), grpc.WithStatsHandler(grpctrace.NewClientStatsHandler()), grpc.WithBlock())
+	clientConn, err := grpc.Dial(listener.Addr().String(), grpc.WithInsecure(), grpc.WithStatsHandler(&grpctrace.ClientStatsHandler{}), grpc.WithBlock())
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("grpc.Dial: %v", err)
 	}


### PR DESCRIPTION
Exporting these handlers makes the package more compatible with
the grpctrace package and allow us to document the behavior via godoc.

/cc @dfawley