### PR TITLE
Add a opencensus_task label to Stackdriver exporter

### DIFF
--- a/exporter/stats/stackdriver/stackdriver.go
+++ b/exporter/stats/stackdriver/stackdriver.go
@@ -102,6 +102,7 @@ type Options struct {
 }
 
 // NewExporter returns an exporter that uploads stats data to Stackdriver Monitoring.
+// Only one Stackdriver exporter should be created per process.
 func NewExporter(o Options) (*Exporter, error) {
 	opts := append(o.ClientOptions, option.WithUserAgent(internal.UserAgent))
 	client, err := monitoring.NewMetricClient(context.Background(), opts...)

--- a/exporter/stats/stackdriver/stackdriver.go
+++ b/exporter/stats/stackdriver/stackdriver.go
@@ -24,8 +24,10 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"os"
 	"path"
 	"reflect"
+	"strconv"
 	"sync"
 	"time"
 
@@ -48,6 +50,8 @@ import (
 )
 
 const maxTimeSeriesPerUpload = 200
+const opencensusTaskKey = "opencensus_task"
+const opencensusTaskDescription = "Opencensus task identifier"
 
 // Exporter exports stats to the Stackdriver Monitoring.
 type Exporter struct {
@@ -57,7 +61,8 @@ type Exporter struct {
 	createdViewsMu sync.Mutex
 	createdViews   map[string]*metricpb.MetricDescriptor // Views already created remotely
 
-	c *monitoring.MetricClient
+	c         *monitoring.MetricClient
+	taskValue string
 }
 
 // Options contains options for configuring the exporter.
@@ -107,6 +112,7 @@ func NewExporter(o Options) (*Exporter, error) {
 		c:            client,
 		o:            o,
 		createdViews: make(map[string]*metricpb.MetricDescriptor),
+		taskValue:    getTaskValue(),
 	}
 	e.bundler = bundler.NewBundler((*stats.ViewData)(nil), func(bundle interface{}) {
 		vds := bundle.([]*stats.ViewData)
@@ -134,6 +140,16 @@ func (e *Exporter) Export(vd *stats.ViewData) {
 	default:
 		e.onError(err)
 	}
+}
+
+// getTaskValue returns a task label value in the format of
+// "go-<pid>@<hostname>".
+func getTaskValue() string {
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "localhost"
+	}
+	return "go-" + strconv.Itoa(os.Getpid()) + "@" + hostname
 }
 
 // handleUpload handles uploading a slice
@@ -203,7 +219,7 @@ func (e *Exporter) makeReq(vds []*stats.ViewData, limit int) []*monitoringpb.Cre
 			ts := &monitoringpb.TimeSeries{
 				Metric: &metricpb.Metric{
 					Type:   namespacedViewName(vd.View.Name(), false),
-					Labels: newLabels(row.Tags),
+					Labels: newLabels(row.Tags, e.taskValue),
 				},
 				Resource: resource,
 				Points:   []*monitoringpb.Point{newPoint(vd.View, row, vd.Start, vd.End)},
@@ -384,21 +400,28 @@ func namespacedViewName(v string, escaped bool) string {
 	return path.Join("custom.googleapis.com", p)
 }
 
-func newLabels(tags []tag.Tag) map[string]string {
+func newLabels(tags []tag.Tag, taskValue string) map[string]string {
 	labels := make(map[string]string)
 	for _, tag := range tags {
 		labels[internal.Sanitize(tag.Key.Name())] = tag.Value
 	}
+	labels[opencensusTaskKey] = taskValue
 	return labels
 }
 
 func newLabelDescriptors(keys []tag.Key) []*labelpb.LabelDescriptor {
-	labelDescriptors := make([]*labelpb.LabelDescriptor, len(keys))
+	labelDescriptors := make([]*labelpb.LabelDescriptor, len(keys)+1)
 	for i, key := range keys {
 		labelDescriptors[i] = &labelpb.LabelDescriptor{
 			Key:       internal.Sanitize(key.Name()),
 			ValueType: labelpb.LabelDescriptor_STRING, // We only use string tags
 		}
+	}
+	// Add a specific open census task id label.
+	labelDescriptors[len(keys)] = &labelpb.LabelDescriptor{
+		Key:         opencensusTaskKey,
+		ValueType:   labelpb.LabelDescriptor_STRING,
+		Description: opencensusTaskDescription,
 	}
 	return labelDescriptors
 }
@@ -439,14 +462,15 @@ func equalAggWindowTagKeys(md *metricpb.MetricDescriptor, agg stats.Aggregation,
 		return fmt.Errorf("stackdriver metric descriptor was not created with window type %T", w)
 	}
 
-	if len(md.Labels) != len(keys) {
+	if len(md.Labels) != len(keys)+1 {
 		return errors.New("stackdriver metric descriptor was not created with the view labels")
 	}
 
-	labels := make(map[string]struct{}, len(keys))
+	labels := make(map[string]struct{}, len(keys)+1)
 	for _, k := range keys {
 		labels[internal.Sanitize(k.Name())] = struct{}{}
 	}
+	labels[opencensusTaskKey] = struct{}{}
 
 	for _, k := range md.Labels {
 		if _, ok := labels[k.Key]; !ok {

--- a/exporter/stats/stackdriver/stackdriver_test.go
+++ b/exporter/stats/stackdriver/stackdriver_test.go
@@ -78,6 +78,7 @@ func TestExporter_makeReq(t *testing.T) {
 		Mean:  -7.7,
 		Count: 5,
 	}
+	taskValue := getTaskValue()
 
 	tests := []struct {
 		name   string
@@ -94,8 +95,11 @@ func TestExporter_makeReq(t *testing.T) {
 				TimeSeries: []*monitoringpb.TimeSeries{
 					{
 						Metric: &metricpb.Metric{
-							Type:   "custom.googleapis.com/opencensus/cumview",
-							Labels: map[string]string{"test_key": "test-value-1"},
+							Type: "custom.googleapis.com/opencensus/cumview",
+							Labels: map[string]string{
+								"test_key":        "test-value-1",
+								opencensusTaskKey: taskValue,
+							},
 						},
 						Resource: &monitoredrespb.MonitoredResource{
 							Type: "global",
@@ -120,8 +124,11 @@ func TestExporter_makeReq(t *testing.T) {
 					},
 					{
 						Metric: &metricpb.Metric{
-							Type:   "custom.googleapis.com/opencensus/cumview",
-							Labels: map[string]string{"test_key": "test-value-2"},
+							Type: "custom.googleapis.com/opencensus/cumview",
+							Labels: map[string]string{
+								"test_key":        "test-value-2",
+								opencensusTaskKey: taskValue,
+							},
 						},
 						Resource: &monitoredrespb.MonitoredResource{
 							Type: "global",
@@ -156,8 +163,11 @@ func TestExporter_makeReq(t *testing.T) {
 				TimeSeries: []*monitoringpb.TimeSeries{
 					{
 						Metric: &metricpb.Metric{
-							Type:   "custom.googleapis.com/opencensus/cumview",
-							Labels: map[string]string{"test_key": "test-value-1"},
+							Type: "custom.googleapis.com/opencensus/cumview",
+							Labels: map[string]string{
+								"test_key":        "test-value-1",
+								opencensusTaskKey: taskValue,
+							},
 						},
 						Resource: &monitoredrespb.MonitoredResource{
 							Type: "global",
@@ -182,8 +192,11 @@ func TestExporter_makeReq(t *testing.T) {
 					},
 					{
 						Metric: &metricpb.Metric{
-							Type:   "custom.googleapis.com/opencensus/cumview",
-							Labels: map[string]string{"test_key": "test-value-2"},
+							Type: "custom.googleapis.com/opencensus/cumview",
+							Labels: map[string]string{
+								"test_key":        "test-value-2",
+								opencensusTaskKey: taskValue,
+							},
 						},
 						Resource: &monitoredrespb.MonitoredResource{
 							Type: "global",
@@ -218,8 +231,11 @@ func TestExporter_makeReq(t *testing.T) {
 				TimeSeries: []*monitoringpb.TimeSeries{
 					{
 						Metric: &metricpb.Metric{
-							Type:   "custom.googleapis.com/opencensus/cumview",
-							Labels: map[string]string{"test_key": "test-value-1"},
+							Type: "custom.googleapis.com/opencensus/cumview",
+							Labels: map[string]string{
+								"test_key":        "test-value-1",
+								opencensusTaskKey: taskValue,
+							},
 						},
 						Resource: &monitoredrespb.MonitoredResource{
 							Type: "global",
@@ -256,8 +272,11 @@ func TestExporter_makeReq(t *testing.T) {
 					},
 					{
 						Metric: &metricpb.Metric{
-							Type:   "custom.googleapis.com/opencensus/cumview",
-							Labels: map[string]string{"test_key": "test-value-2"},
+							Type: "custom.googleapis.com/opencensus/cumview",
+							Labels: map[string]string{
+								"test_key":        "test-value-2",
+								opencensusTaskKey: taskValue,
+							},
 						},
 						Resource: &monitoredrespb.MonitoredResource{
 							Type: "global",
@@ -304,7 +323,10 @@ func TestExporter_makeReq(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			e := &Exporter{o: Options{ProjectID: tt.projID}}
+			e := &Exporter{
+				o:         Options{ProjectID: tt.projID},
+				taskValue: taskValue,
+			}
 			resps := e.makeReq([]*stats.ViewData{tt.vd}, maxTimeSeriesPerUpload)
 			if got, want := len(resps), len(tt.want); got != want {
 				t.Fatalf("%v: Exporter.makeReq() returned %d responses; want %d", tt.name, got, want)
@@ -411,6 +433,7 @@ func TestEqualAggWindowTagKeys(t *testing.T) {
 			md: &metricpb.MetricDescriptor{
 				MetricKind: metricpb.MetricDescriptor_CUMULATIVE,
 				ValueType:  metricpb.MetricDescriptor_INT64,
+				Labels:     []*label.LabelDescriptor{{Key: opencensusTaskKey}},
 			},
 			agg:     stats.CountAggregation{},
 			window:  stats.Cumulative{},
@@ -421,6 +444,7 @@ func TestEqualAggWindowTagKeys(t *testing.T) {
 			md: &metricpb.MetricDescriptor{
 				MetricKind: metricpb.MetricDescriptor_CUMULATIVE,
 				ValueType:  metricpb.MetricDescriptor_DOUBLE,
+				Labels:     []*label.LabelDescriptor{{Key: opencensusTaskKey}},
 			},
 			agg:     stats.SumAggregation{},
 			window:  stats.Cumulative{},
@@ -431,6 +455,7 @@ func TestEqualAggWindowTagKeys(t *testing.T) {
 			md: &metricpb.MetricDescriptor{
 				MetricKind: metricpb.MetricDescriptor_CUMULATIVE,
 				ValueType:  metricpb.MetricDescriptor_DISTRIBUTION,
+				Labels:     []*label.LabelDescriptor{{Key: opencensusTaskKey}},
 			},
 			agg:     stats.MeanAggregation{},
 			window:  stats.Cumulative{},
@@ -441,6 +466,7 @@ func TestEqualAggWindowTagKeys(t *testing.T) {
 			md: &metricpb.MetricDescriptor{
 				MetricKind: metricpb.MetricDescriptor_CUMULATIVE,
 				ValueType:  metricpb.MetricDescriptor_DISTRIBUTION,
+				Labels:     []*label.LabelDescriptor{{Key: opencensusTaskKey}},
 			},
 			agg:     stats.CountAggregation{},
 			window:  stats.Cumulative{},
@@ -451,6 +477,7 @@ func TestEqualAggWindowTagKeys(t *testing.T) {
 			md: &metricpb.MetricDescriptor{
 				MetricKind: metricpb.MetricDescriptor_CUMULATIVE,
 				ValueType:  metricpb.MetricDescriptor_DOUBLE,
+				Labels:     []*label.LabelDescriptor{{Key: opencensusTaskKey}},
 			},
 			agg:     stats.MeanAggregation{},
 			window:  stats.Cumulative{},
@@ -461,6 +488,7 @@ func TestEqualAggWindowTagKeys(t *testing.T) {
 			md: &metricpb.MetricDescriptor{
 				MetricKind: metricpb.MetricDescriptor_DELTA,
 				ValueType:  metricpb.MetricDescriptor_DISTRIBUTION,
+				Labels:     []*label.LabelDescriptor{{Key: opencensusTaskKey}},
 			},
 			agg:     stats.DistributionAggregation{},
 			window:  stats.Interval{},
@@ -471,6 +499,7 @@ func TestEqualAggWindowTagKeys(t *testing.T) {
 			md: &metricpb.MetricDescriptor{
 				MetricKind: metricpb.MetricDescriptor_CUMULATIVE,
 				ValueType:  metricpb.MetricDescriptor_DISTRIBUTION,
+				Labels:     []*label.LabelDescriptor{{Key: opencensusTaskKey}},
 			},
 			agg:     stats.DistributionAggregation{},
 			window:  stats.Interval{},
@@ -484,6 +513,7 @@ func TestEqualAggWindowTagKeys(t *testing.T) {
 				Labels: []*label.LabelDescriptor{
 					{Key: "test_key_one"},
 					{Key: "test_key_two"},
+					{Key: opencensusTaskKey},
 				},
 			},
 			agg:     stats.DistributionAggregation{},
@@ -507,6 +537,7 @@ func TestEqualAggWindowTagKeys(t *testing.T) {
 			md: &metricpb.MetricDescriptor{
 				MetricKind: metricpb.MetricDescriptor_CUMULATIVE,
 				ValueType:  metricpb.MetricDescriptor_INT64,
+				Labels:     []*label.LabelDescriptor{{Key: opencensusTaskKey}},
 			},
 			agg:     &stats.CountAggregation{},
 			window:  &stats.Cumulative{},
@@ -616,6 +647,7 @@ func TestExporter_makeReq_withCustomMonitoredResource(t *testing.T) {
 	end := start.Add(time.Minute)
 	count1 := stats.CountData(10)
 	count2 := stats.CountData(16)
+	taskValue := getTaskValue()
 
 	resource := &monitoredrespb.MonitoredResource{
 		Type:   "gce_instance",
@@ -637,8 +669,11 @@ func TestExporter_makeReq_withCustomMonitoredResource(t *testing.T) {
 				TimeSeries: []*monitoringpb.TimeSeries{
 					{
 						Metric: &metricpb.Metric{
-							Type:   "custom.googleapis.com/opencensus/cumview",
-							Labels: map[string]string{"test_key": "test-value-1"},
+							Type: "custom.googleapis.com/opencensus/cumview",
+							Labels: map[string]string{
+								"test_key":        "test-value-1",
+								opencensusTaskKey: taskValue,
+							},
 						},
 						Resource: resource,
 						Points: []*monitoringpb.Point{
@@ -661,8 +696,11 @@ func TestExporter_makeReq_withCustomMonitoredResource(t *testing.T) {
 					},
 					{
 						Metric: &metricpb.Metric{
-							Type:   "custom.googleapis.com/opencensus/cumview",
-							Labels: map[string]string{"test_key": "test-value-2"},
+							Type: "custom.googleapis.com/opencensus/cumview",
+							Labels: map[string]string{
+								"test_key":        "test-value-2",
+								opencensusTaskKey: taskValue,
+							},
 						},
 						Resource: resource,
 						Points: []*monitoringpb.Point{
@@ -689,7 +727,10 @@ func TestExporter_makeReq_withCustomMonitoredResource(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			e := &Exporter{o: Options{ProjectID: tt.projID, Resource: resource}}
+			e := &Exporter{
+				o:         Options{ProjectID: tt.projID, Resource: resource},
+				taskValue: taskValue,
+			}
 			resps := e.makeReq([]*stats.ViewData{tt.vd}, maxTimeSeriesPerUpload)
 			if got, want := len(resps), len(tt.want); got != want {
 				t.Fatalf("%v: Exporter.makeReq() returned %d responses; want %d", tt.name, got, want)


### PR DESCRIPTION
A supplementary change to https://github.com/census-instrumentation/opencensus-go/pull/249.

**Background**: sometimes using a MonitoredResource is not enough to uniquely identify stats. For example, if there are multiple exporters running on the same GCE instance, they will all have the same MonitoredResource. If they export stats to the same Stackdriver metric, there will still be a race condition. To fix that, @jcd2 suggest to have a reserved `opencensus_task` label that can further separate the stats. The value of this label will be in the format "go-pid@hostname".

Equivalent changes for Java: https://github.com/census-instrumentation/opencensus-java/pull/885.