### PR TITLE
Don't allow collector to mutate the exported data

### DIFF
--- a/stats/aggregation_data.go
+++ b/stats/aggregation_data.go
@@ -28,6 +28,7 @@ type AggregationData interface {
 	addOther(other AggregationData)
 	multiplyByFraction(fraction float64) AggregationData
 	clear()
+	clone() AggregationData
 	equal(other AggregationData) bool
 }
 
@@ -48,6 +49,10 @@ func (a *CountData) isAggregationData() bool { return true }
 
 func (a *CountData) addSample(v interface{}) {
 	*a = *a + 1
+}
+
+func (a *CountData) clone() AggregationData {
+	return &(*a)
 }
 
 func (a *CountData) multiplyByFraction(fraction float64) AggregationData {
@@ -104,6 +109,10 @@ func (a *SumData) addSample(v interface{}) {
 
 func (a *SumData) multiplyByFraction(fraction float64) AggregationData {
 	return newSumData(float64(*a) * fraction)
+}
+
+func (a *SumData) clone() AggregationData {
+	return &(*a)
 }
 
 func (a *SumData) addOther(av AggregationData) {
@@ -164,6 +173,10 @@ func (a *MeanData) addSample(v interface{}) {
 		return
 	}
 	a.Mean = a.Mean + (f-a.Mean)/float64(a.Count)
+}
+
+func (a *MeanData) clone() AggregationData {
+	return &(*a)
 }
 
 // Only Count will be mutiplied by the fraction, Mean will remain the same.
@@ -331,6 +344,14 @@ func (a *DistributionData) clear() {
 	for i := range a.CountPerBucket {
 		a.CountPerBucket[i] = 0
 	}
+}
+
+func (a *DistributionData) clone() AggregationData {
+	counts := make([]int64, len(a.CountPerBucket))
+	copy(counts, a.CountPerBucket)
+	c := *a
+	c.CountPerBucket = counts
+	return &c
 }
 
 func (a *DistributionData) equal(other AggregationData) bool {

--- a/stats/worker.go
+++ b/stats/worker.go
@@ -268,7 +268,6 @@ func (w *worker) tryRegisterView(v *View) error {
 	}
 
 	w.views[v.Name()] = v
-
 	v.Measure().addView(v)
 	return nil
 }
@@ -287,6 +286,9 @@ func (w *worker) reportUsage(start time.Time) {
 				start = s
 			}
 		}
+		// Make sure collector is never going
+		// to mutate the exported data.
+		rows = deepCopy(rows)
 		viewData := &ViewData{
 			View:  v,
 			Start: start,
@@ -312,4 +314,38 @@ func isCumulative(v *View) bool {
 		return true
 	}
 	return false
+}
+
+func deepCopy(rows []*Row) []*Row {
+	// TODO(jbd): Find a better solution so each time
+	// we add a new aggreagtion data type, we don't have
+	// to modify this function.
+	newRows := make([]*Row, 0, len(rows))
+	for _, r := range rows {
+		var cloned AggregationData
+		switch d := r.Data.(type) {
+		case *CountData:
+			cloned = &(*d)
+		case *DistributionData:
+			counts := make([]int64, len(d.CountPerBucket))
+			copy(counts, d.CountPerBucket)
+			c := *d
+			c.CountPerBucket = counts
+			cloned = &c
+		case *SumData:
+			cloned = &(*d)
+		case *MeanData:
+			cloned = &(*d)
+		default:
+			// Panic, so we can easily tell we forgot
+			// to add support for the aggregation data type
+			// during development time.
+			panic("deep copy failed for unknown type")
+		}
+		newRows = append(newRows, &Row{
+			Data: cloned,
+			Tags: r.Tags,
+		})
+	}
+	return newRows
 }


### PR DESCRIPTION
Deep copy the aggregation data before exporting.

Fixes #206.