### PR TITLE
Tweak wording of StartSpan for an already existent span

### DIFF
--- a/trace/doc.go
+++ b/trace/doc.go
@@ -46,8 +46,8 @@ lines to the top of the function:
     ctx = trace.StartSpan(ctx, "your choice of name")
     defer trace.EndSpan(ctx)
 
-Invoking StartSpan with the name of an existing span will create a child span.
-Otherwise it will create a new top-level span.
+StartSpan will create a new top-level span if the context
+doesn't contain another span, otherwise it will create a child span.
 
 As a suggestion, use the fully-qualified function name as the span name, e.g.
 "github.com/me/mypackage.Run".

--- a/trace/doc.go
+++ b/trace/doc.go
@@ -46,8 +46,8 @@ lines to the top of the function:
     ctx = trace.StartSpan(ctx, "your choice of name")
     defer trace.EndSpan(ctx)
 
-Invoking StartSpan with the name of an already existent span will create a child span,
-otherwise it will create a new top-level span.
+Invoking StartSpan with the name of an existing span will create a child span.
+Otherwise it will create a new top-level span.
 
 As a suggestion, use the fully-qualified function name as the span name, e.g.
 "github.com/me/mypackage.Run".

--- a/trace/doc.go
+++ b/trace/doc.go
@@ -46,8 +46,8 @@ lines to the top of the function:
     ctx = trace.StartSpan(ctx, "your choice of name")
     defer trace.EndSpan(ctx)
 
-StartSpan will create a child span if one already exists, and will create a
-new top-level span otherwise.
+Invoking StartSpan with the name of an already existent span will create a child span,
+otherwise it will create a new top-level span.
 
 As a suggestion, use the fully-qualified function name as the span name, e.g.
 "github.com/me/mypackage.Run".


### PR DESCRIPTION
The previous doc seemed to imply that a child span would
be created if "the child span" already existed but
we meant to say that the child span would only be created
if there was an already existent span with the same name.