### PR TITLE
Remove project id resource label

### DIFF
--- a/exporter/stats/stackdriver/stackdriver.go
+++ b/exporter/stats/stackdriver/stackdriver.go
@@ -172,8 +172,7 @@ func (e *Exporter) makeReq(vds []*stats.ViewData) *monitoringpb.CreateTimeSeries
 					Labels: newLabels(row.Tags),
 				},
 				Resource: &monitoredrespb.MonitoredResource{
-					Type:   "global",
-					Labels: map[string]string{"project_id": e.o.ProjectID},
+					Type: "global",
 				},
 				Points: []*monitoringpb.Point{newPoint(vd.View, row, vd.Start, vd.End)},
 			}

--- a/exporter/stats/stackdriver/stackdriver_test.go
+++ b/exporter/stats/stackdriver/stackdriver_test.go
@@ -80,7 +80,6 @@ func TestExporter_makeReq(t *testing.T) {
 						},
 						Resource: &monitoredrespb.MonitoredResource{
 							Type:   "global",
-							Labels: map[string]string{"project_id": "proj-id"},
 						},
 						Points: []*monitoringpb.Point{
 							{
@@ -107,7 +106,6 @@ func TestExporter_makeReq(t *testing.T) {
 						},
 						Resource: &monitoredrespb.MonitoredResource{
 							Type:   "global",
-							Labels: map[string]string{"project_id": "proj-id"},
 						},
 						Points: []*monitoringpb.Point{
 							{


### PR DESCRIPTION
To be consistent with https://github.com/census-instrumentation/opencensus-java/pull/832. We don't need this label since project id is already set in CreateTimeSeriesRequest and CreateMetricDescriptor.

In the future we might want to support custom resource labels.