### PR TITLE
Implement a SanitizeNoClash that errors on same result but different inputs

### DIFF
--- a/exporter/stats/stackdriver/stackdriver.go
+++ b/exporter/stats/stackdriver/stackdriver.go
@@ -428,6 +428,8 @@ func namespacedViewName(v string, escaped bool) string {
 func newLabels(tags []tag.Tag, taskValue string) map[string]string {
 	labels := make(map[string]string)
 	for _, tag := range tags {
+		// TODO(odeke-em, rakyll): decide if we should
+		// instead use internal.SanitizeNoClash here
 		labels[internal.Sanitize(tag.Key.Name())] = tag.Value
 	}
 	labels[opencensusTaskKey] = taskValue
@@ -438,6 +440,8 @@ func newLabelDescriptors(keys []tag.Key) []*labelpb.LabelDescriptor {
 	labelDescriptors := make([]*labelpb.LabelDescriptor, len(keys)+1)
 	for i, key := range keys {
 		labelDescriptors[i] = &labelpb.LabelDescriptor{
+			// TODO(odeke-em, rakyll): decide if we should
+			// instead use internal.SanitizeNoClash here
 			Key:       internal.Sanitize(key.Name()),
 			ValueType: labelpb.LabelDescriptor_STRING, // We only use string tags
 		}
@@ -493,7 +497,11 @@ func equalAggWindowTagKeys(md *metricpb.MetricDescriptor, agg stats.Aggregation,
 
 	labels := make(map[string]struct{}, len(keys)+1)
 	for _, k := range keys {
-		labels[internal.Sanitize(k.Name())] = struct{}{}
+		sanitizedKey, err := internal.SanitizeNoClash(k.Name())
+		if err != nil {
+			return err
+		}
+		labels[sanitizedKey] = struct{}{}
 	}
 	labels[opencensusTaskKey] = struct{}{}
 


### PR DESCRIPTION
Updates #173

A sanitizer that returns an error if the input produces a sanitization
that clashes with a previous input that's lexicographically different
from the current one.

For example:

Sanitize("_0123?foo")    = "key_0123_foo"
Sanitize("key_0123?foo") = "key_0123_foo"
Sanitize("0123_foo")	 = "key_0123_foo"

and all the above clash so it returns an error telling the caller
what and where the clash is.