### PR TITLE
Don't document the Interval window

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,19 +159,10 @@ meanAgg := stats.MeanAggregation{}
 
 ### Create an aggregation window
 
-Currently only two types of aggregation windows are supported. The Cumulative
-is used to continuously aggregate the data received.
-The Interval window is used to aggregate the data received over the last specified time interval.
-Currently all aggregation types are compatible with all aggregation windows.
-Later we might provide aggregation types that are incompatible with some windows.
+Use Cumulative to continuously aggregate the recorded data.
 
 [embedmd]:# (stats.go windows)
 ```go
-interval := stats.Interval{
-	Duration:  10 * time.Second,
-	Intervals: 5,
-}
-
 cum := stats.Cumulative{}
 ```
 

--- a/examples/stats/helloworld/main.go
+++ b/examples/stats/helloworld/main.go
@@ -47,7 +47,7 @@ func main() {
 		nil,
 		videoSize,
 		stats.DistributionAggregation([]float64{0, 1 << 16, 1 << 32}),
-		stats.Interval{Duration: 10 * time.Second, Intervals: 10},
+		stats.Cumulative{},
 	)
 	if err != nil {
 		log.Fatalf("Cannot create view: %v", err)

--- a/internal/readme/source.md
+++ b/internal/readme/source.md
@@ -98,11 +98,7 @@ sample values.
 
 ### Create an aggregation window
 
-Currently only two types of aggregation windows are supported. The Cumulative
-is used to continuously aggregate the data received.
-The Interval window is used to aggregate the data received over the last specified time interval.
-Currently all aggregation types are compatible with all aggregation windows.
-Later we might provide aggregation types that are incompatible with some windows.
+Use Cumulative to continuously aggregate the recorded data.
 
 [embedmd]:# (stats.go windows)
 

--- a/internal/readme/stats.go
+++ b/internal/readme/stats.go
@@ -62,15 +62,8 @@ func statsExamples() {
 	_, _, _, _ = distAgg, countAgg, sumAgg, meanAgg
 
 	// START windows
-	interval := stats.Interval{
-		Duration:  10 * time.Second,
-		Intervals: 5,
-	}
-
 	cum := stats.Cumulative{}
 	// END windows
-
-	_, _ = interval, cum
 
 	// START view
 	view, err := stats.NewView(


### PR DESCRIPTION
This window is only useful for introspection and
we will consider removing it. Don't document it
for now not to encourage users to depend on it.