### PR TITLE
Add sanitization to tag key names for Exporter

### DIFF
--- a/exporter/stats/stackdriver/stackdriver.go
+++ b/exporter/stats/stackdriver/stackdriver.go
@@ -407,9 +407,11 @@ func sanitize(s string) string {
 	return strings.Map(sanitizeRune, s)
 }
 
+// converts anything that is not a letter or digit to an underscore
 func sanitizeRune(r rune) rune {
-	if unicode.IsLetter(r) || unicode.IsDigit(r) || r == 95 {
+	if unicode.IsLetter(r) || unicode.IsDigit(r) {
 		return r
 	}
-	return 95 // Sanitize everything that is not letter, digit or underscore to underscore
+	// Everything else turns into an underscore
+	return '_'
 }

--- a/exporter/stats/stackdriver/stackdriver.go
+++ b/exporter/stats/stackdriver/stackdriver.go
@@ -338,14 +338,12 @@ func newLabels(tags []tag.Tag) map[string]string {
 }
 
 func newLabelDescriptors(keys []tag.Key) []*labelpb.LabelDescriptor {
-	labelDescriptors := make([]*labelpb.LabelDescriptor, 0, len(keys))
-	for _, key := range keys {
-		labelDescriptors = append(
-			labelDescriptors,
-			&labelpb.LabelDescriptor{
-				Key:       sanitize(key.Name()),
-				ValueType: labelpb.LabelDescriptor_STRING, // We only use string tags
-			})
+	labelDescriptors := make([]*labelpb.LabelDescriptor, len(keys))
+	for i, key := range keys {
+		labelDescriptors[i] = &labelpb.LabelDescriptor{
+			Key:       sanitize(key.Name()),
+			ValueType: labelpb.LabelDescriptor_STRING, // We only use string tags
+		}
 	}
 	return labelDescriptors
 }
@@ -410,8 +408,8 @@ func sanitize(s string) string {
 }
 
 func sanitizeRune(r rune) rune {
-	if !(unicode.IsLetter(r) || unicode.IsDigit(r) || r == 95) {
-		r = 95 // Sanitize everything that is not letter, digit or underscore to underscore
+	if unicode.IsLetter(r) || unicode.IsDigit(r) || r == 95 {
+		return r
 	}
-	return r
+	return 95 // Sanitize everything that is not letter, digit or underscore to underscore
 }

--- a/exporter/stats/stackdriver/stackdriver_test.go
+++ b/exporter/stats/stackdriver/stackdriver_test.go
@@ -252,32 +252,31 @@ func TestEqualAggWindowTagKeys(t *testing.T) {
 
 func TestSanitize(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    string
-		expected string
+		name  string
+		input string
+		want  string
 	}{
 		{
-			name:     "trunacate long string",
-			input:    strings.Repeat("a", 101),
-			expected: strings.Repeat("a", 100),
+			name:  "trunacate long string",
+			input: strings.Repeat("a", 101),
+			want:  strings.Repeat("a", 100),
 		},
 		{
-			name:     "replace character",
-			input:    "test/key-1",
-			expected: "test_key_1",
+			name:  "replace character",
+			input: "test/key-1",
+			want:  "test_key_1",
 		},
 		{
-			name:     "don't modify alphanumeric string",
-			input:    "testkey1",
-			expected: "testkey1",
+			name:  "don't modify alphanumeric string",
+			input: "0123456789_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz",
+			want:  "0123456789_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual := sanitize(tt.input)
-			if actual != tt.expected {
-				t.Errorf("sanitize() = %s; want %s", actual, tt.expected)
+			if got, want := sanitize(tt.input), tt.want; got != want {
+				t.Errorf("sanitize() = %q; want %q", got, want)
 			}
 		})
 	}

--- a/exporter/stats/stackdriver/stackdriver_test.go
+++ b/exporter/stats/stackdriver/stackdriver_test.go
@@ -16,7 +16,6 @@ package stackdriver
 
 import (
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 
@@ -246,38 +245,6 @@ func TestEqualAggWindowTagKeys(t *testing.T) {
 				t.Errorf("equalAggWindowTagKeys() = %q; want error", err)
 			}
 
-		})
-	}
-}
-
-func TestSanitize(t *testing.T) {
-	tests := []struct {
-		name  string
-		input string
-		want  string
-	}{
-		{
-			name:  "trunacate long string",
-			input: strings.Repeat("a", 101),
-			want:  strings.Repeat("a", 100),
-		},
-		{
-			name:  "replace character",
-			input: "test/key-1",
-			want:  "test_key_1",
-		},
-		{
-			name:  "don't modify alphanumeric string",
-			input: "0123456789_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz",
-			want:  "0123456789_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got, want := sanitize(tt.input), tt.want; got != want {
-				t.Errorf("sanitize() = %q; want %q", got, want)
-			}
 		})
 	}
 }

--- a/internal/sanitize.go
+++ b/internal/sanitize.go
@@ -1,0 +1,40 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"strings"
+	"unicode"
+)
+
+const labelKeySizeLimit = 100
+
+// Sanitize returns a string that is trunacated to 100 characters if it's too
+// long, and replaces non-alphanumeric characters to underscores.
+func Sanitize(s string) string {
+	if len(s) > labelKeySizeLimit {
+		s = s[:labelKeySizeLimit]
+	}
+	return strings.Map(sanitizeRune, s)
+}
+
+// converts anything that is not a letter or digit to an underscore
+func sanitizeRune(r rune) rune {
+	if unicode.IsLetter(r) || unicode.IsDigit(r) {
+		return r
+	}
+	// Everything else turns into an underscore
+	return '_'
+}

--- a/internal/sanitize_test.go
+++ b/internal/sanitize_test.go
@@ -1,0 +1,52 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitize(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "trunacate long string",
+			input: strings.Repeat("a", 101),
+			want:  strings.Repeat("a", 100),
+		},
+		{
+			name:  "replace character",
+			input: "test/key-1",
+			want:  "test_key_1",
+		},
+		{
+			name:  "don't modify alphanumeric string",
+			input: "0123456789_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz",
+			want:  "0123456789_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got, want := Sanitize(tt.input), tt.want; got != want {
+				t.Errorf("sanitize() = %q; want %q", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Quote from @jcd2 :
> The tag keys will need to be escaped for Stackdriver. It limits length to 100 and only accepts some characters. Letters, digits and underscores work.