### PR TITLE
Use DistributionValue for MeanData, check Sum and Mean in equalAggWindowTagKeys

### DIFF
--- a/exporter/stats/stackdriver/stackdriver.go
+++ b/exporter/stats/stackdriver/stackdriver.go
@@ -313,6 +313,14 @@ func newTypedValue(view *stats.View, r *stats.Row) *monitoringpb.TypedValue {
 				Count: int64(v.Count),
 				Mean:  v.Mean,
 				SumOfSquaredDeviation: 0,
+				BucketOptions: &distributionpb.Distribution_BucketOptions{
+					Options: &distributionpb.Distribution_BucketOptions_ExplicitBuckets{
+						ExplicitBuckets: &distributionpb.Distribution_BucketOptions_Explicit{
+							Bounds: []float64{0},
+						},
+					},
+				},
+				BucketCounts: []int64{0, int64(v.Count)},
 			},
 		}}
 	case *stats.DistributionData:

--- a/exporter/stats/stackdriver/stackdriver.go
+++ b/exporter/stats/stackdriver/stackdriver.go
@@ -245,7 +245,7 @@ func (e *Exporter) createMeasure(ctx context.Context, vd *stats.ViewData) error 
 	case stats.SumAggregation:
 		valueType = metricpb.MetricDescriptor_DOUBLE
 	case stats.MeanAggregation:
-		valueType = metricpb.MetricDescriptor_DOUBLE
+		valueType = metricpb.MetricDescriptor_DISTRIBUTION
 	case stats.DistributionAggregation:
 		valueType = metricpb.MetricDescriptor_DISTRIBUTION
 	default:
@@ -308,8 +308,12 @@ func newTypedValue(view *stats.View, r *stats.Row) *monitoringpb.TypedValue {
 			DoubleValue: float64(*v),
 		}}
 	case *stats.MeanData:
-		return &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_DoubleValue{
-			DoubleValue: v.Mean,
+		return &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_DistributionValue{
+			DistributionValue: &distributionpb.Distribution{
+				Count: int64(v.Count),
+				Mean:  v.Mean,
+				SumOfSquaredDeviation: 0,
+			},
 		}}
 	case *stats.DistributionData:
 		bounds := view.Aggregation().(stats.DistributionAggregation)

--- a/exporter/stats/stackdriver/stackdriver_test.go
+++ b/exporter/stats/stackdriver/stackdriver_test.go
@@ -239,6 +239,14 @@ func TestExporter_makeReq(t *testing.T) {
 										Count: 7,
 										Mean:  3.3,
 										SumOfSquaredDeviation: 0,
+										BucketOptions: &distributionpb.Distribution_BucketOptions{
+											Options: &distributionpb.Distribution_BucketOptions_ExplicitBuckets{
+												ExplicitBuckets: &distributionpb.Distribution_BucketOptions_Explicit{
+													Bounds: []float64{0},
+												},
+											},
+										},
+										BucketCounts: []int64{0, 7},
 									},
 								}},
 							},
@@ -269,6 +277,14 @@ func TestExporter_makeReq(t *testing.T) {
 										Count: 5,
 										Mean:  -7.7,
 										SumOfSquaredDeviation: 0,
+										BucketOptions: &distributionpb.Distribution_BucketOptions{
+											Options: &distributionpb.Distribution_BucketOptions_ExplicitBuckets{
+												ExplicitBuckets: &distributionpb.Distribution_BucketOptions_Explicit{
+													Bounds: []float64{0},
+												},
+											},
+										},
+										BucketCounts: []int64{0, 5},
 									},
 								}},
 							},

--- a/exporter/stats/stackdriver/stackdriver_test.go
+++ b/exporter/stats/stackdriver/stackdriver_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	distributionpb "google.golang.org/genproto/googleapis/api/distribution"
 	"google.golang.org/genproto/googleapis/api/label"
 
 	"go.opencensus.io/stats"
@@ -233,8 +234,12 @@ func TestExporter_makeReq(t *testing.T) {
 										Nanos:   int32(end.Nanosecond()),
 									},
 								},
-								Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_DoubleValue{
-									DoubleValue: 3.3,
+								Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_DistributionValue{
+									DistributionValue: &distributionpb.Distribution{
+										Count: 7,
+										Mean:  3.3,
+										SumOfSquaredDeviation: 0,
+									},
 								}},
 							},
 						},
@@ -259,8 +264,12 @@ func TestExporter_makeReq(t *testing.T) {
 										Nanos:   int32(end.Nanosecond()),
 									},
 								},
-								Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_DoubleValue{
-									DoubleValue: -7.7,
+								Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_DistributionValue{
+									DistributionValue: &distributionpb.Distribution{
+										Count: 5,
+										Mean:  -7.7,
+										SumOfSquaredDeviation: 0,
+									},
 								}},
 							},
 						},

--- a/exporter/stats/stackdriver/stackdriver_test.go
+++ b/exporter/stats/stackdriver/stackdriver_test.go
@@ -399,12 +399,42 @@ func TestEqualAggWindowTagKeys(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "sum agg + cum",
+			md: &metricpb.MetricDescriptor{
+				MetricKind: metricpb.MetricDescriptor_CUMULATIVE,
+				ValueType:  metricpb.MetricDescriptor_DOUBLE,
+			},
+			agg:     stats.SumAggregation{},
+			window:  stats.Cumulative{},
+			wantErr: false,
+		},
+		{
+			name: "mean agg + cum",
+			md: &metricpb.MetricDescriptor{
+				MetricKind: metricpb.MetricDescriptor_CUMULATIVE,
+				ValueType:  metricpb.MetricDescriptor_DISTRIBUTION,
+			},
+			agg:     stats.MeanAggregation{},
+			window:  stats.Cumulative{},
+			wantErr: false,
+		},
+		{
 			name: "distribution agg + cum - mismatch",
 			md: &metricpb.MetricDescriptor{
 				MetricKind: metricpb.MetricDescriptor_CUMULATIVE,
 				ValueType:  metricpb.MetricDescriptor_DISTRIBUTION,
 			},
 			agg:     stats.CountAggregation{},
+			window:  stats.Cumulative{},
+			wantErr: true,
+		},
+		{
+			name: "mean agg + cum - mismatch",
+			md: &metricpb.MetricDescriptor{
+				MetricKind: metricpb.MetricDescriptor_CUMULATIVE,
+				ValueType:  metricpb.MetricDescriptor_DOUBLE,
+			},
+			agg:     stats.MeanAggregation{},
 			window:  stats.Cumulative{},
 			wantErr: true,
 		},


### PR DESCRIPTION
As a follow up of https://github.com/census-instrumentation/opencensus-go/pull/208