### PR TITLE
exporter/stats/stackdriver: Avoid repetiton, use type switched type

### DIFF
--- a/exporter/stats/stackdriver/stackdriver.go
+++ b/exporter/stats/stackdriver/stackdriver.go
@@ -284,14 +284,12 @@ func newPoint(v *stats.View, row *stats.Row, start, end time.Time) *monitoringpb
 }
 
 func newTypedValue(view *stats.View, r *stats.Row) *monitoringpb.TypedValue {
-	switch r.Data.(type) {
+	switch v := r.Data.(type) {
 	case *stats.CountData:
-		v := r.Data.(*stats.CountData)
 		return &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{
 			Int64Value: int64(*v),
 		}}
 	case *stats.DistributionData:
-		v := r.Data.(*stats.DistributionData)
 		bounds := view.Aggregation().(stats.DistributionAggregation)
 		return &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_DistributionValue{
 			DistributionValue: &distributionpb.Distribution{


### PR DESCRIPTION
Type switching then receiving the value, while in a switch
avoids the need for us to perform the same type assertion,
so let's reuse that type.