### PR TITLE
/exporter/trace/zipkin fix example

### DIFF
--- a/exporter/trace/zipkin/zipkin.go
+++ b/exporter/trace/zipkin/zipkin.go
@@ -19,7 +19,7 @@
 // 	import (
 // 		openzipkin "github.com/openzipkin/zipkin-go"
 // 		"github.com/openzipkin/zipkin-go/reporter/http"
-// 		"go.opencensus.io/trace/adaptor/zipkin"
+// 		"go.opencensus.io/exporter/trace/zipkin"
 // 	)
 //	...
 //		localEndpoint, err := openzipkin.NewEndpoint("server", "server:5454")


### PR DESCRIPTION
The example used an incorrect import path: `go.opencensus.io/trace/adaptor/zipkin`
It should be: `go.opencensus.io/exporter/trace/zipkin`