### PR TITLE
stats: Measurement doesn't need to be a pointer.

### DIFF
--- a/plugin/grpc/grpcstats/client_handler.go
+++ b/plugin/grpc/grpcstats/client_handler.go
@@ -139,7 +139,7 @@ func (h *ClientStatsHandler) handleRPCEnd(ctx context.Context, s *stats.End) {
 	reqCount := atomic.LoadInt64(&d.reqCount)
 	respCount := atomic.LoadInt64(&d.respCount)
 
-	m := []*istats.Measurement{
+	m := []istats.Measurement{
 		RPCClientRequestCount.M(reqCount),
 		RPCClientResponseCount.M(respCount),
 		RPCClientFinishedCount.M(1),

--- a/plugin/grpc/grpcstats/server_handler.go
+++ b/plugin/grpc/grpcstats/server_handler.go
@@ -132,7 +132,7 @@ func (h *ServerStatsHandler) handleRPCEnd(ctx context.Context, s *stats.End) {
 	reqCount := atomic.LoadInt64(&d.reqCount)
 	respCount := atomic.LoadInt64(&d.respCount)
 
-	m := []*istats.Measurement{
+	m := []istats.Measurement{
 		RPCServerRequestCount.M(reqCount),
 		RPCServerResponseCount.M(respCount),
 		RPCServerFinishedCount.M(1),

--- a/stats/benchmark_test.go
+++ b/stats/benchmark_test.go
@@ -1,0 +1,27 @@
+package stats
+
+import (
+	"testing"
+	"log"
+	"context"
+)
+
+
+func BenchmarkRecord(b *testing.B) {
+	restart()
+	var m = makeMeasure()
+	var ctx = context.Background()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		Record(ctx, m.M(1), m.M(1), m.M(1), m.M(1), m.M(1), m.M(1), m.M(1), m.M(1), m.M(1), m.M(1))
+	}
+}
+
+func makeMeasure() *MeasureInt64 {
+	m, err := NewMeasureInt64("m", "test measure", "")
+	if err != nil {
+		log.Fatal(err)
+	}
+	return m
+}

--- a/stats/measure_float64.go
+++ b/stats/measure_float64.go
@@ -39,6 +39,6 @@ func (m *MeasureFloat64) Unit() string {
 
 // M creates a new float64 measurement.
 // Use Record to record measurements.
-func (m *MeasureFloat64) M(v float64) *Measurement {
-	return &Measurement{m: m, v: v}
+func (m *MeasureFloat64) M(v float64) Measurement {
+	return Measurement{m: m, v: v}
 }

--- a/stats/measure_int64.go
+++ b/stats/measure_int64.go
@@ -39,6 +39,6 @@ func (m *MeasureInt64) Unit() string {
 
 // M creates a new int64 measurement.
 // Use Record to record measurements.
-func (m *MeasureInt64) M(v int64) *Measurement {
-	return &Measurement{m: m, v: v}
+func (m *MeasureInt64) M(v int64) Measurement {
+	return Measurement{m: m, v: v}
 }

--- a/stats/worker.go
+++ b/stats/worker.go
@@ -181,7 +181,7 @@ func (v *View) RetrieveData() ([]*Row, error) {
 
 // Record records one or multiple measurements with the same tags at once.
 // If there are any tags in the context, measurements will be tagged with them.
-func Record(ctx context.Context, ms ...*Measurement) {
+func Record(ctx context.Context, ms ...Measurement) {
 	req := &recordReq{
 		now: time.Now(),
 		tm:  tag.FromContext(ctx),

--- a/stats/worker_commands.go
+++ b/stats/worker_commands.go
@@ -211,7 +211,7 @@ func (cmd *retrieveDataReq) handleCommand(w *worker) {
 type recordReq struct {
 	now time.Time
 	tm  *tag.Map
-	ms  []*Measurement
+	ms  []Measurement
 }
 
 func (cmd *recordReq) handleCommand(w *worker) {


### PR DESCRIPTION
Also added a simple benchmark to show that we reduce allocations by not using pointers.

Before:

```
go test -bench=BenchmarkRecord -benchmem -benchtime=3s
goos: darwin
goarch: amd64
pkg: go.opencensus.io/stats
BenchmarkRecord-8   	 2000000	      2816 ns/op	     600 B/op	      24 allocs/op
PASS
ok  	go.opencensus.io/stats	8.939s
```

After:

```
go test -bench=BenchmarkRecord -benchmem -benchtime=3s
goos: darwin
goarch: amd64
pkg: go.opencensus.io/stats
BenchmarkRecord-8   	 2000000	      2393 ns/op	     520 B/op	      14 allocs/op
PASS
ok  	go.opencensus.io/stats	7.647s
```