### PR TITLE
Record error status code not the error message

### DIFF
--- a/plugin/grpc/grpcstats/client_handler_test.go
+++ b/plugin/grpc/grpcstats/client_handler_test.go
@@ -16,8 +16,10 @@
 package grpcstats
 
 import (
-	"errors"
 	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"golang.org/x/net/context"
 
@@ -147,7 +149,7 @@ func TestClientDefaultCollections(t *testing.T) {
 						{Length: 10},
 						{Length: 10},
 					},
-					&stats.End{Error: errors.New("someError")},
+					&stats.End{Error: status.Error(codes.Canceled, "canceled")},
 				},
 			},
 			[]*wantData{
@@ -156,8 +158,8 @@ func TestClientDefaultCollections(t *testing.T) {
 					[]*istats.Row{
 						{
 							[]tag.Tag{
+								{Key: keyStatus, Value: "Canceled"},
 								{Key: keyMethod, Value: "method"},
-								{Key: keyOpStatus, Value: "someError"},
 								{Key: keyService, Value: "package.service"},
 							},
 							newMeanData(1, 1),
@@ -216,7 +218,7 @@ func TestClientDefaultCollections(t *testing.T) {
 						{Length: 4096},
 						{Length: 16384},
 					},
-					&stats.End{Error: errors.New("someError1")},
+					&stats.End{Error: status.Error(codes.Canceled, "canceled")},
 				},
 				{
 					[]tagPair{{k1, "v11"}, {k2, "v22"}},
@@ -230,7 +232,7 @@ func TestClientDefaultCollections(t *testing.T) {
 						{Length: 4096},
 						{Length: 16384},
 					},
-					&stats.End{Error: errors.New("someError2")},
+					&stats.End{Error: status.Error(codes.Aborted, "aborted")},
 				},
 			},
 			[]*wantData{
@@ -239,16 +241,16 @@ func TestClientDefaultCollections(t *testing.T) {
 					[]*istats.Row{
 						{
 							[]tag.Tag{
+								{Key: keyStatus, Value: "Canceled"},
 								{Key: keyMethod, Value: "method"},
-								{Key: keyOpStatus, Value: "someError1"},
 								{Key: keyService, Value: "package.service"},
 							},
 							newMeanData(1, 1),
 						},
 						{
 							[]tag.Tag{
+								{Key: keyStatus, Value: "Aborted"},
 								{Key: keyMethod, Value: "method"},
-								{Key: keyOpStatus, Value: "someError2"},
 								{Key: keyService, Value: "package.service"},
 							},
 							newMeanData(1, 1),
@@ -327,17 +329,13 @@ func TestClientDefaultCollections(t *testing.T) {
 			}
 			encoded := tag.Encode(tm)
 			ctx := stats.SetTags(context.Background(), encoded)
-
 			ctx = h.TagRPC(ctx, rpc.tagInfo)
-
 			for _, out := range rpc.outPayloads {
 				h.HandleRPC(ctx, out)
 			}
-
 			for _, in := range rpc.inPayloads {
 				h.HandleRPC(ctx, in)
 			}
-
 			h.HandleRPC(ctx, rpc.end)
 		}
 

--- a/plugin/grpc/grpcstats/client_metrics.go
+++ b/plugin/grpc/grpcstats/client_metrics.go
@@ -100,7 +100,7 @@ func defaultClientViews() {
 	RPCClientErrorCountView, _ = stats.NewView(
 		"grpc.io/client/error_count/cumulative",
 		"RPC Errors",
-		[]tag.Key{keyOpStatus, keyService, keyMethod},
+		[]tag.Key{keyStatus, keyService, keyMethod},
 		RPCClientErrorCount,
 		aggMean,
 		windowCumulative)

--- a/plugin/grpc/grpcstats/grpcstats.go
+++ b/plugin/grpc/grpcstats/grpcstats.go
@@ -65,21 +65,21 @@ var (
 	windowSlidingHour   = istats.Interval{Duration: 1 * time.Hour, Intervals: 6}
 	windowSlidingMinute = istats.Interval{Duration: 1 * time.Minute, Intervals: 6}
 
-	keyService  tag.Key
-	keyMethod   tag.Key
-	keyOpStatus tag.Key
+	keyService tag.Key
+	keyMethod  tag.Key
+	keyStatus  tag.Key
 )
 
 func init() {
 	var err error
-	if keyService, err = tag.NewKey("grpc.service"); err != nil {
-		log.Fatalf("Cannot create grpc.service key: %v", err)
+	if keyService, err = tag.NewKey("service"); err != nil {
+		log.Fatalf("Cannot create service key: %v", err)
 	}
-	if keyMethod, err = tag.NewKey("grpc.method"); err != nil {
-		log.Fatalf("Cannot create grpc.method key: %v", err)
+	if keyMethod, err = tag.NewKey("method"); err != nil {
+		log.Fatalf("Cannot create method key: %v", err)
 	}
-	if keyOpStatus, err = tag.NewKey("grpc.opstatus"); err != nil {
-		log.Fatalf("Cannot create grpc.opstatus key: %v", err)
+	if keyStatus, err = tag.NewKey("canonical_status"); err != nil {
+		log.Fatalf("Cannot create canonical_status key: %v", err)
 	}
 	initServer()
 	initClient()

--- a/plugin/grpc/grpcstats/server_metrics.go
+++ b/plugin/grpc/grpcstats/server_metrics.go
@@ -99,7 +99,7 @@ func defaultServerViews() {
 	RPCServerErrorCountView, _ = stats.NewView(
 		"grpc.io/server/error_count/cumulative",
 		"RPC Errors",
-		[]tag.Key{keyMethod, keyOpStatus, keyService},
+		[]tag.Key{keyMethod, keyStatus, keyService},
 		RPCServerErrorCount,
 		aggCount,
 		windowCumulative)


### PR DESCRIPTION
Also make the status key name is consistent with other language implementations.

Fixes #222.