### PR TITLE
 Add HTTP propagation support for traces

### DIFF
--- a/plugin/http/httptrace/httptrace.go
+++ b/plugin/http/httptrace/httptrace.go
@@ -1,0 +1,120 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package httptrace contains OpenCensus tracing integrations with net/http.
+package httptrace
+
+import (
+	"net/http"
+	"strings"
+
+	"go.opencensus.io/trace"
+	"go.opencensus.io/trace/propagation"
+)
+
+const httpHeader = `X-Cloud-Trace-Context`
+
+type transport struct {
+	base        http.RoundTripper
+	propogators []propagation.HTTPPropagator
+}
+
+// RoundTrip creates a trace.Span and inserts it into the outgoing request's headers.
+// The created span can follow a parent span, if a parent is presented in
+// the request's context.
+func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	name := "Sent" + strings.Replace(req.URL.String(), req.URL.Scheme, ".", -1)
+	ctx := trace.StartSpan(req.Context(), name)
+	req = req.WithContext(ctx)
+
+	span := trace.FromContext(ctx)
+	for _, p := range t.propogators {
+		req = p.ToRequest(span.SpanContext(), req)
+	}
+
+	resp, err := t.base.RoundTrip(req)
+
+	// TODO(jbd): Add status and attributes.
+	trace.EndSpan(ctx)
+	return resp, err
+}
+
+// CancelRequest cancels an in-flight request by closing its connection.
+func (t *transport) CancelRequest(req *http.Request) {
+	type canceler interface {
+		CancelRequest(*http.Request)
+	}
+	if cr, ok := t.base.(canceler); ok {
+		cr.CancelRequest(req)
+	}
+}
+
+// NewTransport returns an http.RoundTripper that traces the outgoing requests.
+//
+// All the requests are done by the given base roundtripper. If nil is given,
+// http.DefaultTransport is used.
+//
+// Traces are propagated via the provided HTTP propagation mechanisms.
+func NewTransport(base http.RoundTripper, p ...propagation.HTTPPropagator) http.RoundTripper {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return &transport{base: base, propogators: p}
+}
+
+// NewHandler returns a http.Handler from the given handler
+// that is aware of the incoming request's span.
+// The span can be extracted from the incoming request in handler
+// functions from incoming request's context:
+//
+//    span := trace.FromContext(r.Context())
+//
+// The span will be auto finished by the handler.
+//
+// Incoming propagation mechanism is determined by the given HTTP propagators.
+func NewHandler(base http.Handler, p ...propagation.HTTPPropagator) http.Handler {
+	return &handler{handler: base, propogators: p}
+}
+
+type handler struct {
+	handler     http.Handler
+	propogators []propagation.HTTPPropagator
+}
+
+func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	name := "Recv" + strings.Replace(r.URL.String(), r.URL.Scheme, ".", -1)
+
+	var (
+		sc trace.SpanContext
+		ok bool
+	)
+
+	ctx := r.Context()
+	for _, p := range h.propogators {
+		sc, ok = p.FromRequest(r)
+		if ok {
+			break
+		}
+	}
+	if ok {
+		ctx = trace.StartSpanWithRemoteParent(ctx, name, sc, trace.StartSpanOptions{})
+	} else {
+		ctx = trace.StartSpan(ctx, name)
+	}
+	defer trace.EndSpan(ctx)
+
+	// TODO(jbd): Add status and attributes.
+	r = r.WithContext(ctx)
+	h.handler.ServeHTTP(w, r)
+}

--- a/plugin/http/httptrace/httptrace_test.go
+++ b/plugin/http/httptrace/httptrace_test.go
@@ -53,13 +53,12 @@ func (t *testPropagator) FromRequest(req *http.Request) (sc trace.SpanContext, o
 	return sc, true
 }
 
