### PR TITLE
Remove trace.SetStackTrace

### DIFF
--- a/exporter/stackdriver/trace.go
+++ b/exporter/stackdriver/trace.go
@@ -94,7 +94,6 @@ func (e *traceExporter) ExportSpan(s *trace.SpanData) {
 	n += len(s.Attributes)
 	n += len(s.Annotations)
 	n += len(s.MessageEvents)
-	n += len(s.StackTrace)
 	err := e.bundler.Add(s, n)
 	switch err {
 	case nil:

--- a/exporter/stackdriver/trace_proto_test.go
+++ b/exporter/stackdriver/trace_proto_test.go
@@ -100,7 +100,6 @@ func TestExportTrace(t *testing.T) {
 				trace.EndSpan(ctx4)
 			}
 		}
-		trace.SetStackTrace(ctx1)
 		trace.EndSpan(ctx1)
 	}
 	trace.EndSpan(ctx)
@@ -113,22 +112,6 @@ func TestExportTrace(t *testing.T) {
 		spbs = append(spbs, protoFromSpanData(s, "testproject"))
 	}
 	sort.Sort(spbs)
-
-	if st := spbs[1].StackTrace; st == nil {
-		t.Error("expected stack trace in span 1")
-	} else {
-		ok := false
-		if st.StackFrames != nil {
-			for _, frame := range st.StackFrames.Frame {
-				if strings.HasSuffix(frame.FunctionName.Value, "stackdriver.TestExportTrace") {
-					ok = true
-				}
-			}
-		}
-		if !ok {
-			t.Error("expected stack frame for stackdriver.TestExportTrace")
-		}
-	}
 
 	for i, want := range []string{
 		spanID.String(),
@@ -154,9 +137,6 @@ func TestExportTrace(t *testing.T) {
 			for _, te := range span.TimeEvents.TimeEvent {
 				checkTime(&te.Time)
 			}
-		}
-		if span.StackTrace != nil {
-			span.StackTrace = nil
 		}
 		if want := fmt.Sprintf("projects/testproject/traces/%s/spans/%s", traceID, span.SpanId); span.Name != want {
 			t.Errorf("got span name %q want %q", span.Name, want)

--- a/trace/export.go
+++ b/trace/export.go
@@ -66,7 +66,6 @@ type SpanData struct {
 	Annotations   []Annotation
 	MessageEvents []MessageEvent
 	Status
-	StackTrace      []uintptr
 	Links           []Link
 	HasRemoteParent bool
 }

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -20,7 +20,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math/rand"
-	"runtime"
 	"sync"
 	"time"
 )
@@ -443,27 +442,6 @@ func (s *Span) Annotate(attributes []Attribute, str string) {
 		return
 	}
 	s.printStringInternal(attributes, str)
-}
-
-// SetStackTrace adds a stack trace to the current span.
-func SetStackTrace(ctx context.Context) {
-	s, ok := ctx.Value(contextKey{}).(*Span)
-	if !ok {
-		return
-	}
-	s.SetStackTrace()
-}
-
-// SetStackTrace adds a stack trace to the span.
-func (s *Span) SetStackTrace() {
-	if !s.IsRecordingEvents() {
-		return
-	}
-	pcs := make([]uintptr, 20 /* TODO: configurable stack size? */)
-	_ = runtime.Callers(1, pcs[:])
-	s.mu.Lock()
-	s.data.StackTrace = pcs
-	s.mu.Unlock()
 }
 
 // AddMessageSendEvent adds a message send event to the current span.

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -341,34 +341,6 @@ func checkTime(x *time.Time) bool {
 	return true
 }
 
-func TestStackTrace(t *testing.T) {
-	ctx := startSpan()
-	SetStackTrace(ctx)
-	got, err := endSpan(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(got.StackTrace) == 0 || got.StackTrace[0] == 0 {
-		t.Error("exporting span: expected stack trace")
-	}
-	got.StackTrace = nil
-
-	want := &SpanData{
-		SpanContext: SpanContext{
-			TraceID:      tid,
-			SpanID:       SpanID{},
-			TraceOptions: 0x1,
-		},
-		ParentSpanID:    sid,
-		Name:            "span0",
-		HasRemoteParent: true,
-	}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("exporting span: got %#v want %#v", got, want)
-	}
-}
-
 func TestSetSpanAttributes(t *testing.T) {
 	ctx := startSpan()
 	SetSpanAttributes(ctx, StringAttribute{"key1", "value1"})


### PR DESCRIPTION
Our data model allows spans to have stack traces
for legacy reasons. We don't want new users to depend
on this functionality.

Fixes #365.