### PR TITLE
Simplify the trace package

### DIFF
--- a/examples/trace/helloworld/main.go
+++ b/examples/trace/helloworld/main.go
@@ -32,19 +32,16 @@ func main() {
 
 	trace.SetDefaultSampler(trace.AlwaysSample())
 
-	span := trace.NewSpan("/foo", trace.StartSpanOptions{})
-
-	ctx = trace.WithSpan(ctx, span)
+	ctx, span := trace.StartSpan(ctx, "/foo")
 	bar(ctx)
-
 	span.End()
 
 	time.Sleep(1 * time.Second) // Wait enough for the exporter to report.
 }
 
 func bar(ctx context.Context) {
-	ctx = trace.StartSpan(ctx, "/bar")
-	defer trace.EndSpan(ctx)
+	ctx, span := trace.StartSpan(ctx, "/bar")
+	defer span.End()
 
 	// Do bar...
 }

--- a/examples/trace/jaeger/main.go
+++ b/examples/trace/jaeger/main.go
@@ -41,16 +41,16 @@ func main() {
 	// For demoing purposes, always sample.
 	trace.SetDefaultSampler(trace.AlwaysSample())
 
-	ctx = trace.StartSpan(ctx, "/foo")
+	ctx, span := trace.StartSpan(ctx, "/foo")
 	bar(ctx)
-	trace.EndSpan(ctx)
+	span.End()
 
 	exporter.Flush()
 }
 
 func bar(ctx context.Context) {
-	ctx = trace.StartSpan(ctx, "/bar")
-	defer trace.EndSpan(ctx)
+	ctx, span := trace.StartSpan(ctx, "/bar")
+	defer span.End()
 
 	// Do bar...
 }

