### PR TITLE
Represent mean and sum as untyped values

### DIFF
--- a/exporter/stats/prometheus/prometheus.go
+++ b/exporter/stats/prometheus/prometheus.go
@@ -219,11 +219,11 @@ func (c *collector) toMetric(desc *prometheus.Desc, view *stats.View, row *stats
 
 	case stats.MeanAggregation:
 		data := row.Data.(*stats.MeanData)
-		return prometheus.NewConstMetric(desc, prometheus.GaugeValue, data.Mean, tagValues(row.Tags)...)
+		return prometheus.NewConstMetric(desc, prometheus.UntypedValue, data.Mean, tagValues(row.Tags)...)
 
 	case stats.SumAggregation:
 		data := row.Data.(*stats.SumData)
-		return prometheus.NewConstMetric(desc, prometheus.GaugeValue, float64(*data), tagValues(row.Tags)...)
+		return prometheus.NewConstMetric(desc, prometheus.UntypedValue, float64(*data), tagValues(row.Tags)...)
 
 	default:
 		return nil, fmt.Errorf("aggregation %T is not yet supported", view.Aggregation())


### PR DESCRIPTION
Gauges are a special type of value and their value is
determined by running a function that calculates the
some value and reports on the gauge usually periodically.

Sum and mean are not gauges but untyped simple metrics.