### PR TITLE
Implement prometheus exporter with [Count, Distribution] Aggregation

### DIFF
--- a/examples/stats/prometheus/main.go
+++ b/examples/stats/prometheus/main.go
@@ -91,10 +91,9 @@ func main() {
 	// Set reporting period to report data at every second.
 	stats.SetReportingPeriod(1 * time.Second)
 
-	// Goroutine to record some data points.
+	// Record some data points...
 	go func() {
 		for {
-			// Record some data points.
 			stats.Record(ctx, videoCount.M(1))
 			stats.Record(ctx, videoSize.M(rand.Int63()))
 			<-time.After(time.Millisecond * time.Duration(1+rand.Intn(400)))

--- a/exporter/stats/prometheus/prometheus.go
+++ b/exporter/stats/prometheus/prometheus.go
@@ -21,10 +21,18 @@ package prometheus
 import (
 	"log"
 	"net/http"
+	"sync"
+
+	"go.opencensus.io/internal"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"go.opencensus.io/stats"
+)
+
+const (
+	defaultNamespace = "opencensus"
 )
 
 // Exporter exports stats to Prometheus, users need
@@ -39,39 +47,86 @@ type Exporter struct {
 
 // Options contains options for configuring the exporter.
 type Options struct {
-	OnError func(err error)
-}
-
-type collector struct {
-	descs   []*prometheus.Desc
-	metrics []prometheus.Metric
-}
-
-func (c *collector) Describe(ch chan<- *prometheus.Desc) {
-	panic("not implemented")
-}
-
-func (c *collector) Collect(ch chan<- prometheus.Metric) {
-	panic("not implemented")
+	Namespace string
+	OnError   func(err error)
 }
 
 // NewExporter returns an exporter that exports stats to Prometheus.
 func NewExporter(o Options) (*Exporter, error) {
-	r := prometheus.NewRegistry()
-	collector := &collector{}
+	reg := prometheus.NewRegistry()
+	collector := newCollector(o, reg)
 	e := &Exporter{
 		opts:    o,
-		g:       r,
+		g:       reg,
 		c:       collector,
-		handler: promhttp.HandlerFor(r, promhttp.HandlerOpts{}),
+		handler: promhttp.HandlerFor(reg, promhttp.HandlerOpts{}),
 	}
-	go func() {
-		if err := r.Register(collector); err != nil {
-			e.onError(err)
-		}
-	}()
-	// TODO(jbd): Implement a Close function to unregister.
 	return e, nil
+}
+
+var _ http.Handler = (*Exporter)(nil)
+var _ stats.Exporter = (*Exporter)(nil)
+var _ stats.ViewRegistrar = (*Exporter)(nil)
+
+// RegisterView is the hook that's run either intentionally
+// by the client or the stat's library will automatically invoke
+// it everytime that a new view is added.
+func (e *Exporter) RegisterView(view *stats.View) {
+	e.c.registerViews(view)
+}
+
+func (e *Exporter) UnregisterView(view *stats.View) {
+	// TODO: (@rakyll, @odeke-em) implement UnregisterView.
+}
+
+func (c *collector) namespace() string {
+	c.mu.RLock()
+	ns := c.opts.Namespace
+	if ns == "" {
+		ns = defaultNamespace
+	}
+	c.mu.RUnlock()
+	return ns
+}
+
+func (c *collector) registerViews(views ...*stats.View) {
+	if len(views) == 0 {
+		return
+	}
+
+	namespace := c.namespace()
+
+	newViewCount := 0
+	for _, view := range views {
+		c.mu.Lock()
+		if _, registered := c.registeredViews[view]; !registered {
+			desc := prometheus.NewDesc(
+				internal.Sanitize(namespace+"_"+view.Name()),
+				view.Description(),
+				tagKeysToLabels(view.TagKeys()),
+				nil,
+			)
+			c.registeredViews[view] = true
+			c.descs = append(c.descs, desc)
+			newViewCount += 1
+		}
+		c.mu.Unlock()
+	}
+
+	if newViewCount == 0 {
+		return
+	}
+
+	c.mu.Lock()
+	reg := c.reg
+	c.mu.Unlock()
+
+	if ok := reg.Unregister(c); !ok {
+		log.Printf("unregister could not unregister: %v", c)
+	}
+	if err := reg.Register(c); err != nil {
+		log.Printf("register err: %v", err)
+	}
 }
 
 func (e *Exporter) onError(err error) {
@@ -87,12 +142,182 @@ func (e *Exporter) Export(vd *stats.ViewData) {
 	if len(vd.Rows) == 0 {
 		return
 	}
-	// TODO(jbd,odeke-em): Make sure Export is not blocking
-	// for a long period of time.
-	panic("not implemented")
+
+	e.c.addViewData(vd)
 }
 
 // ServeHTTP serves the Prometheus endpoint.
 func (e *Exporter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	e.handler.ServeHTTP(w, r)
+}
+
+// collector implements prometheus.Collector
+type collector struct {
+	opts Options
+	mu   sync.RWMutex
+
+	// reg helps us keep a reference to our registrar
+	// so that when views are dynamically added, we'll
+	// able to register again without having to expose
+	// an ugly API for the client in which they'll have
+	// to invoke RegisterView for every single view that
+	// they create.
+	reg *prometheus.Registry
+
+	// views are accumulated and atomically
+	// appended to on every Export invocation, from
+	// stats. These views are cleared out when
+	// Collect is invoked and the cycle is repeated.
+	views []*stats.ViewData
+
+	// descs contains the one-time listing of all
+	// descriptions that are retrieved after converting
+	// each view into a prometheus.Metric.
+	//
+	// Note: we use slices here because trying to use channels
+	// with Prometheus.Collector Describe and Collect methods
+	// is quite hairy, moreover for methods that are run once,
+	// yet the count of elements to be collected is unknown
+	// trying to drain our input channel could potential block forever.
+	descs []*prometheus.Desc
+
+	registeredViews map[*stats.View]bool
+
+	// seenMetrics maps from the metric's rawType to the actual Metric.
+	// It is an interface to interface mapping
+	// but the key is the zero value while the value is the instance.
+	seenMetrics map[interface{}]prometheus.Metric
+}
+
+var _ prometheus.Collector = (*collector)(nil)
+
+func (c *collector) Describe(ch chan<- *prometheus.Desc) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	for _, desc := range c.descs {
+		ch <- desc
+	}
+}
+
+func (c *collector) lookupMetric(key interface{}) (prometheus.Metric, bool) {
+	c.mu.RLock()
+	value, ok := c.seenMetrics[key]
+	c.mu.RUnlock()
+	return value, ok
+}
+
+func (c *collector) memoizeMetric(key interface{}, value prometheus.Metric) {
+	c.mu.Lock()
+	c.seenMetrics[key] = value
+	c.mu.Unlock()
+}
+
+// Collect fetches the statistics from OpenCensus
+// and delivers them as Prometheus Metrics.
+// Collect is invoked everytime a prometheus.Gatherer is run
+// for example when the HTTP endpoint is invoked by Prometheus.
+func (c *collector) Collect(ch chan<- prometheus.Metric) {
+	c.mu.Lock()
+	// Get the last views
+	views := c.views
+	// Now clear them out for the next accumulation
+	c.views = c.views[:0]
+	c.mu.Unlock()
+
+	if len(views) == 0 {
+		return
+	}
+
+	seen := make(map[prometheus.Metric]bool)
+	for _, vd := range views {
+		for _, row := range vd.Rows {
+			metric := c.toMetric(vd.View, row)
+			if _, ok := seen[metric]; !ok && metric != nil {
+				ch <- metric
+				seen[metric] = true
+			}
+		}
+	}
+}
+
+func (c *collector) toMetric(view *stats.View, row *stats.Row) prometheus.Metric {
+	switch aggregation := view.Aggregation().(type) {
+	case stats.CountAggregation:
+		data := row.Data.(*stats.CountData)
+		var key *stats.CountData
+		sc, ok := c.lookupMetric(key)
+		firstTime := !ok
+		if firstTime {
+			sc = prometheus.NewCounter(prometheus.CounterOpts{
+				Name:      internal.Sanitize(view.Name()),
+				Help:      view.Description(),
+				Namespace: c.namespace(),
+			})
+			c.memoizeMetric(key, sc)
+		}
+		counter := sc.(prometheus.Counter)
+		counter.Add(float64(*data))
+		return counter
+
+	case stats.DistributionAggregation:
+		var key *stats.DistributionData
+		hm, ok := c.lookupMetric(key)
+		firstTime := !ok
+		if firstTime {
+			hOpts := prometheus.HistogramOpts{
+				Name:        internal.Sanitize(view.Name()),
+				Help:        view.Description(),
+				Namespace:   c.namespace(),
+				ConstLabels: tagsToLabels(row.Tags),
+			}
+			hm = prometheus.NewHistogram(hOpts)
+			c.memoizeMetric(key, hm)
+		}
+		histogram := hm.(prometheus.Histogram)
+		for _, point := range aggregation {
+			histogram.Observe(float64(point))
+		}
+		return histogram
+
+	case stats.SumAggregation:
+		panic("stats.SumData:: unimplemented")
+
+	case *stats.MeanAggregation:
+		panic("stats.MeanData:: unimplemented")
+
+	default:
+		panic("default: Unknown")
+	}
+}
+
+func tagKeysToLabels(keys []tag.Key) (labels []string) {
+	for _, key := range keys {
+		labels = append(labels, key.Name())
+	}
+	return labels
+}
+
+func tagsToLabels(tags []tag.Tag) map[string]string {
+	m := make(map[string]string)
+	for _, tag := range tags {
+		m[tag.Key.Name()] = tag.Value
+	}
+	return m
+}
+
+func newCollector(opts Options, registrar *prometheus.Registry) *collector {
+	return &collector{
+		reg:  registrar,
+		opts: opts,
+
+		registeredViews: make(map[*stats.View]bool),
+		seenMetrics:     make(map[interface{}]prometheus.Metric),
+	}
+}
+
+func (c *collector) addViewData(vd *stats.ViewData) {
+	c.mu.Lock()
+	c.views = append(c.views, vd)
+	c.mu.Unlock()
 }

--- a/stats/export.go
+++ b/stats/export.go
@@ -17,7 +17,7 @@ package stats
 import "sync"
 
 var (
-	exportersMu sync.Mutex // guards exporters
+	exportersMu sync.RWMutex // guards exporters
 	exporters   = make(map[Exporter]struct{})
 )
 

--- a/stats/worker.go
+++ b/stats/worker.go
@@ -273,25 +273,8 @@ func (w *worker) tryRegisterView(v *View) error {
 	w.viewsByName[v.Name()] = v
 	w.views[v] = true
 
-	// If any exporter implements ViewRegistrar, broadcast to it
-	go w.broadcastViewToExporters(v)
-
 	v.Measure().addView(v)
 	return nil
-}
-
-type ViewRegistrar interface {
-	RegisterView(*View)
-}
-
-func (w *worker) broadcastViewToExporters(v *View) {
-	exportersMu.RLock()
-	for e := range exporters {
-		if vr, ok := e.(ViewRegistrar); ok {
-			vr.RegisterView(v)
-		}
-	}
-	exportersMu.RUnlock()
 }
 
 func (w *worker) reportUsage(now time.Time) {


### PR DESCRIPTION
Follow up of #181
Updates #168

Implements the Prometheus endpoint and now we can examine
data of the OpenCensus View Aggregation types of:
* CountAggregation
* DistributionAggregation

Also added a ViewRegistrar interface to stats so that
we can avoid the client having manually register views
to the exporter. With ViewRegistrar's RegisterView,
when a new View's Subscribe is invoked, the underlying
worker publishes the view to all Exporters that have
the RegisterView method. This way all the client has
to do is:
1. Create the Exporter.
2. Make measures and views
3. Invoke view.Subscribe() per view
thus simplifying our API.

And the sample output data after running the example
in examples/stats/prometheus/main.go

* Exhibit:

shows video count + processed byte data continuously
being generated and due to the nice API @rakyll
thought of, we can view the video data by
visiting the set endpoint, in a sample case /metrics

```shell
curl http://localhost:9999/metrics
```

```shell
 # HELP opencensus_video_count number of videos processed processed over
 # time
 # TYPE opencensus_video_count counter
 opencensus_video_count 1879
 # HELP opencensus_video_cum processed video size over time
 # TYPE opencensus_video_cum histogram
 opencensus_video_cum_bucket{le="0.005"} 372
 opencensus_video_cum_bucket{le="0.01"} 372
 opencensus_video_cum_bucket{le="0.025"} 372
 opencensus_video_cum_bucket{le="0.05"} 372
 opencensus_video_cum_bucket{le="0.1"} 372
 opencensus_video_cum_bucket{le="0.25"} 372
 opencensus_video_cum_bucket{le="0.5"} 372
 opencensus_video_cum_bucket{le="1"} 372
 opencensus_video_cum_bucket{le="2.5"} 372
 opencensus_video_cum_bucket{le="5"} 372
 opencensus_video_cum_bucket{le="10"} 372
 opencensus_video_cum_bucket{le="+Inf"} 1116
 opencensus_video_cum_sum 1.597752213504e+12
 opencensus_video_cum_count 1116
```