--- a/exporter/stackdriver/trace_test.go
+++ b/exporter/stackdriver/trace_test.go
@@ -37,8 +37,8 @@ func TestBundling(t *testing.T) {
 
 	trace.SetDefaultSampler(trace.AlwaysSample())
 	for i := 0; i < 35; i++ {
-		ctx := trace.StartSpan(context.Background(), "span")
-		trace.EndSpan(ctx)
+		_, span := trace.StartSpan(context.Background(), "span")
+		span.End()
 	}
 
 	// Read the first three bundles.

--- a/internal/readme/trace.go
+++ b/internal/readme/trace.go
@@ -24,7 +24,7 @@ func traceExamples() {
 	ctx := context.Background()
 
 	// START startend
-	ctx = trace.StartSpan(ctx, "your choice of name")
-	defer trace.EndSpan(ctx)
+	ctx, span := trace.StartSpan(ctx, "your choice of name")
+	defer span.End()
 	// END startend
 }

--- a/plugin/grpc/grpc_test.go
+++ b/plugin/grpc/grpc_test.go
@@ -37,7 +37,7 @@ func TestNewClientStatsHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	span := trace.NewSpan("/foo", trace.StartSpanOptions{
+	span := trace.NewSpan("/foo", nil, trace.StartOptions{
 		Sampler: trace.AlwaysSample(),
 	})
 	ctx = trace.WithSpan(ctx, span)
@@ -84,7 +84,7 @@ func TestNewServerStatsHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	span := trace.NewSpan("/foo", trace.StartSpanOptions{
+	span := trace.NewSpan("/foo", nil, trace.StartOptions{
 		Sampler: trace.AlwaysSample(),
 	})
 	ctx = trace.WithSpan(ctx, span)

--- a/plugin/http/httptrace/httptrace_test.go
+++ b/plugin/http/httptrace/httptrace_test.go
@@ -71,7 +71,7 @@ func (t testPropagator) ToRequest(sc trace.SpanContext, req *http.Request) {
 }
 
 func TestTransport_RoundTrip(t *testing.T) {
-	parent := trace.NewSpan("parent", trace.StartSpanOptions{})
+	parent := trace.NewSpan("parent", nil, trace.StartOptions{})
 	tests := []struct {
 		name       string
 		parent     *trace.Span
@@ -171,9 +171,9 @@ func TestEndToEnd(t *testing.T) {
 	trace.RegisterExporter(&spans)
 	defer trace.UnregisterExporter(&spans)
 
-	ctx := trace.StartSpanWithOptions(context.Background(),
+	ctx, _ := trace.StartSpanWithOptions(context.Background(),
 		"top-level",
-		trace.StartSpanOptions{
+		trace.StartOptions{
 			RecordEvents: true,
 			Sampler:      trace.AlwaysSample(),
 		})

--- a/trace/doc.go
+++ b/trace/doc.go
@@ -43,7 +43,7 @@ It is common to want to capture all the activity of a function call in a span. F
 this to work, the function must take a context.Context as a parameter. Add these two
 lines to the top of the function:
 
-    ctx = trace.StartSpan(ctx, "your choice of name")
+    ctx, _ = trace.StartSpan(ctx, "your choice of name")
     defer trace.EndSpan(ctx)
 
 StartSpan will create a new top-level span if the context

--- a/trace/doc.go
+++ b/trace/doc.go
@@ -43,8 +43,8 @@ It is common to want to capture all the activity of a function call in a span. F
 this to work, the function must take a context.Context as a parameter. Add these two
 lines to the top of the function:
 
-    ctx, _ = trace.StartSpan(ctx, "your choice of name")
-    defer trace.EndSpan(ctx)
+    ctx, span := trace.StartSpan(ctx, "your choice of name")
+    defer span.End()
 
 StartSpan will create a new top-level span if the context
 doesn't contain another span, otherwise it will create a child span.

--- a/trace/examples_test.go
+++ b/trace/examples_test.go
@@ -21,13 +21,13 @@ import (
 	"golang.org/x/net/context"
 )
 
-// This example shows how to use StartSpan and EndSpan to capture
+// This example shows how to use StartSpan and (*Span).End to capture
 // a function execution in a Span. It assumes that the function
 // has a context.Context argument.
 func ExampleStartSpan() {
 	printEvens := func(ctx context.Context) {
-		ctx = trace.StartSpan(ctx, "my/package.Function")
-		defer trace.EndSpan(ctx)
+		ctx, span := trace.StartSpan(ctx, "my/package.Function")
+		defer span.End()
 
 		for i := 0; i < 10; i++ {
 			if i%2 == 0 {

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -86,19 +86,9 @@ func checkChild(p SpanContext, c *Span, expectRecordingEvents bool) error {
 }
 
 func TestStartSpan(t *testing.T) {
-	ctx := StartSpan(context.Background(), "StartSpan")
+	ctx, _ := StartSpan(context.Background(), "StartSpan")
 	if FromContext(ctx).data != nil {
 		t.Error("StartSpan: new span is recording events")
-	}
-	sc, ok := SpanContextFromContext(ctx)
-	if !ok {
-		t.Error("StartSpan: no span in context")
-	}
-	if sc.SpanID == (SpanID{}) {
-		t.Error("StartSpan: got zero SpanID, want nonzero")
-	}
-	if sc.TraceOptions != 0 {
-		t.Errorf("StartSpan: got TraceOptions %x, want 0", sc.TraceOptions)
 	}
 }
 
@@ -146,7 +136,7 @@ func TestSampling(t *testing.T) {
 				SpanID:       sid,
 				TraceOptions: test.parentTraceOptions,
 			}
-			ctx = StartSpanWithRemoteParent(context.Background(), "foo", sc, StartSpanOptions{
+			ctx, _ = StartSpanWithRemoteParent(context.Background(), "foo", sc, StartOptions{
 				RecordEvents: test.recordEvents,
 				Sampler:      test.sampler,
 			})
@@ -155,19 +145,19 @@ func TestSampling(t *testing.T) {
 			if test.parentTraceOptions == 1 {
 				sampler = AlwaysSample()
 			}
-			ctx2 := StartSpanWithOptions(context.Background(), "foo", StartSpanOptions{Sampler: sampler})
-			ctx = StartSpanWithOptions(ctx2, "foo", StartSpanOptions{
+			ctx2, _ := StartSpanWithOptions(context.Background(), "foo", StartOptions{Sampler: sampler})
+			ctx, _ = StartSpanWithOptions(ctx2, "foo", StartOptions{
 				RecordEvents: test.recordEvents,
 				Sampler:      test.sampler,
 			})
 		} else {
-			ctx = StartSpanWithOptions(context.Background(), "foo", StartSpanOptions{
+			ctx, _ = StartSpanWithOptions(context.Background(), "foo", StartOptions{
 				RecordEvents: test.recordEvents,
 				Sampler:      test.sampler,
 			})
 		}
-		sc, ok := SpanContextFromContext(ctx)
-		if !ok {
+		sc := FromContext(ctx).SpanContext()
+		if (sc == SpanContext{}) {
 			t.Errorf("case %#v: starting new span: no span in context", test)
 			continue
 		}
@@ -204,12 +194,12 @@ func TestSampling(t *testing.T) {
 			if test.parentTraceOptions == 1 {
 				sampler = AlwaysSample()
 			}
-			ctx2 := StartSpanWithOptions(context.Background(), "foo", StartSpanOptions{Sampler: sampler})
-			ctx := StartSpanWithOptions(ctx2, "foo", StartSpanOptions{
+			ctx2, _ := StartSpanWithOptions(context.Background(), "foo", StartOptions{Sampler: sampler})
+			ctx, _ := StartSpanWithOptions(ctx2, "foo", StartOptions{
 				RecordEvents: test.recordEvents,
 			})
-			sc, ok := SpanContextFromContext(ctx)
-			if !ok {
+			sc := FromContext(ctx).SpanContext()
+			if (sc == SpanContext{}) {
 				t.Errorf("case %#v: starting new child of local span: no span in context", test)
 				continue
 			}
@@ -230,10 +220,10 @@ func TestSampling(t *testing.T) {
 func TestProbabilitySampler(t *testing.T) {
 	exported := 0
 	for i := 0; i < 1000; i++ {
-		ctx := StartSpanWithOptions(context.Background(), "foo", StartSpanOptions{
+		_, span := StartSpanWithOptions(context.Background(), "foo", StartOptions{
 			Sampler: ProbabilitySampler(0.3),
 		})
-		if IsSampled(ctx) {
+		if span.SpanContext().IsSampled() {
 			exported++
 		}
 	}
@@ -248,12 +238,12 @@ func TestStartSpanWithRemoteParent(t *testing.T) {
 		SpanID:       sid,
 		TraceOptions: 0x0,
 	}
-	ctx := StartSpanWithRemoteParent(context.Background(), "StartSpanWithRemoteParent", sc, StartSpanOptions{})
+	ctx, _ := StartSpanWithRemoteParent(context.Background(), "StartSpanWithRemoteParent", sc, StartOptions{})
 	if err := checkChild(sc, FromContext(ctx), false); err != nil {
 		t.Error(err)
 	}
 
-	ctx = StartSpanWithRemoteParent(context.Background(), "StartSpanWithRemoteParent", sc, StartSpanOptions{RecordEvents: true})
+	ctx, _ = StartSpanWithRemoteParent(context.Background(), "StartSpanWithRemoteParent", sc, StartOptions{RecordEvents: true})
 	if err := checkChild(sc, FromContext(ctx), true); err != nil {
 		t.Error(err)
 	}
@@ -263,32 +253,32 @@ func TestStartSpanWithRemoteParent(t *testing.T) {
 		SpanID:       sid,
 		TraceOptions: 0x1,
 	}
-	ctx = StartSpanWithRemoteParent(context.Background(), "StartSpanWithRemoteParent", sc, StartSpanOptions{})
+	ctx, _ = StartSpanWithRemoteParent(context.Background(), "StartSpanWithRemoteParent", sc, StartOptions{})
 	if err := checkChild(sc, FromContext(ctx), true); err != nil {
 		t.Error(err)
 	}
 
-	ctx = StartSpanWithRemoteParent(context.Background(), "StartSpanWithRemoteParent", sc, StartSpanOptions{RecordEvents: true})
+	ctx, _ = StartSpanWithRemoteParent(context.Background(), "StartSpanWithRemoteParent", sc, StartOptions{RecordEvents: true})
 	if err := checkChild(sc, FromContext(ctx), true); err != nil {
 		t.Error(err)
 	}
 
-	ctx2 := StartSpan(ctx, "StartSpan")
-	parent, _ := SpanContextFromContext(ctx)
+	ctx2, _ := StartSpan(ctx, "StartSpan")
+	parent := FromContext(ctx).SpanContext()
 	if err := checkChild(parent, FromContext(ctx2), true); err != nil {
 		t.Error(err)
 	}
 }
 
 // startSpan returns a context with a new Span that is recording events and will be exported.
-func startSpan() context.Context {
-	return StartSpanWithRemoteParent(context.Background(), "span0",
+func startSpan() *Span {
+	return NewSpanWithRemoteParent("span0",
 		SpanContext{
 			TraceID:      tid,
 			SpanID:       sid,
 			TraceOptions: 1,
 		},
-		StartSpanOptions{
+		StartOptions{
 			RecordEvents: true,
 		})
 }
@@ -304,16 +294,17 @@ func (t *testExporter) ExportSpan(s *SpanData) {
 // endSpan ends the Span in the context and returns the exported SpanData.
 //
 // It also does some tests on the Span, and tests and clears some fields in the SpanData.
-func endSpan(ctx context.Context) (*SpanData, error) {
-	if !IsRecordingEvents(ctx) {
+func endSpan(span *Span) (*SpanData, error) {
+
+	if !span.IsRecordingEvents() {
 		return nil, fmt.Errorf("IsRecordingEvents: got false, want true")
 	}
-	if !IsSampled(ctx) {
+	if !span.SpanContext().IsSampled() {
 		return nil, fmt.Errorf("IsSampled: got false, want true")
 	}
 	var te testExporter
 	RegisterExporter(&te)
-	EndSpan(ctx)
+	span.End()
 	UnregisterExporter(&te)
 	if len(te.spans) != 1 {
 		return nil, fmt.Errorf("got exported spans %#v, want one span", te.spans)
@@ -342,9 +333,9 @@ func checkTime(x *time.Time) bool {
 }
 
 func TestSetSpanAttributes(t *testing.T) {
-	ctx := startSpan()
-	SetSpanAttributes(ctx, StringAttribute{"key1", "value1"})
-	got, err := endSpan(ctx)
+	span := startSpan()
+	span.SetAttributes(StringAttribute{"key1", "value1"})
+	got, err := endSpan(span)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -366,10 +357,10 @@ func TestSetSpanAttributes(t *testing.T) {
 }
 
 func TestAnnotations(t *testing.T) {
-	ctx := startSpan()
-	Annotatef(ctx, []Attribute{StringAttribute{"key1", "value1"}}, "%f", 1.5)
-	Annotate(ctx, []Attribute{StringAttribute{"key2", "value2"}}, "Annotate")
-	got, err := endSpan(ctx)
+	span := startSpan()
+	span.Annotatef([]Attribute{StringAttribute{"key1", "value1"}}, "%f", 1.5)
+	span.Annotate([]Attribute{StringAttribute{"key2", "value2"}}, "Annotate")
+	got, err := endSpan(span)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -400,10 +391,10 @@ func TestAnnotations(t *testing.T) {
 }
 
 func TestMessageEvents(t *testing.T) {
-	ctx := startSpan()
-	AddMessageReceiveEvent(ctx, 3, 400, 300)
-	AddMessageSendEvent(ctx, 1, 200, 100)
-	got, err := endSpan(ctx)
+	span := startSpan()
+	span.AddMessageReceiveEvent(3, 400, 300)
+	span.AddMessageSendEvent(1, 200, 100)
+	got, err := endSpan(span)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -434,9 +425,9 @@ func TestMessageEvents(t *testing.T) {
 }
 
 func TestSetSpanStatus(t *testing.T) {
-	ctx := startSpan()
-	SetSpanStatus(ctx, Status{Code: int32(1), Message: "request failed"})
-	got, err := endSpan(ctx)
+	span := startSpan()
+	span.SetStatus(Status{Code: int32(1), Message: "request failed"})
+	got, err := endSpan(span)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -458,14 +449,14 @@ func TestSetSpanStatus(t *testing.T) {
 }
 
 func TestAddLink(t *testing.T) {
-	ctx := startSpan()
-	AddLink(ctx, Link{
+	span := startSpan()
+	span.AddLink(Link{
 		TraceID:    tid,
 		SpanID:     sid,
 		Type:       LinkTypeParent,
 		Attributes: map[string]interface{}{"key5": "value5"},
 	})
-	got, err := endSpan(ctx)
+	got, err := endSpan(span)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -566,9 +557,9 @@ func Test_Issue328_EndSpanTwice(t *testing.T) {
 	RegisterExporter(&spans)
 	defer UnregisterExporter(&spans)
 	ctx := context.Background()
-	ctx = StartSpanWithOptions(ctx, "span-1", StartSpanOptions{Sampler: AlwaysSample()})
-	EndSpan(ctx)
-	EndSpan(ctx)
+	ctx, span := StartSpanWithOptions(ctx, "span-1", StartOptions{Sampler: AlwaysSample()})
+	span.End()
+	span.End()
 	UnregisterExporter(&spans)
 	if len(spans) != 1 {
 		t.Fatalf("expected only a single span, got %#v", spans)
@@ -579,14 +570,14 @@ func TestStartSpanAfterEnd(t *testing.T) {
 	spans := make(exporter)
 	RegisterExporter(&spans)
 	defer UnregisterExporter(&spans)
-	ctx := StartSpanWithOptions(context.Background(), "parent", StartSpanOptions{Sampler: AlwaysSample()})
-	ctx1 := StartSpanWithOptions(ctx, "span-1", StartSpanOptions{Sampler: AlwaysSample()})
-	EndSpan(ctx1)
+	ctx, span0 := StartSpanWithOptions(context.Background(), "parent", StartOptions{Sampler: AlwaysSample()})
+	ctx1, span1 := StartSpanWithOptions(ctx, "span-1", StartOptions{Sampler: AlwaysSample()})
+	span1.End()
 	// Start a new span with the context containing span-1
 	// even though span-1 is ended, we still add this as a new child of span-1
-	ctx2 := StartSpanWithOptions(ctx1, "span-2", StartSpanOptions{Sampler: AlwaysSample()})
-	EndSpan(ctx2)
-	EndSpan(ctx)
+	_, span2 := StartSpanWithOptions(ctx1, "span-2", StartOptions{Sampler: AlwaysSample()})
+	span2.End()
+	span0.End()
 	UnregisterExporter(&spans)
 	if got, want := len(spans), 3; got != want {
 		t.Fatalf("len(%#v) = %d; want %d", spans, got, want)

--- a/zpages/rpcz.go
+++ b/zpages/rpcz.go
@@ -198,7 +198,7 @@ func getSummaryPageData() summaryPageData {
 		Links:          true,
 		TracesEndpoint: "/tracez",
 	}
-	for name, s := range trace.SampledSpansSummary() {
+	for name, s := range trace.ReportSpansPerMethod() {
 		if len(data.Header) == 0 {
 			data.Header = []string{"Name", "Active"}
 			for _, b := range s.LatencyBuckets {

--- a/zpages/tracez.go
+++ b/zpages/tracez.go
@@ -335,7 +335,7 @@ func traceSpans(spanName string, spanType, spanSubtype int) []*trace.SpanData {
 	var spans []*trace.SpanData
 	switch spanType {
 	case 0: // active
-		spans = trace.ActiveSpans(spanName)
+		spans = trace.ReportActiveSpans(spanName)
 	case 1: // latency
 		var min, max time.Duration
 		n := len(defaultLatencies)
@@ -346,9 +346,9 @@ func traceSpans(spanName string, spanType, spanSubtype int) []*trace.SpanData {
 		} else if 0 < spanSubtype && spanSubtype < n {
 			min, max = defaultLatencies[spanSubtype-1], defaultLatencies[spanSubtype]
 		}
-		spans = trace.LatencySampledSpans(spanName, min, max)
+		spans = trace.ReportSpansByLatency(spanName, min, max)
 	case 2: // error
-		spans = trace.ErrorSampledSpans(spanName, 0)
+		spans = trace.ReportSpansByError(spanName, 0)
 	}
 	return spans
 }


### PR DESCRIPTION
- NewSpan now can create children; (*Span).StartSpan is removed.
- s/StartSpanOptions/StartOptions to help the verbosity.
- Only connivance functions works against the context object, Span type provides the full API.
- Introspection functions are prefixed with Report* that make them distinguishable.

