### PR TITLE
tag.Do: call f on pre-1.9 to preserve program behavior.

### DIFF
--- a/tag/map_test.go
+++ b/tag/map_test.go
@@ -40,6 +40,20 @@ func TestContext(t *testing.T) {
 	}
 }
 
+func TestDoFunctionCalled(t *testing.T) {
+	ctx := context.Background()
+	want, _ := NewMap(ctx)
+	called := false
+
+	Do(ctx, want, func(ctx context.Context) {
+			called = true
+	})
+
+	if !called {
+		t.Errorf("function should be called")
+	}
+}
+
 func TestNewMap(t *testing.T) {
 	k1, _ := NewKey("k1")
 	k2, _ := NewKey("k2")

--- a/tag/profile_not19.go
+++ b/tag/profile_not19.go
@@ -18,4 +18,6 @@ package tag
 
 import "context"
 
-func do(ctx context.Context, m *Map, f func(ctx context.Context)) {}
+func do(ctx context.Context, m *Map, f func(ctx context.Context)) {
+	f(ctx)
+}


### PR DESCRIPTION
pprof.Do internally calls f. On pre-1.9, we should also call f so the caller
doesn't themselves need to write code conditional on the Go version.