### PR TITLE
Fix panic in StackDriver Trace Exporter

### DIFF
--- a/exporter/trace/stackdriver/stackdriver.go
+++ b/exporter/trace/stackdriver/stackdriver.go
@@ -224,7 +224,7 @@ func (e *Exporter) FromRequest(req *http.Request) (sc trace.SpanContext, ok bool
 		return trace.SpanContext{}, false
 	}
 
-	buf = make([]byte, 8)
+	buf = make([]byte, binary.MaxVarintLen64)
 	binary.PutUvarint(buf, sid)
 	copy(sc.SpanID[:], buf)
 


### PR DESCRIPTION
I've hit a panic in `Exporter.FromRequest`:

```
panic: runtime error: index out of range
2018/01/19 10:00:27 goroutine 97 [running]:
[...]
encoding/binary.PutUvarint(0xc4201ea728, 0x8, 0x8, 0xccbfb17fc225ee58, 0xccbfb17fc225ee58)
	/usr/local/go/src/encoding/binary/varint.go:44 +0x68
[...]/exporter/trace/stackdriver.(*Exporter).FromRequest(0xc4201e0080, 0xc420143900, 0x4d2e9cf5f080b2d, 0xe90e7f174d220107, 0x0, 0xc400000000)
	[...]/exporter/trace/stackdriver/stackdriver.go:228 +0x277
```

This fixes it.