### PR TITLE
Remove Measure's dependency on Views

### DIFF
--- a/stats/measure.go
+++ b/stats/measure.go
@@ -29,10 +29,6 @@ type Measure interface {
 	Name() string
 	Description() string
 	Unit() string
-
-	addView(v *View)
-	removeView(v *View)
-	viewsCount() int
 }
 
 // Measurement is the numeric value measured when recording stats. Each measure

--- a/stats/measure_float64.go
+++ b/stats/measure_float64.go
@@ -20,7 +20,6 @@ type MeasureFloat64 struct {
 	name        string
 	unit        string
 	description string
-	views       map[*View]bool
 }
 
 // Name returns the name of the measure.
@@ -38,15 +37,7 @@ func (m *MeasureFloat64) Unit() string {
 	return m.unit
 }
 
-func (m *MeasureFloat64) addView(v *View) {
-	m.views[v] = true
-}
-
-func (m *MeasureFloat64) removeView(v *View) {
-	delete(m.views, v)
-}
-
-func (m *MeasureFloat64) viewsCount() int { return len(m.views) }
+var _ Measure = (*MeasureFloat64)(nil)
 
 // M creates a new float64 measurement.
 // Use Record to record measurements.

--- a/stats/measure_int64.go
+++ b/stats/measure_int64.go
@@ -20,7 +20,6 @@ type MeasureInt64 struct {
 	name        string
 	unit        string
 	description string
-	views       map[*View]bool
 }
 
 // Name returns the name of the measure.
@@ -38,15 +37,7 @@ func (m *MeasureInt64) Unit() string {
 	return m.unit
 }
 
-func (m *MeasureInt64) addView(v *View) {
-	m.views[v] = true
-}
-
-func (m *MeasureInt64) removeView(v *View) {
-	delete(m.views, v)
-}
-
-func (m *MeasureInt64) viewsCount() int { return len(m.views) }
+var _ Measure = (*MeasureInt64)(nil)
 
 // M creates a new int64 measurement.
 // Use Record to record measurements.


### PR DESCRIPTION
Removes the need for each Measure having to implement:
* addView
* removeView
* viewsCount

by tracking which views use a Measure with a map
keyed by Measure, values *Views and tracked by the worker.

Fixes #198