### PR TITLE
Introduce tag.Do for profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,30 @@ ctx = trace.StartSpan(ctx, "your choice of name")
 defer trace.EndSpan(ctx)
 ```
 
+More tracing examples are coming soon...
+
+## Profiling
+
+OpenCensus tags can be applied as profiler labels
+for users who are on Go 1.9 and above.
+
+[embedmd]:# (tags.go profiler)
+```go
+tagMap, err = tag.NewMap(ctx,
+	tag.Insert(key, "macOS-10.12.5"),
+	tag.Upsert(key, "macOS-10.12.7"),
+	tag.Upsert(userIDKey, "fff0989878"),
+)
+if err != nil {
+	log.Fatal(err)
+}
+tag.Do(ctx, tagMap, func(ctx context.Context) {
+	// Do work.
+	// When profiling is on, samples will be
+	// recorded with the key/values from the tag map.
+})
+```
+
 
 [travis-image]: https://travis-ci.org/census-instrumentation/opencensus-go.svg?branch=master
 [travis-url]: https://travis-ci.org/census-instrumentation/opencensus-go

--- a/internal/readme/source.md
+++ b/internal/readme/source.md
@@ -156,6 +156,15 @@ An example logger exporter is below:
 
 [embedmd]:# (trace.go startend)
 
+More tracing examples are coming soon...
+
+## Profiling
+
+OpenCensus tags can be applied as profiler labels
+for users who are on Go 1.9 and above.
+
+[embedmd]:# (tags.go profiler)
+
 
 [travis-image]: https://travis-ci.org/census-instrumentation/opencensus-go.svg?branch=master
 [travis-url]: https://travis-ci.org/census-instrumentation/opencensus-go

--- a/internal/readme/tags.go
+++ b/internal/readme/tags.go
@@ -68,4 +68,19 @@ func tagsExamples() {
 	ctx = tag.NewContext(ctx, tagMap)
 	// END replaceTagMap
 
+	// START profiler
+	tagMap, err = tag.NewMap(ctx,
+		tag.Insert(key, "macOS-10.12.5"),
+		tag.Upsert(key, "macOS-10.12.7"),
+		tag.Upsert(userIDKey, "fff0989878"),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	tag.Do(ctx, tagMap, func(ctx context.Context) {
+		// Do work.
+		// When profiling is on, samples will be
+		// recorded with the key/values from the tag map.
+	})
+	// END profiler
 }

--- a/tag/map.go
+++ b/tag/map.go
@@ -169,6 +169,16 @@ func NewMap(ctx context.Context, mutator ...Mutator) (*Map, error) {
 	return m, nil
 }
 
+// Do is similar to pprof.Do.
+//
+// It converts the key/values from the given map to Go profiler labels
+// and calls pprof.Do.
+//
+// Do is going to do nothing if your Go version is below 1.9.
+func Do(ctx context.Context, m *Map, f func(ctx context.Context)) {
+	do(ctx, m, f)
+}
+
 type mutator struct {
 	fn func(t *Map) (*Map, error)
 }

--- a/tag/profile_19.go
+++ b/tag/profile_19.go
@@ -1,0 +1,30 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build go1.9
+
+package tag
+
+import (
+	"context"
+	"runtime/pprof"
+)
+
+func do(ctx context.Context, m *Map, f func(ctx context.Context)) {
+	keyvals := make([]string, 0, 2*len(m.m))
+	for k, v := range m.m {
+		keyvals = append(keyvals, k.Name(), v)
+	}
+	pprof.Do(ctx, pprof.Labels(keyvals...), f)
+}

--- a/tag/profile_not19.go
+++ b/tag/profile_not19.go
@@ -1,0 +1,21 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !go1.9
+
+package tag
+
+import "context"
+
+func do(ctx context.Context, m *Map, f func(ctx context.Context)) {}


### PR DESCRIPTION
tag.Do labels the profiler samples with the key values from the tag map. It is only enabled for users
who are running Go 1.9 and above.

Fixes #45.