-func (t *testPropagator) ToRequest(sc trace.SpanContext, req *http.Request) *http.Request {
+func (t *testPropagator) ToRequest(sc trace.SpanContext, req *http.Request) {
 	var buf bytes.Buffer
 	buf.Write(sc.TraceID[:])
 	buf.Write(sc.SpanID[:])
 	buf.WriteByte(byte(sc.TraceOptions))
 	req.Header.Set("trace", hex.EncodeToString(buf.Bytes()))
-	return req
 }
 
 func TestTransport_RoundTrip(t *testing.T) {

--- a/plugin/http/httptrace/httptrace_test.go
+++ b/plugin/http/httptrace/httptrace_test.go
@@ -1,0 +1,149 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httptrace
+
+import (
+	"bytes"
+	"encoding/hex"
+	"errors"
+	"log"
+	"net/http"
+	"testing"
+
+	"go.opencensus.io/trace"
+)
+
+type testTransport struct {
+	ch chan *http.Request
+}
+
+func (t *testTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.ch <- req
+	return nil, errors.New("noop")
+}
+
+type testPropagator struct{}
+
+func (t *testPropagator) FromRequest(req *http.Request) (sc trace.SpanContext, ok bool) {
+	header := req.Header.Get("trace")
+	buf, err := hex.DecodeString(header)
+	if err != nil {
+		log.Fatalf("Cannot decode trace header: %q", header)
+	}
+	r := bytes.NewReader(buf)
+	r.Read(sc.TraceID[:])
+	r.Read(sc.SpanID[:])
+	opts, err := r.ReadByte()
+	if err != nil {
+		log.Fatalf("Cannot read trace options from trace header: %q", header)
+	}
+	sc.TraceOptions = trace.TraceOptions(opts)
+	return sc, true
+}
+
+func (t *testPropagator) ToRequest(sc trace.SpanContext, req *http.Request) *http.Request {
+	var buf bytes.Buffer
+	buf.Write(sc.TraceID[:])
+	buf.Write(sc.SpanID[:])
+	buf.WriteByte(byte(sc.TraceOptions))
+	req.Header.Set("trace", hex.EncodeToString(buf.Bytes()))
+	return req
+}
+
+func TestTransport_RoundTrip(t *testing.T) {
+	parent := trace.NewSpan("parent", trace.StartSpanOptions{})
+	tests := []struct {
+		name       string
+		parent     *trace.Span
+		wantHeader string
+	}{
+		{
+			name:   "no parent",
+			parent: nil,
+		},
+		{
+			name:   "parent",
+			parent: parent,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := &testTransport{ch: make(chan *http.Request, 1)}
+			rt := NewTransport(transport, &testPropagator{})
+
+			req, _ := http.NewRequest("GET", "http://foo.com", nil)
+			if tt.parent != nil {
+				req = req.WithContext(trace.WithSpan(req.Context(), tt.parent))
+			}
+			rt.RoundTrip(req)
+
+			req = <-transport.ch
+			span := trace.FromContext(req.Context())
+
+			if header := req.Header.Get("trace"); header == "" {
+				t.Fatalf("Trace header = empty; want valid trace header")
+			}
+			if span == nil {
+				t.Fatalf("Got no spans in req context; want one")
+			}
+			if tt.parent != nil {
+				if got, want := span.SpanContext().TraceID, tt.parent.SpanContext().TraceID; got != want {
+					t.Errorf("span.SpanContext().TraceID=%v; want %v", got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestHandler(t *testing.T) {
+	traceID := [16]byte{16, 84, 69, 170, 120, 67, 188, 139, 242, 6, 177, 32, 0, 16, 0, 0}
+	tests := []struct {
+		header           string
+		wantTraceID      trace.TraceID
+		wantTraceOptions trace.TraceOptions
+	}{
+		{
+			header:           "105445aa7843bc8bf206b12000100000000000000000000000",
+			wantTraceID:      traceID,
+			wantTraceOptions: trace.TraceOptions(0),
+		},
+		{
+			header:           "105445aa7843bc8bf206b12000100000000000000000000001",
+			wantTraceID:      traceID,
+			wantTraceOptions: trace.TraceOptions(1),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.header, func(t *testing.T) {
+			propagator := &testPropagator{}
+
+			handler := NewHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				span := trace.FromContext(r.Context())
+				sc := span.SpanContext()
+				if got, want := sc.TraceID, tt.wantTraceID; got != want {
+					t.Errorf("TraceID = %q; want %q", got, want)
+				}
+				if got, want := sc.TraceOptions, tt.wantTraceOptions; got != want {
+					t.Errorf("TraceOptions = %v; want %v", got, want)
+				}
+			}), propagator)
+			req, _ := http.NewRequest("GET", "http://foo.com", nil)
+			req.Header.Add("trace", tt.header)
+			handler.ServeHTTP(nil, req)
+		})
+	}
+}

--- a/trace/propagation/propagation.go
+++ b/trace/propagation/propagation.go
@@ -92,15 +92,17 @@ func FromBinary(b []byte) (sc trace.SpanContext, ok bool) {
 	return sc, true
 }
 
-// HTTPPropagator propoagates span contexts in HTTP requests.
+// HTTPFormat implementations propoagates span contexts
+// in HTTP requests.
 //
 // FromRequest extracts a span context from incoming
-// requests. If the request doesn't contain a trace header,
-// nil is returned.
+// requests.
 //
 // ToRequest modifies the given request to include the given
-// span context in the request. Modified request is returned.
-type HTTPPropagator interface {
+// span context.
+type HTTPFormat interface {
 	FromRequest(req *http.Request) (sc trace.SpanContext, ok bool)
-	ToRequest(sc trace.SpanContext, req *http.Request) *http.Request
+	ToRequest(sc trace.SpanContext, req *http.Request)
 }
+
+// TODO(jbd): Find a more representative but short name for HTTPFormat.

--- a/trace/propagation/propagation.go
+++ b/trace/propagation/propagation.go
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 // Package propagation implements the binary trace context format.
-//
-// TODO: link to external spec document.
 package propagation
+
+// TODO: link to external spec document.
 
 // BinaryFormat format:
 //
@@ -46,6 +46,8 @@ package propagation
 // trace_options = {1};
 
 import (
+	"net/http"
+
 	"go.opencensus.io/trace"
 )
 
@@ -88,4 +90,17 @@ func FromBinary(b []byte) (sc trace.SpanContext, ok bool) {
 		sc.TraceOptions = trace.TraceOptions(b[1])
 	}
 	return sc, true
+}
+
+// HTTPPropagator propoagates span contexts in HTTP requests.
+//
+// FromRequest extracts a span context from incoming
+// requests. If the request doesn't contain a trace header,
+// nil is returned.
+//
+// ToRequest modifies the given request to include the given
+// span context in the request. Modified request is returned.
+type HTTPPropagator interface {
+	FromRequest(req *http.Request) (sc trace.SpanContext, ok bool)
+	ToRequest(sc trace.SpanContext, req *http.Request) *http.Request
 }


### PR DESCRIPTION
The change introduces propagation.HTTPFormat. Implementations of HTTPFormat allows trace context to be propagated in HTTP requests.

The change also includes tracing integrations with the net/http package.

Updates #285.