### PR TITLE
DUMMY PR: DO NOT MERGE:: Rollback "context" to "golang.org/x/net/context" to support Go1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.8.x
+  - 1.6.x
   - 1.9.x
 
 go_import_path: go.opencensus.io

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ clone_folder: c:\gopath\src\go.opencensus.io
 
 environment:
   GOPATH: c:\gopath
-  GOVERSION: 1.8
+  GOVERSION: 1.6
 
 install:
   - set PATH=%GOPATH%\bin;c:\go\bin;%PATH%

--- a/examples/stats/helloworld/main.go
+++ b/examples/stats/helloworld/main.go
@@ -17,10 +17,11 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"time"
+
+	"golang.org/x/net/context"
 
 	"go.opencensus.io/stats"
 )

--- a/examples/stats/prometheus/main.go
+++ b/examples/stats/prometheus/main.go
@@ -17,11 +17,12 @@
 package main
 
 import (
-	"context"
 	"log"
 	"math/rand"
 	"net/http"
 	"time"
+
+	"golang.org/x/net/context"
 
 	"go.opencensus.io/exporter/stats/prometheus"
 	"go.opencensus.io/stats"

--- a/examples/stats/stackdriver/main.go
+++ b/examples/stats/stackdriver/main.go
@@ -18,10 +18,11 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"time"
+
+	"golang.org/x/net/context"
 
 	"go.opencensus.io/exporter/stats/stackdriver"
 	"go.opencensus.io/stats"

--- a/examples/trace/helloworld/main.go
+++ b/examples/trace/helloworld/main.go
@@ -16,9 +16,10 @@
 package main
 
 import (
-	"context"
 	"log"
 	"time"
+
+	"golang.org/x/net/context"
 
 	"go.opencensus.io/trace"
 )

--- a/exporter/stats/stackdriver/stackdriver.go
+++ b/exporter/stats/stackdriver/stackdriver.go
@@ -19,7 +19,6 @@
 package stackdriver
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -28,6 +27,8 @@ import (
 	"reflect"
 	"sync"
 	"time"
+
+	"golang.org/x/net/context"
 
 	"go.opencensus.io/tag"
 

--- a/exporter/trace/stackdriver/proto.go
+++ b/exporter/trace/stackdriver/proto.go
@@ -17,7 +17,6 @@ package stackdriver
 import (
 	"fmt"
 	"math"
-	"runtime"
 	"time"
 	"unicode/utf8"
 
@@ -110,29 +109,7 @@ func protoFromSpanData(s *trace.SpanData, projectID string) *tracepb.Span {
 		sp.TimeEvents.DroppedMessageEventsCount = clip32(droppedMessageEventsCount)
 	}
 
-	if pcs := s.StackTrace; pcs != nil {
-		sf := &tracepb.StackTrace_StackFrames{}
-		sp.StackTrace = &tracepb.StackTrace{StackFrames: sf}
-		frames := runtime.CallersFrames(pcs)
-		dropped := 0
-		for {
-			frame, more := frames.Next()
-			if len(sf.Frame) >= 128 {
-				// TODO: drop from the middle
-				dropped++
-			} else {
-				sf.Frame = append(sf.Frame, &tracepb.StackTrace_StackFrame{
-					FunctionName: trunc(frame.Function, 1024),
-					FileName:     trunc(frame.File, 256),
-					LineNumber:   int64(frame.Line),
-				})
-			}
-			if !more {
-				break
-			}
-		}
-		sf.DroppedFramesCount = clip32(dropped)
-	}
+	sp.StackTrace = pbStackTrace(s)
 
 	if len(s.Links) > 0 {
 		sp.Links = &tracepb.Span_Links{}

--- a/exporter/trace/stackdriver/proto_go16.go
+++ b/exporter/trace/stackdriver/proto_go16.go
@@ -1,0 +1,48 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build go1.6
+
+package stackdriver
+
+import (
+	"runtime"
+
+	"go.opencensus.io/trace"
+	tracepb "google.golang.org/genproto/googleapis/devtools/cloudtrace/v2"
+)
+
+func pbStackTrace(s *trace.SpanData) *tracepb.StackTrace {
+	pcs := s.StackTrace
+	if pcs == nil {
+		return nil
+	}
+	sf := &tracepb.StackTrace_StackFrames{}
+	for _, pc := range pcs {
+		// The idea is to expand and find the function-name and line numbers.
+		// However, Go1.6 and below didn't have runtime.CallersFrame.
+		fn := runtime.FuncForPC(pc)
+		if fn == nil {
+			continue
+		}
+		entryPC := fn.Entry()
+		fileName, lineNumber := fn.FileLine(entryPC)
+		sf.Frame = append(sf.Frame, &tracepb.StackTrace_StackFrame{
+			FunctionName: trunc(fn.Name(), 1024),
+			FileName:     trunc(fileName, 256),
+			LineNumber:   int64(lineNumber),
+		})
+	}
+	return &tracepb.StackTrace{StackFrames: sf}
+}

--- a/exporter/trace/stackdriver/proto_notgo16.go
+++ b/exporter/trace/stackdriver/proto_notgo16.go
@@ -1,0 +1,50 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !go1.6
+
+package stackdriver
+
+import (
+	"runtime"
+)
+
+func pbStackTrace(s *trace.SpanData) *tracepb.StackTrace {
+	pcs := s.StackTrace
+	if pcs == nil {
+		return nil
+	}
+	sf := &tracepb.StackTrace_StackFrames{}
+	sp.StackTrace = &tracepb.StackTrace{StackFrames: sf}
+	frames := runtime.CallersFrames(pcs)
+	dropped := 0
+	for {
+		frame, more := frames.Next()
+		if len(sf.Frame) >= 128 {
+			// TODO: drop from the middle
+			dropped++
+		} else {
+			sf.Frame = append(sf.Frame, &tracepb.StackTrace_StackFrame{
+				FunctionName: trunc(frame.Function, 1024),
+				FileName:     trunc(frame.File, 256),
+				LineNumber:   int64(frame.Line),
+			})
+		}
+		if !more {
+			break
+		}
+	}
+	sf.DroppedFramesCount = clip32(dropped)
+	return &tracepb.StackTrace{StackFrames: sf}
+}

--- a/exporter/trace/stackdriver/proto_test.go
+++ b/exporter/trace/stackdriver/proto_test.go
@@ -15,7 +15,6 @@
 package stackdriver
 
 import (
-	"context"
 	"fmt"
 	"math/big"
 	"reflect"
@@ -23,6 +22,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"golang.org/x/net/context"
 
 	"github.com/golang/protobuf/proto"
 	timestamppb "github.com/golang/protobuf/ptypes/timestamp"

--- a/exporter/trace/stackdriver/stackdriver.go
+++ b/exporter/trace/stackdriver/stackdriver.go
@@ -30,7 +30,6 @@
 package stackdriver
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"sync"
@@ -39,6 +38,7 @@ import (
 	"go.opencensus.io/internal"
 
 	tracingclient "cloud.google.com/go/trace/apiv2"
+	"golang.org/x/net/context"
 	"go.opencensus.io/trace"
 	"google.golang.org/api/option"
 	"google.golang.org/api/support/bundler"

--- a/exporter/trace/stackdriver/stackdriver_test.go
+++ b/exporter/trace/stackdriver/stackdriver_test.go
@@ -15,9 +15,10 @@
 package stackdriver
 
 import (
-	"context"
 	"testing"
 	"time"
+
+	"golang.org/x/net/context"
 
 	"go.opencensus.io/trace"
 )

--- a/internal/readme/stats.go
+++ b/internal/readme/stats.go
@@ -16,9 +16,10 @@
 package readme
 
 import (
-	"context"
 	"log"
 	"time"
+
+	"golang.org/x/net/context"
 
 	"go.opencensus.io/stats"
 )

--- a/internal/readme/tags.go
+++ b/internal/readme/tags.go
@@ -15,8 +15,9 @@
 package readme
 
 import (
-	"context"
 	"log"
+
+	"golang.org/x/net/context"
 
 	"go.opencensus.io/tag"
 )

--- a/stats/collector.go
+++ b/stats/collector.go
@@ -16,7 +16,6 @@
 package stats
 
 import (
-	"sort"
 	"time"
 
 	"go.opencensus.io/internal/tagencoding"
@@ -83,6 +82,6 @@ func decodeTags(buf []byte, keys []tag.Key) []tag.Tag {
 		}
 	}
 	vb.ReadIndex = 0
-	sort.Slice(tags, func(i, j int) bool { return tags[i].Key.Name() < tags[j].Key.Name() })
+	tag.SortTagsByKeyName(tags)
 	return tags
 }

--- a/stats/collector_test.go
+++ b/stats/collector_test.go
@@ -15,8 +15,9 @@
 package stats
 
 import (
-	"context"
 	"testing"
+
+	"golang.org/x/net/context"
 
 	"go.opencensus.io/tag"
 )

--- a/stats/example_test.go
+++ b/stats/example_test.go
@@ -15,9 +15,10 @@
 package stats_test
 
 import (
-	"context"
 	"log"
 	"time"
+
+	"golang.org/x/net/context"
 
 	"go.opencensus.io/stats"
 )

--- a/stats/view_test.go
+++ b/stats/view_test.go
@@ -16,9 +16,10 @@
 package stats
 
 import (
-	"context"
 	"testing"
 	"time"
+
+	"golang.org/x/net/context"
 
 	"go.opencensus.io/tag"
 )

--- a/stats/worker.go
+++ b/stats/worker.go
@@ -16,10 +16,11 @@
 package stats
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"time"
+
+	"golang.org/x/net/context"
 
 	"go.opencensus.io/tag"
 )

--- a/stats/worker_test.go
+++ b/stats/worker_test.go
@@ -16,12 +16,13 @@
 package stats
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"sync"
 	"testing"
 	"time"
+
+	"golang.org/x/net/context"
 
 	"go.opencensus.io/tag"
 )

--- a/tag/context.go
+++ b/tag/context.go
@@ -15,7 +15,7 @@
 
 package tag
 
-import "context"
+import "golang.org/x/net/context"
 
 // FromContext returns the tag map stored in the context.
 func FromContext(ctx context.Context) *Map {

--- a/tag/example_test.go
+++ b/tag/example_test.go
@@ -16,8 +16,9 @@
 package tag_test
 
 import (
-	"context"
 	"log"
+
+	"golang.org/x/net/context"
 
 	"go.opencensus.io/tag"
 )

--- a/tag/map.go
+++ b/tag/map.go
@@ -17,9 +17,9 @@ package tag
 
 import (
 	"bytes"
-	"context"
 	"fmt"
-	"sort"
+
+	"golang.org/x/net/context"
 )
 
 // Tag is a key value pair that can be propagated on wire.
@@ -45,7 +45,7 @@ func (m *Map) String() string {
 	for k := range m.m {
 		keys = append(keys, k)
 	}
-	sort.Slice(keys, func(i, j int) bool { return keys[i].Name() < keys[j].Name() })
+	SortKeysByName(keys)
 
 	var buffer bytes.Buffer
 	buffer.WriteString("{ ")

--- a/tag/map_codec_test.go
+++ b/tag/map_codec_test.go
@@ -16,24 +16,25 @@
 package tag
 
 import (
-	"context"
 	"reflect"
 	"sort"
 	"testing"
+
+	"golang.org/x/net/context"
 )
 
 var keys []Key
+
+type pair struct {
+	k Key
+	v string
+}
 
 func Test_EncodeDecode_Set(t *testing.T) {
 	k1, _ := NewKey("k1")
 	k2, _ := NewKey("k2")
 	k3, _ := NewKey("k3 is very weird <>.,?/'\";:`~!@#$%^&*()_-+={[}]|\\")
 	k4, _ := NewKey("k4")
-
-	type pair struct {
-		k Key
-		v string
-	}
 
 	type testCase struct {
 		label string
@@ -99,11 +100,19 @@ func Test_EncodeDecode_Set(t *testing.T) {
 		}
 		want := tc.pairs
 
-		sort.Slice(got, func(i, j int) bool { return got[i].k.name < got[j].k.name })
-		sort.Slice(want, func(i, j int) bool { return got[i].k.name < got[j].k.name })
+		sort.Sort(pairs(got))
+		sort.Sort(pairs(want))
 
-		if !reflect.DeepEqual(got, tc.pairs) {
+		if !reflect.DeepEqual(got, want) {
 			t.Errorf("%v: decoded tag map = %#v; want %#v", tc.label, got, want)
 		}
 	}
 }
+
+type pairs []pair
+
+func (ps pairs) Len() int           { return len(ps) }
+func (ps pairs) Swap(i, j int)      { ps[i], ps[j] = ps[j], ps[i] }
+func (ps pairs) Less(i, j int) bool { return ps[i].k.name < ps[j].k.name }
+
+var _ sort.Interface = (pairs)(nil)

--- a/tag/map_go17.go
+++ b/tag/map_go17.go
@@ -1,0 +1,38 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build go1.6,go1.7
+
+package tag
+
+import "sort"
+
+type keySlice []Key
+
+func (ks keySlice) Len() int           { return len(ks) }
+func (ks keySlice) Less(i, j int) bool { return ks[i].Name() < ks[j].Name() }
+func (ks keySlice) Swap(i, j int)      { ks[i], ks[j] = ks[j], ks[i] }
+
+func SortKeysByName(keys []Key) {
+	sort.Sort(keySlice(keys))
+}
+
+type tagsByName []Tag
+func (tn tagsByName) Len() int { return len(tn) }
+func (tn tagsByName) Less(i, j int) bool { return tn[i].Key.Name() < tn[j].Key.Name() }
+func (tn tagsByName) Swap(i, j int) { tn[i], tn[j] = tn[j], tn[i] }
+
+func SortTagsByKeyName(tags []Tag) {
+	sort.Sort(tagsByName(tags))
+}

--- a/tag/map_notgo17.go
+++ b/tag/map_notgo17.go
@@ -1,0 +1,27 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !go1.6,!go1.7
+
+package tag
+
+import "sort"
+
+func SortKeysByName(keys []Key) {
+	sort.Slice(keys, func(i, j int) bool { return keys[i].Name() < keys[j].Name() })
+}
+
+func SortTagsByKeyName(tags []Tag) {
+	sort.Slice(tags, func(i, j int) bool { return tags[i].Key.Name() < tags[j].Key.Name() })
+}

--- a/tag/map_test.go
+++ b/tag/map_test.go
@@ -16,10 +16,11 @@
 package tag
 
 import (
-	"context"
 	"fmt"
 	"reflect"
 	"testing"
+
+	"golang.org/x/net/context"
 )
 
 func TestContext(t *testing.T) {

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -15,7 +15,6 @@
 package trace
 
 import (
-	"context"
 	crand "crypto/rand"
 	"encoding/binary"
 	"fmt"
@@ -23,6 +22,8 @@ import (
 	"runtime"
 	"sync"
 	"time"
+
+	"golang.org/x/net/context"
 )
 
 // Span represents a span of a trace.  It has an associated SpanContext, and
@@ -696,15 +697,4 @@ func newSpanIDLocked() SpanID {
 	var sid SpanID
 	binary.LittleEndian.PutUint64(sid[:], id)
 	return sid
-}
-
-// newTraceIDLocked returns a non-zero TraceID from a randomly-chosen sequence.
-// mu should be held while this function is called.
-func newTraceIDLocked() TraceID {
-	var tid TraceID
-	// Construct the trace ID from two outputs of traceIDRand, with a constant
-	// added to each half for additional entropy.
-	binary.LittleEndian.PutUint64(tid[0:8], traceIDRand.Uint64()+traceIDAdd[0])
-	binary.LittleEndian.PutUint64(tid[8:16], traceIDRand.Uint64()+traceIDAdd[1])
-	return tid
 }

--- a/trace/trace_go16.go
+++ b/trace/trace_go16.go
@@ -1,0 +1,38 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build go1.6
+
+package trace
+
+import (
+	"encoding/binary"
+)
+
+// newTraceIDLocked returns a non-zero TraceID from a randomly-chosen sequence.
+// mu should be held while this function is called.
+func newTraceIDLocked() TraceID {
+	var tid TraceID
+	// Construct the trace ID from two outputs of traceIDRand, with a constant
+	// added to each half for additional entropy.
+	binary.LittleEndian.PutUint64(tid[0:8], randUint64()+traceIDAdd[0])
+	binary.LittleEndian.PutUint64(tid[8:16], randUint64()+traceIDAdd[1])
+	return tid
+}
+
+func randUint64() uint64 {
+	// Copied from later Go version after 1.6
+	// https://github.com/golang/go/blob/70f441bc49afa4e9d10c27d7ed5733c4df7bddd3/src/math/rand/rand.go#L87-L93
+	return uint64(traceIDRand.Int63())>>31 | uint64(traceIDRand.Int63())<<32
+}

--- a/trace/trace_notgo16.go
+++ b/trace/trace_notgo16.go
@@ -1,0 +1,32 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !go1.6
+
+package trace
+
+import (
+	"encoding/binary"
+)
+
+// newTraceIDLocked returns a non-zero TraceID from a randomly-chosen sequence.
+// mu should be held while this function is called.
+func newTraceIDLocked() TraceID {
+	var tid TraceID
+	// Construct the trace ID from two outputs of traceIDRand, with a constant
+	// added to each half for additional entropy.
+	binary.LittleEndian.PutUint64(tid[0:8], traceIDRand.Uint64()+traceIDAdd[0])
+	binary.LittleEndian.PutUint64(tid[8:16], traceIDRand.Uint64()+traceIDAdd[1])
+	return tid
+}

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -15,11 +15,12 @@
 package trace
 
 import (
-	"context"
 	"fmt"
 	"reflect"
 	"testing"
 	"time"
+
+	"golang.org/x/net/context"
 )
 
 var (


### PR DESCRIPTION
To maximize support/adoption with gRPC, it doesn't hurt for
us to use "golang.org/x/net/context" so that systems running
Go1.6 can use this package.