### PR TITLE
Validate Key,Value pairs in seed Map for tag.NewContext

### DIFF
--- a/tag/key.go
+++ b/tag/key.go
@@ -25,7 +25,7 @@ type Key struct {
 // Calling NewKey consequently with the same name returns the same key.
 func NewKey(name string) (Key, error) {
 	if !checkKeyName(name) {
-		return Key{}, errInvalid
+		return Key{}, errInvalidKeyName
 	}
 	return km.newStringKey(name)
 }

--- a/tag/map.go
+++ b/tag/map.go
@@ -93,7 +93,7 @@ func Insert(k Key, v string) Mutator {
 	return &mutator{
 		fn: func(m *Map) (*Map, error) {
 			if !checkValue(v) {
-				return nil, errInvalid
+				return nil, errInvalidValue
 			}
 			m.insert(k, v)
 			return m, nil
@@ -108,7 +108,7 @@ func Update(k Key, v string) Mutator {
 	return &mutator{
 		fn: func(m *Map) (*Map, error) {
 			if !checkValue(v) {
-				return nil, errInvalid
+				return nil, errInvalidValue
 			}
 			m.update(k, v)
 			return m, nil
@@ -124,7 +124,7 @@ func Upsert(k Key, v string) Mutator {
 	return &mutator{
 		fn: func(m *Map) (*Map, error) {
 			if !checkValue(v) {
-				return nil, errInvalid
+				return nil, errInvalidValue
 			}
 			m.upsert(k, v)
 			return m, nil
@@ -146,11 +146,16 @@ func Delete(k Key) Mutator {
 // NewMap returns a new tag map originated from the incoming context
 // and modified with the provided mutators.
 func NewMap(ctx context.Context, mutator ...Mutator) (*Map, error) {
-	// TODO(jbd): Implement validation of keys and values.
 	m := newMap(0)
 	orig := FromContext(ctx)
 	if orig != nil {
 		for k, v := range orig.m {
+			if !checkKeyName(k.Name()) {
+				return nil, fmt.Errorf("key:%q: %v", k, errInvalidKeyName)
+			}
+			if !checkValue(v) {
+				return nil, fmt.Errorf("key:%q value:%q: %v", k.Name(), v, errInvalidValue)
+			}
 			m.insert(k, v)
 		}
 	}

--- a/tag/map_codec.go
+++ b/tag/map_codec.go
@@ -218,7 +218,7 @@ func Decode(bytes []byte) (*Map, error) {
 		}
 		val := string(v)
 		if !checkValue(val) {
-			return nil, errInvalid // no partial failures
+			return nil, errInvalidValue // no partial failures
 		}
 		ts.upsert(key, val)
 	}

--- a/tag/validate.go
+++ b/tag/validate.go
@@ -24,7 +24,10 @@ const (
 	validKeyValueMax = 126
 )
 
-var errInvalid = errors.New("invalid key name: only ASCII characters accepted; max length must be 255 characters")
+var (
+	errInvalidKeyName = errors.New("invalid key name: only ASCII characters accepted; max length must be 255 characters")
+	errInvalidValue   = errors.New("invalid value: only ASCII characters accepted; max length must be 255 characters")
+)
 
 func checkKeyName(name string) bool {
 	if len(name) == 0 {


### PR DESCRIPTION
Fixes #269

Validate the Key, Value pairs from the seed *Map that was
propagated in the input Context.