### PR TITLE
Only support stats.Cumulative window for Prometheus

### DIFF
--- a/exporter/stats/prometheus/prometheus.go
+++ b/exporter/stats/prometheus/prometheus.go
@@ -170,14 +170,14 @@ func (c *collector) Describe(ch chan<- *prometheus.Desc) {
 // Collect is invoked everytime a prometheus.Gatherer is run
 // for example when the HTTP endpoint is invoked by Prometheus.
 func (c *collector) Collect(ch chan<- prometheus.Metric) {
-	c.mu.Lock()
-	views := make(map[string]*stats.ViewData, len(c.viewData))
-	for i, vd := range c.viewData {
-		views[i] = vd
-	}
-	c.mu.Unlock()
-
 	for _, vd := range c.viewData {
+		if _, ok := vd.View.Window().(stats.Cumulative); !ok {
+			// TODO: (@rakyll, @odeke-em): Only the cumulative window will
+			// be exported in this version. Support others in the future.
+			// See Issue https://github.com/census-instrumentation/opencensus-go/issues/214
+			continue
+		}
+
 		sig := viewSignature(c.opts.Namespace, vd.View)
 		c.registeredViewsMu.Lock()
 		desc := c.registeredViews[sig]

--- a/exporter/stats/prometheus/prometheus_test.go
+++ b/exporter/stats/prometheus/prometheus_test.go
@@ -1,0 +1,82 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheus
+
+import (
+	"testing"
+
+	"go.opencensus.io/stats"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func newView(agg stats.Aggregation, window stats.Window) *stats.View {
+	m, _ := stats.NewMeasureInt64("tests/foo1", "bytes", "byte")
+	view, _ := stats.NewView("foo", "bar", nil, m, agg, window)
+	return view
+}
+
+type fauxWindow struct {
+	stats.Cumulative
+	name string
+}
+
+func TestOnlyCumulativeWindowSupported(t *testing.T) {
+	// See Issue https://github.com/census-instrumentation/opencensus-go/issues/214.
+	count1 := stats.CountData(1)
+	tests := []struct {
+		vds  *stats.ViewData
+		want int
+	}{
+		0: {
+			vds: &stats.ViewData{
+				View: newView(stats.CountAggregation{}, stats.Cumulative{}),
+			},
+			want: 0, // no rows present
+		},
+		1: {
+			vds: &stats.ViewData{
+				View: newView(stats.CountAggregation{}, stats.Cumulative{}),
+				Rows: []*stats.Row{
+					{nil, &count1},
+				},
+			},
+			want: 1,
+		},
+		2: {
+			vds: &stats.ViewData{
+				View: newView(stats.CountAggregation{}, fauxWindow{}),
+				Rows: []*stats.Row{
+					{nil, &count1},
+				},
+			},
+			want: 0,
+		},
+	}
+
+	for i, tt := range tests {
+		reg := prometheus.NewRegistry()
+		collector := newCollector(Options{}, reg)
+		collector.addViewData(tt.vds)
+		mm, err := reg.Gather()
+		if err != nil {
+			t.Errorf("#%d: Gather err: %v", i, err)
+		}
+		reg.Unregister(collector)
+		if got, want := len(mm), tt.want; got != want {
+			t.Errorf("#%d: got nil %v want nil %v", i, got, want)
+		}
+	}
+}

--- a/exporter/stats/prometheus/prometheus_test.go
+++ b/exporter/stats/prometheus/prometheus_test.go
@@ -28,11 +28,6 @@ func newView(agg stats.Aggregation, window stats.Window) *stats.View {
 	return view
 }
 
-type fauxWindow struct {
-	stats.Cumulative
-	name string
-}
-
 func TestOnlyCumulativeWindowSupported(t *testing.T) {
 	// See Issue https://github.com/census-instrumentation/opencensus-go/issues/214.
 	count1 := stats.CountData(1)
@@ -57,7 +52,7 @@ func TestOnlyCumulativeWindowSupported(t *testing.T) {
 		},
 		2: {
 			vds: &stats.ViewData{
-				View: newView(stats.CountAggregation{}, fauxWindow{}),
+				View: newView(stats.CountAggregation{}, stats.Interval{}),
 				Rows: []*stats.Row{
 					{nil, &count1},
 				},


### PR DESCRIPTION
If a View doesn't have a stats.Cumulative
window at export time, skip collecting it.

Fixes #214