### PR TITLE
Fix the span names generated from HTTP requests

### DIFF
--- a/plugin/http/httptrace/httptrace_test.go
+++ b/plugin/http/httptrace/httptrace_test.go
@@ -293,6 +293,11 @@ func TestSpanNameFromURL(t *testing.T) {
 			want:   "Recv.localhost/a",
 		},
 		{
+			prefix: "Recv",
+			u:      "https://example.com:7654/a",
+			want:   "Recv.example.com:7654/a",
+		},
+		{
 			prefix: "Sent",
 			u:      "/a/b?q=c",
 			want:   "Sent./a/b",


### PR DESCRIPTION
Handle cases where there is no hostname and port name.
Avoid putting :80 and :443 in the span name.

Fixes #335.