### PR TITLE
Sanitize tag keys when looking up for the matching metric descriptor

### DIFF
--- a/exporter/stats/stackdriver/stackdriver.go
+++ b/exporter/stats/stackdriver/stackdriver.go
@@ -382,7 +382,7 @@ func equalAggWindowTagKeys(md *metricpb.MetricDescriptor, agg stats.Aggregation,
 
 	labels := make(map[string]struct{}, len(keys))
 	for _, k := range keys {
-		labels[k.Name()] = struct{}{}
+		labels[internal.Sanitize(k.Name())] = struct{}{}
 	}
 
 	for _, k := range md.Labels {

--- a/exporter/stats/stackdriver/stackdriver_test.go
+++ b/exporter/stats/stackdriver/stackdriver_test.go
@@ -148,8 +148,8 @@ func TestExporter_makeReq(t *testing.T) {
 }
 
 func TestEqualAggWindowTagKeys(t *testing.T) {
-	key1, _ := tag.NewKey("test_key_one")
-	key2, _ := tag.NewKey("test_key_two")
+	key1, _ := tag.NewKey("test-key-one")
+	key2, _ := tag.NewKey("test-key-two")
 	tests := []struct {
 		name    string
 		md      *metricpb.MetricDescriptor

--- a/internal/sanitize.go
+++ b/internal/sanitize.go
@@ -24,6 +24,15 @@ const labelKeySizeLimit = 100
 // Sanitize returns a string that is trunacated to 100 characters if it's too
 // long, and replaces non-alphanumeric characters to underscores.
 func Sanitize(s string) string {
+	if len(s) == 0 {
+		return s
+	}
+	if unicode.IsDigit(rune(s[0])) {
+		s = "key_" + s
+	}
+	if s[0] == '_' {
+		s = "key" + s
+	}
 	if len(s) > labelKeySizeLimit {
 		s = s[:labelKeySizeLimit]
 	}

--- a/internal/sanitize_test.go
+++ b/internal/sanitize_test.go
@@ -37,8 +37,18 @@ func TestSanitize(t *testing.T) {
 		},
 		{
 			name:  "don't modify alphanumeric string",
-			input: "0123456789_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz",
-			want:  "0123456789_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz",
+			input: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_0123456789",
+			want:  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_0123456789",
+		},
+		{
+			name:  "add prefix if starting with digit",
+			input: "0123456789",
+			want:  "key_0123456789",
+		},
+		{
+			name:  "add prefix if starting with _",
+			input: "_0123456789",
+			want:  "key_0123456789",
 		},
 	}
 

--- a/internal/sanitize_test.go
+++ b/internal/sanitize_test.go
@@ -36,11 +36,6 @@ func TestSanitize(t *testing.T) {
 			want:  "test_key_1",
 		},
 		{
-			name:  "don't modify alphanumeric string",
-			input: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_0123456789",
-			want:  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_0123456789",
-		},
-		{
 			name:  "add prefix if starting with digit",
 			input: "0123456789",
 			want:  "key_0123456789",
@@ -49,6 +44,11 @@ func TestSanitize(t *testing.T) {
 			name:  "add prefix if starting with _",
 			input: "_0123456789",
 			want:  "key_0123456789",
+		},
+		{
+			name:  "valid input",
+			input: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_0123456789",
+			want:  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_0123456789",
 		},
 	}
 


### PR DESCRIPTION
Updates #173.