### PR TITLE
Fix stats doc typo

### DIFF
--- a/stats/export.go
+++ b/stats/export.go
@@ -34,9 +34,9 @@ type Exporter interface {
 
 // RegisterExporter registers an exporter.
 // Collected data will be reported via all the
-// registered exporters. Once you don't want data
-// to be expoter on the registered exporter, use
-// UnregisterExporter.
+// registered exporters. Once you no longer
+// want data to be exported, invoke UnregisterExporter
+// with the previously registered exporter.
 func RegisterExporter(e Exporter) {
 	exportersMu.Lock()
 	defer exportersMu.Unlock()


### PR DESCRIPTION
Noticed while reading through the godoc https://godoc.org/go.opencensus.io/stats#RegisterExporter
<img width="788" alt="screen shot 2017-12-15 at 2 21 43 pm" src="https://user-images.githubusercontent.com/4898263/34060977-4d977230-e1a3-11e7-9d0f-1de92573cfa4.png">
