### PR TITLE
Fix aggregation data cloning

### DIFF
--- a/stats/aggregation_data.go
+++ b/stats/aggregation_data.go
@@ -52,7 +52,7 @@ func (a *CountData) addSample(v interface{}) {
 }
 
 func (a *CountData) clone() AggregationData {
-	return &(*a)
+	return newCountData(int64(*a))
 }
 
 func (a *CountData) multiplyByFraction(fraction float64) AggregationData {
@@ -112,7 +112,7 @@ func (a *SumData) multiplyByFraction(fraction float64) AggregationData {
 }
 
 func (a *SumData) clone() AggregationData {
-	return &(*a)
+	return newSumData(float64(*a))
 }
 
 func (a *SumData) addOther(av AggregationData) {
@@ -176,7 +176,7 @@ func (a *MeanData) addSample(v interface{}) {
 }
 
 func (a *MeanData) clone() AggregationData {
-	return &(*a)
+	return newMeanData(a.Mean, a.Count)
 }
 
 // Only Count will be mutiplied by the fraction, Mean will remain the same.

--- a/stats/aggregation_data_test.go
+++ b/stats/aggregation_data_test.go
@@ -1,0 +1,65 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package stats
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDataClone(t *testing.T) {
+	dist := newDistributionData([]float64{1, 2, 3, 4})
+	dist.Count = 7
+	dist.Max = 11
+	dist.Min = 1
+	dist.CountPerBucket = []int64{0, 2, 3, 2}
+	dist.Mean = 4
+	dist.SumOfSquaredDev = 1.2
+
+	tests := []struct {
+		name string
+		src  AggregationData
+	}{
+		{
+			name: "count data",
+			src:  newCountData(5),
+		},
+		{
+			name: "distribution data",
+			src:  dist,
+		},
+		{
+			name: "mean data",
+			src:  newMeanData(11.0, 5),
+		},
+		{
+			name: "sum data",
+			src:  newSumData(65.7),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.src.clone()
+			if !reflect.DeepEqual(got, tt.src) {
+				t.Errorf("AggregationData.clone() = %v, want %v", got, tt.src)
+			}
+			// TODO(jbd): Make sure that data is deep copied.
+			if got == tt.src {
+				t.Errorf("AggregationData.clone() returned the same pointer")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Some clone() implementations return the same object rather
than cloning the data.

Fixes #338.