### PR TITLE
Provide a convenience import to install OpenCensus HTTP

### DIFF
--- a/plugin/http/install/install.go
+++ b/plugin/http/install/install.go
@@ -1,0 +1,28 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Import to install OpenCensus HTTP tracing globally, replacing http.DefaultTransport
+package installhttpplugin
+
+import (
+	"net/http"
+
+	"go.opencensus.io/plugin/http/httptrace"
+)
+
+func init() {
+	http.DefaultTransport = &httptrace.Transport{
+		Base: http.DefaultTransport,
+	}
+}


### PR DESCRIPTION
tracing for the default HTTP client.

Mainly useful for integrating with existing code that uses
http.Get, http.Post etc. or http.DefaultClient.