### PR TITLE
Fix accidental View name typo and add tests for plugin/grpc/grpcstats

### DIFF
--- a/plugin/grpc/grpcstats/client_metrics.go
+++ b/plugin/grpc/grpcstats/client_metrics.go
@@ -99,7 +99,7 @@ func defaultClientMeasures() {
 func defaultClientViews() {
 	// Use the Java implementation as a reference at
 	// https://github.com/census-instrumentation/opencensus-java/blob/2b464864e3dd3f80e8e4c9dc72fccc225444a939/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViewConstants.java#L113-L658
-	RPCClientErrorCountView, _ = stats.NewView(" rpc.io/client/error_count/cumulative", "RPC Errors", []tag.Key{keyOpStatus, keyService, keyMethod}, RPCClientErrorCount, aggMean, windowCumulative)
+	RPCClientErrorCountView, _ = stats.NewView("grpc.io/client/error_count/cumulative", "RPC Errors", []tag.Key{keyOpStatus, keyService, keyMethod}, RPCClientErrorCount, aggMean, windowCumulative)
 	clientViews = append(clientViews, RPCClientErrorCountView)
 	RPCClientRoundTripLatencyView, _ = stats.NewView("grpc.io/client/roundtrip_latency/cumulative", "Latency in msecs", []tag.Key{keyService, keyMethod}, RPCClientRoundTripLatency, aggDistMillis, windowCumulative)
 	clientViews = append(clientViews, RPCClientRoundTripLatencyView)

--- a/plugin/grpc/grpcstats/client_metrics_test.go
+++ b/plugin/grpc/grpcstats/client_metrics_test.go
@@ -63,3 +63,41 @@ func TestViewsAggregationsConform(t *testing.T) {
 	assertTypeOf(RPCClientRequestCountHourView, stats.MeanAggregation{})
 	assertTypeOf(RPCClientResponseCountHourView, stats.MeanAggregation{})
 }
+
+func TestStrictViewNames(t *testing.T) {
+	alreadySeen := make(map[string]int)
+	assertName := func(v *stats.View, want string) {
+		_, _, line, _ := runtime.Caller(1)
+		if prevLine, ok := alreadySeen[v.Name()]; ok {
+			t.Errorf("Item's Name on line %d was already used on line %d", line, prevLine)
+			return
+		}
+		if got := v.Name(); got != want {
+			t.Errorf("Item on line: %d got %q want %q", line, got, want)
+		}
+		alreadySeen[v.Name()] = line
+	}
+
+	assertName(RPCClientErrorCountView, "grpc.io/client/error_count/cumulative")
+	assertName(RPCClientRoundTripLatencyView, "grpc.io/client/roundtrip_latency/cumulative")
+	assertName(RPCClientRequestBytesView, "grpc.io/client/request_bytes/cumulative")
+	assertName(RPCClientResponseBytesView, "grpc.io/client/response_bytes/cumulative")
+	assertName(RPCClientRequestCountView, "grpc.io/client/request_count/cumulative")
+	assertName(RPCClientResponseCountView, "grpc.io/client/response_count/cumulative")
+	assertName(RPCClientRoundTripLatencyMinuteView, "grpc.io/client/roundtrip_latency/minute")
+	assertName(RPCClientRequestBytesMinuteView, "grpc.io/client/request_bytes/minute")
+	assertName(RPCClientResponseBytesMinuteView, "grpc.io/client/response_bytes/minute")
+	assertName(RPCClientErrorCountMinuteView, "grpc.io/client/error_count/minute")
+	assertName(RPCClientStartedCountMinuteView, "grpc.io/client/started_count/minute")
+	assertName(RPCClientFinishedCountMinuteView, "grpc.io/client/finished_count/minute")
+	assertName(RPCClientRequestCountMinuteView, "grpc.io/client/request_count/minute")
+	assertName(RPCClientResponseCountMinuteView, "grpc.io/client/response_count/minute")
+	assertName(RPCClientRoundTripLatencyHourView, "grpc.io/client/roundtrip_latency/hour")
+	assertName(RPCClientRequestBytesHourView, "grpc.io/client/request_bytes/hour")
+	assertName(RPCClientResponseBytesHourView, "grpc.io/client/response_bytes/hour")
+	assertName(RPCClientErrorCountHourView, "grpc.io/client/error_count/hour")
+	assertName(RPCClientStartedCountHourView, "grpc.io/client/started_count/hour")
+	assertName(RPCClientFinishedCountHourView, "grpc.io/client/finished_count/hour")
+	assertName(RPCClientRequestCountHourView, "grpc.io/client/request_count/hour")
+	assertName(RPCClientResponseCountHourView, "grpc.io/client/response_count/hour")
+}


### PR DESCRIPTION
Reported by @jcd2, I accidentally typo'd
  " rpc.io/client/error_count/cumulative"
instead of
  "grpc.io/client/error_count/cumulative"
in PR #217.

Added a test to ensure that we never regress/repeat this,
because the code has many moving parts and such a typo
or copy and paste errors would have lurked if not for
a sharp eye or an explicit error.