### PR TITLE
Revise annotation APIs

### DIFF
--- a/exporter/trace/stackdriver/proto_test.go
+++ b/exporter/trace/stackdriver/proto_test.go
@@ -71,8 +71,8 @@ func TestExportTrace(t *testing.T) {
 		{
 			ctx2 := trace.StartSpan(ctx1, "span2")
 			trace.AddMessageSendEvent(ctx2, 0x123, 1024, 512)
-			trace.LazyPrintf(ctx2, "in span%d", 2)
-			trace.LazyPrint(ctx2, big.NewRat(2, 4))
+			trace.Annotatef(ctx2, nil, "in span%d", 2)
+			trace.Annotate(ctx2, nil, big.NewRat(2, 4).String())
 			trace.SetSpanAttributes(ctx2,
 				trace.StringAttribute{Key: "key1", Value: "value1"},
 				trace.StringAttribute{Key: "key2", Value: "value2"})
@@ -81,7 +81,7 @@ func TestExportTrace(t *testing.T) {
 		}
 		{
 			ctx3 := trace.StartSpan(ctx1, "span3")
-			trace.Print(ctx3, "in span3")
+			trace.Annotate(ctx3, nil, "in span3")
 			trace.AddMessageReceiveEvent(ctx3, 0x456, 2048, 1536)
 			trace.SetSpanStatus(ctx3, trace.Status{Code: int32(codepb.Code_UNAVAILABLE)})
 			trace.EndSpan(ctx3)
@@ -93,9 +93,9 @@ func TestExportTrace(t *testing.T) {
 				a3 := []trace.Attribute{trace.StringAttribute{Key: "k3", Value: "v3"}}
 				a4 := map[string]interface{}{"k4": "v4"}
 				r := big.NewRat(2, 4)
-				trace.LazyPrintWithAttributes(ctx4, a1, r)
-				trace.LazyPrintfWithAttributes(ctx4, a2, "foo %d", x)
-				trace.PrintWithAttributes(ctx4, a3, "in span4")
+				trace.Annotate(ctx4, a1, r.String())
+				trace.Annotatef(ctx4, a2, "foo %d", x)
+				trace.Annotate(ctx4, a3, "in span4")
 				trace.AddLink(ctx4, trace.Link{TraceID: trace.TraceID{1, 2}, SpanID: trace.SpanID{3}, Type: trace.LinkTypeParent, Attributes: a4})
 				trace.EndSpan(ctx4)
 			}

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -372,86 +372,6 @@ func copyAttributes(m map[string]interface{}, attributes []Attribute) {
 	}
 }
 
-// LazyPrint adds an annotation to the current span using a fmt.Stringer.
-//
-// str.String is called only when the annotation text is needed.
-func LazyPrint(ctx context.Context, str fmt.Stringer) {
-	s, ok := ctx.Value(contextKey{}).(*Span)
-	if !ok {
-		return
-	}
-	s.LazyPrint(str)
-}
-
-// LazyPrint adds an annotation using a fmt.Stringer.
-//
-// str.String is called only when the annotation text is needed.
-func (s *Span) LazyPrint(str fmt.Stringer) {
-	if !s.IsRecordingEvents() {
-		return
-	}
-	s.lazyPrintInternal(nil, str)
-}
-
-// LazyPrintWithAttributes adds an annotation with attributes to the current span using a fmt.Stringer.
-//
-// str.String is called only when the annotation text is needed.
-func LazyPrintWithAttributes(ctx context.Context, attributes []Attribute, str fmt.Stringer) {
-	s, ok := ctx.Value(contextKey{}).(*Span)
-	if !ok {
-		return
-	}
-	s.LazyPrintWithAttributes(attributes, str)
-}
-
-// LazyPrintWithAttributes adds an annotation with attributes using a fmt.Stringer.
-//
-// str.String is called only when the annotation text is needed.
-func (s *Span) LazyPrintWithAttributes(attributes []Attribute, str fmt.Stringer) {
-	if !s.IsRecordingEvents() {
-		return
-	}
-	s.lazyPrintInternal(attributes, str)
-}
-
-func (s *Span) lazyPrintInternal(attributes []Attribute, str fmt.Stringer) {
-	now := time.Now()
-	msg := str.String()
-	var a map[string]interface{}
-	s.mu.Lock()
-	if len(attributes) != 0 {
-		a = make(map[string]interface{})
-		copyAttributes(a, attributes)
-	}
-	s.data.Annotations = append(s.data.Annotations, Annotation{
-		Time:       now,
-		Message:    msg,
-		Attributes: a,
-	})
-	s.mu.Unlock()
-}
-
-// LazyPrintf adds an annotation to the current span.
-//
-// The format string is evaluated with its arguments only when the annotation text is needed.
-func LazyPrintf(ctx context.Context, format string, a ...interface{}) {
-	s, ok := ctx.Value(contextKey{}).(*Span)
-	if !ok {
-		return
-	}
-	s.LazyPrintf(format, a...)
-}
-
-// LazyPrintf adds an annotation.
-//
-// The format string is evaluated with its arguments only when the annotation text is needed.
-func (s *Span) LazyPrintf(format string, a ...interface{}) {
-	if !s.IsRecordingEvents() {
-		return
-	}
-	s.lazyPrintfInternal(nil, format, a...)
-}
-
 func (s *Span) lazyPrintfInternal(attributes []Attribute, format string, a ...interface{}) {
 	now := time.Now()
 	msg := fmt.Sprintf(format, a...)
@@ -469,42 +389,22 @@ func (s *Span) lazyPrintfInternal(attributes []Attribute, format string, a ...in
 	s.mu.Unlock()
 }
 
-// LazyPrintfWithAttributes adds an annotation with attributes to the current span.
-//
-// The format string is evaluated with its arguments only when the annotation text is needed.
-func LazyPrintfWithAttributes(ctx context.Context, attributes []Attribute, format string, a ...interface{}) {
+// Annotatef adds an annotation with attributes to the current span.
+// Attributes can be nil.
+func Annotatef(ctx context.Context, a []Attribute, format string, arg ...interface{}) {
 	s, ok := ctx.Value(contextKey{}).(*Span)
 	if !ok {
 		return
 	}
-	s.LazyPrintfWithAttributes(attributes, format, a...)
+	s.Annotatef(a, format, arg...)
 }
 
-// LazyPrintfWithAttributes adds an annotation with attributes.
-//
-// The format string is evaluated with its arguments only when the annotation text is needed.
-func (s *Span) LazyPrintfWithAttributes(attributes []Attribute, format string, a ...interface{}) {
+// Annotatef adds an annotation with attributes.
+func (s *Span) Annotatef(attributes []Attribute, format string, a ...interface{}) {
 	if !s.IsRecordingEvents() {
 		return
 	}
 	s.lazyPrintfInternal(attributes, format, a...)
-}
-
-// Print adds an annotation to the current span.
-func Print(ctx context.Context, str string) {
-	s, ok := ctx.Value(contextKey{}).(*Span)
-	if !ok {
-		return
-	}
-	s.Print(str)
-}
-
-// Print adds an annotation.
-func (s *Span) Print(str string) {
-	if !s.IsRecordingEvents() {
-		return
-	}
-	s.printStringInternal(nil, str)
 }
 
 func (s *Span) printStringInternal(attributes []Attribute, str string) {
@@ -523,17 +423,19 @@ func (s *Span) printStringInternal(attributes []Attribute, str string) {
 	s.mu.Unlock()
 }
 
-// PrintWithAttributes adds an annotation with attributes to the current span.
-func PrintWithAttributes(ctx context.Context, attributes []Attribute, str string) {
+// Annotate adds an annotation with attributes to the current span.
+// Attributes can be nil.
+func Annotate(ctx context.Context, a []Attribute, str string) {
 	s, ok := ctx.Value(contextKey{}).(*Span)
 	if !ok {
 		return
 	}
-	s.PrintWithAttributes(attributes, str)
+	s.Annotate(a, str)
 }
 
-// PrintWithAttributes adds an annotation with attributes.
-func (s *Span) PrintWithAttributes(attributes []Attribute, str string) {
+// Annotate adds an annotation with attributes.
+// Attributes can be nil.
+func (s *Span) Annotate(attributes []Attribute, str string) {
 	if !s.IsRecordingEvents() {
 		return
 	}

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -395,12 +395,8 @@ func TestSetSpanAttributes(t *testing.T) {
 
 func TestAnnotations(t *testing.T) {
 	ctx := startSpan()
-	LazyPrint(ctx, foo(1))
-	LazyPrintWithAttributes(ctx, []Attribute{StringAttribute{"key2", "value2"}}, foo(2))
-	LazyPrintf(ctx, "%f", -1.5)
-	LazyPrintfWithAttributes(ctx, []Attribute{StringAttribute{"key3", "value3"}}, "%f", 1.5)
-	Print(ctx, "Print")
-	PrintWithAttributes(ctx, []Attribute{StringAttribute{"key4", "value4"}}, "PrintWithAttributes")
+	Annotatef(ctx, []Attribute{StringAttribute{"key1", "value1"}}, "%f", 1.5)
+	Annotate(ctx, []Attribute{StringAttribute{"key2", "value2"}}, "Annotate")
 	got, err := endSpan(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -421,12 +417,8 @@ func TestAnnotations(t *testing.T) {
 		ParentSpanID: sid,
 		Name:         "span0",
 		Annotations: []Annotation{
-			{Message: "foo", Attributes: nil},
-			{Message: "foo", Attributes: map[string]interface{}{"key2": "value2"}},
-			{Message: "-1.500000", Attributes: nil},
-			{Message: "1.500000", Attributes: map[string]interface{}{"key3": "value3"}},
-			{Message: "Print", Attributes: nil},
-			{Message: "PrintWithAttributes", Attributes: map[string]interface{}{"key4": "value4"}},
+			{Message: "1.500000", Attributes: map[string]interface{}{"key1": "value1"}},
+			{Message: "Annotate", Attributes: map[string]interface{}{"key2": "value2"}},
 		},
 		HasRemoteParent: true,
 	}


### PR DESCRIPTION
Provide Annoate and Annoatef.

We don't want to the lazy behavior of the annotation
APIs exposed to the user. Don't document the lazy
behavior.

Passing nil as attributes meets the case for annotating
only with a message. We are removing all other functions
and methods and expect user to pass nil if they
don't want to annotate with attributes.

Fixes #129.