### PR TITLE
Remove duplicated documentation

### DIFF
--- a/exporter/stackdriver/stackdriver.go
+++ b/exporter/stackdriver/stackdriver.go
@@ -32,10 +32,6 @@
 //
 // Export to Stackdriver Trace:
 //
-// 	stats.RegisterExporter(exporter)
-//
-// Export to Stackdriver Trace:
-//
 // 	trace.RegisterExporter(exporter)
 //
 // The package uses Application Default Credentials to authenticate.  See


### PR DESCRIPTION
(copy paste error presumedly; same three lines listed twice)