### PR TITLE
Remove unnecessary/confusing Key doc

### DIFF
--- a/tag/key.go
+++ b/tag/key.go
@@ -15,8 +15,7 @@
 
 package tag
 
-// Key represents a tag key. Keys with the same name will return
-// true when compared with the == operator.
+// Key represents a tag key.
 type Key struct {
 	id   uint16
 	name string


### PR DESCRIPTION
Remove the doc that claims that == on Keys
returns true if the name is the same. If the
ids are differently, obviously it won't match as per
  https://play.golang.org/p/cplbhFsS9k

I guess the doc only applies from an external
view when we use tag.NewKey(name)
because the internal keysManager looks up
the name first and returns an already memoized Key.

However, let's just remove that doc and not make
any of those claims. NewKey's docs are clear enough.

Fixes #212.