### PR TITLE
Enforce singleton on Stackdriver's NewExporter per process

### DIFF
--- a/exporter/stats/stackdriver/stackdriver_test.go
+++ b/exporter/stats/stackdriver/stackdriver_test.go
@@ -24,24 +24,27 @@ import (
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/tag"
+	"google.golang.org/api/option"
 	distributionpb "google.golang.org/genproto/googleapis/api/distribution"
 	"google.golang.org/genproto/googleapis/api/label"
 	"google.golang.org/genproto/googleapis/api/metric"
 	metricpb "google.golang.org/genproto/googleapis/api/metric"
 	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
 	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
+var authOptions = []option.ClientOption{option.WithGRPCConn(&grpc.ClientConn{})}
+
 func TestRejectBlankProjectID(t *testing.T) {
 	ids := []string{"", "     ", " "}
 	for _, projectID := range ids {
-		opts := Options{ProjectID: projectID}
+		opts := Options{ProjectID: projectID, ClientOptions: authOptions}
 		exp, err := NewExporter(opts)
 		if err == nil || exp != nil {
-			t.Errorf("%q ProjectID must be rejected: NewExporter() = %v err = %q",
-				projectID, exp, err)
+			t.Errorf("%q ProjectID must be rejected: NewExporter() = %v err = %q", projectID, exp, err)
 		}
 	}
 }
@@ -51,7 +54,7 @@ func TestRejectBlankProjectID(t *testing.T) {
 func TestNewExporterSingletonPerProcess(t *testing.T) {
 	ids := []string{"open-census.io", "x", "fakeProjectID"}
 	for _, projectID := range ids {
-		opts := Options{ProjectID: projectID}
+		opts := Options{ProjectID: projectID, ClientOptions: authOptions}
 		exp, err := NewExporter(opts)
 		if err != nil {
 			t.Errorf("NewExporter() projectID = %q err = %q", projectID, err)
@@ -61,11 +64,9 @@ func TestNewExporterSingletonPerProcess(t *testing.T) {
 			t.Errorf("NewExporter returned a nil Exporter")
 			continue
 		}
-		for i := 0; i < 10; i++ {
-			exp, err := NewExporter(opts)
-			if err == nil || exp != nil {
-				t.Errorf("#%d: NewExporter more than once should fail; exp (%v) err %v", i, exp, err)
-			}
+		exp, err = NewExporter(opts)
+		if err == nil || exp != nil {
+			t.Errorf("NewExporter more than once should fail; exp (%v) err %v", exp, err)
 		}
 	}
 }

--- a/exporter/stats/stackdriver/stackdriver_test.go
+++ b/exporter/stats/stackdriver/stackdriver_test.go
@@ -34,18 +34,32 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+func TestRejectBlankProjectID(t *testing.T) {
+	ids := []string{"", "     ", " "}
+	for _, projectID := range ids {
+		opts := Options{ProjectID: projectID}
+		exp, err := NewExporter(opts)
+		if err == nil || exp != nil {
+			t.Errorf("%q ProjectID must be rejected: NewExporter() = %v err = %q",
+				projectID, exp, err)
+		}
+	}
+}
+
 // Ensure only one exporter per projectID per process, any
 // subsequent invocations of NewExporter should fail.
 func TestNewExporterSingletonPerProcess(t *testing.T) {
-	ids := []string{"", "x", "fakeProjectID"}
+	ids := []string{"open-census.io", "x", "fakeProjectID"}
 	for _, projectID := range ids {
 		opts := Options{ProjectID: projectID}
 		exp, err := NewExporter(opts)
 		if err != nil {
-			t.Fatalf("NewExporter() projectID = %q err = %q", projectID, err)
+			t.Errorf("NewExporter() projectID = %q err = %q", projectID, err)
+			continue
 		}
 		if exp == nil {
-			t.Fatalf("NewExporter returned a nil Exporter")
+			t.Errorf("NewExporter returned a nil Exporter")
+			continue
 		}
 		for i := 0; i < 10; i++ {
 			exp, err := NewExporter(opts)


### PR DESCRIPTION
For stats
stackdriver packages, NewExporter now implements the singleton
per unique ProjectID so that any subsequent invocations will return an error.
The purpose of fixing this bug is to avoid race conditions
on StackDriver monitoring when multiple exporters are sending
over the same data to the same ProjectID initialized instance of StackDriver.

Fixes #258.