### PR TITLE
tag: simplify key type check in decode

### DIFF
--- a/tag/map_codec.go
+++ b/tag/map_codec.go
@@ -195,10 +195,7 @@ func Decode(bytes []byte) (*Map, error) {
 	for !eg.readEnded() {
 		typ := keyType(eg.readByte())
 
-		switch typ {
-		case keyTypeString:
-			break
-		default:
+		if typ != keyTypeString {
 			return nil, fmt.Errorf("cannot decode: invalid key type: %q", typ)
 		}
 


### PR DESCRIPTION
Would remove `break` first since it's unnecessary but then thought `if` would be simpler.
  