### PR TITLE
Never allow sanitized strings to start with underscore

### DIFF
--- a/internal/sanitize.go
+++ b/internal/sanitize.go
@@ -27,16 +27,17 @@ func Sanitize(s string) string {
 	if len(s) == 0 {
 		return s
 	}
+	if len(s) > labelKeySizeLimit {
+		s = s[:labelKeySizeLimit]
+	}
+	s = strings.Map(sanitizeRune, s)
 	if unicode.IsDigit(rune(s[0])) {
 		s = "key_" + s
 	}
 	if s[0] == '_' {
 		s = "key" + s
 	}
-	if len(s) > labelKeySizeLimit {
-		s = s[:labelKeySizeLimit]
-	}
-	return strings.Map(sanitizeRune, s)
+	return s
 }
 
 // converts anything that is not a letter or digit to an underscore

--- a/internal/sanitize_test.go
+++ b/internal/sanitize_test.go
@@ -46,6 +46,11 @@ func TestSanitize(t *testing.T) {
 			want:  "key_0123456789",
 		},
 		{
+			name:  "starts with _ after sanitization",
+			input: "/0123456789",
+			want:  "key_0123456789",
+		},
+		{
 			name:  "valid input",
 			input: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_0123456789",
 			want:  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_0123456789",


### PR DESCRIPTION
The sanitization may replace the first character with underscore.
Append key prefix after sanitization is completed to make
sure the end result is not starting with an underscore.