### PR TITLE
Add B3 propagation format support

### DIFF
--- a/plugin/http/propagation/b3/b3.go
+++ b/plugin/http/propagation/b3/b3.go
@@ -1,0 +1,119 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package b3 contains a propagation.HTTPFormat implementation
+// for B3 propagation. See https://github.com/openzipkin/b3-propagation
+// for more details.
+package b3
+
+import (
+	"encoding/hex"
+	"net/http"
+
+	"go.opencensus.io/trace"
+	"go.opencensus.io/trace/propagation"
+)
+
+const (
+	traceIDHeader = "X─B3─TraceId"
+	spanIDHeader  = "X─B3─SpanId"
+	sampledHeader = "X─B3─Sampled"
+)
+
+// HTTPFormat implements propagation.HTTPFormat to propagate
+// traces in HTTP headers in B3 propagation format.
+// HTTPFormat skips the X-B3-ParentId and X-B3-Flags headers
+// because there are additional fields not represented in the
+// OpenCensus span context. Spans created from the incoming
+// header will be the direct children of the client-side span.
+// Similarly, reciever of the outgoing spans should use client-side
+// span created by OpenCensus as the parent.
+type HTTPFormat struct{}
+
+var _ propagation.HTTPFormat = (*HTTPFormat)(nil)
+
+// FromRequest extracts a B3 span context from incoming requests.
+func (f HTTPFormat) FromRequest(req *http.Request) (sc trace.SpanContext, ok bool) {
+	tid, ok := parseTraceID(req.Header.Get(traceIDHeader))
+	if !ok {
+		return trace.SpanContext{}, false
+	}
+	sid, ok := parseSpanID(req.Header.Get(spanIDHeader))
+	if !ok {
+		return trace.SpanContext{}, false
+	}
+	sampled, _ := parseSampled(req.Header.Get(sampledHeader))
+	return trace.SpanContext{
+		TraceID:      tid,
+		SpanID:       sid,
+		TraceOptions: sampled,
+	}, true
+}
+
+func parseTraceID(tid string) (trace.TraceID, bool) {
+	if tid == "" {
+		return trace.TraceID{}, false
+	}
+	b, err := hex.DecodeString(tid)
+	if err != nil {
+		return trace.TraceID{}, false
+	}
+	var traceID trace.TraceID
+	if len(b) <= 8 {
+		// The lower 64-bits.
+		start := 8 + (8 - len(b))
+		copy(traceID[start:], b)
+	} else {
+		start := 16 - len(b)
+		copy(traceID[start:], b)
+	}
+
+	return traceID, true
+}
+
+func parseSpanID(sid string) (spanID trace.SpanID, ok bool) {
+	if sid == "" {
+		return trace.SpanID{}, false
+	}
+	b, err := hex.DecodeString(sid)
+	if err != nil {
+		return trace.SpanID{}, false
+	}
+	start := (8 - len(b))
+	copy(spanID[start:], b)
+	return spanID, true
+}
+
+func parseSampled(sampled string) (trace.TraceOptions, bool) {
+	switch sampled {
+	case "true", "1":
+		return trace.TraceOptions(1), true
+	default:
+		return trace.TraceOptions(0), false
+	}
+}
+
+// ToRequest modifies the given request to include B3 headers.
+func (f *HTTPFormat) ToRequest(sc trace.SpanContext, req *http.Request) {
+	req.Header.Set(traceIDHeader, hex.EncodeToString(sc.TraceID[:]))
+	req.Header.Set(spanIDHeader, hex.EncodeToString(sc.SpanID[:]))
+
+	var sampled string
+	if sc.IsSampled() {
+		sampled = "1"
+	} else {
+		sampled = "0"
+	}
+	req.Header.Set(sampledHeader, sampled)
+}

--- a/plugin/http/propagation/b3/b3_test.go
+++ b/plugin/http/propagation/b3/b3_test.go
@@ -1,0 +1,210 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package b3
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+
+	"go.opencensus.io/trace"
+)
+
+func TestHTTPFormat_FromRequest(t *testing.T) {
+	tests := []struct {
+		name    string
+		makeReq func() *http.Request
+		wantSc  trace.SpanContext
+		wantOk  bool
+	}{
+		{
+			name: "128-bit trace ID + 64-bit span ID; sampled=1",
+			makeReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "http://example.com", nil)
+				req.Header.Set(traceIDHeader, "463ac35c9f6413ad48485a3953bb6124")
+				req.Header.Set(spanIDHeader, "0020000000000001")
+				req.Header.Set(sampledHeader, "1")
+				return req
+			},
+			wantSc: trace.SpanContext{
+				TraceID:      trace.TraceID{70, 58, 195, 92, 159, 100, 19, 173, 72, 72, 90, 57, 83, 187, 97, 36},
+				SpanID:       trace.SpanID{0, 32, 0, 0, 0, 0, 0, 1},
+				TraceOptions: trace.TraceOptions(1),
+			},
+			wantOk: true,
+		},
+		{
+			name: "short trace ID + short span ID; sampled=1",
+			makeReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "http://example.com", nil)
+				req.Header.Set(traceIDHeader, "000102")
+				req.Header.Set(spanIDHeader, "000102")
+				req.Header.Set(sampledHeader, "1")
+				return req
+			},
+			wantSc: trace.SpanContext{
+				TraceID:      trace.TraceID{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2},
+				SpanID:       trace.SpanID{0, 0, 0, 0, 0, 0, 1, 2},
+				TraceOptions: trace.TraceOptions(1),
+			},
+			wantOk: true,
+		},
+		{
+			name: "64-bit trace ID + 64-bit span ID; sampled=0",
+			makeReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "http://example.com", nil)
+				req.Header.Set(traceIDHeader, "0020000000000001")
+				req.Header.Set(spanIDHeader, "0020000000000001")
+				req.Header.Set(sampledHeader, "0")
+				return req
+			},
+			wantSc: trace.SpanContext{
+				TraceID:      trace.TraceID{0, 0, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 1},
+				SpanID:       trace.SpanID{0, 32, 0, 0, 0, 0, 0, 1},
+				TraceOptions: trace.TraceOptions(0),
+			},
+			wantOk: true,
+		},
+		{
+			name: "128-bit trace ID + 64-bit span ID; no sampling header",
+			makeReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "http://example.com", nil)
+				req.Header.Set(traceIDHeader, "463ac35c9f6413ad48485a3953bb6124")
+				req.Header.Set(spanIDHeader, "0020000000000001")
+				return req
+			},
+			wantSc: trace.SpanContext{
+				TraceID:      trace.TraceID{70, 58, 195, 92, 159, 100, 19, 173, 72, 72, 90, 57, 83, 187, 97, 36},
+				SpanID:       trace.SpanID{0, 32, 0, 0, 0, 0, 0, 1},
+				TraceOptions: trace.TraceOptions(0),
+			},
+			wantOk: true,
+		},
+		{
+			name: "invalid trace ID + 64-bit span ID; no sampling header",
+			makeReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "http://example.com", nil)
+				req.Header.Set(traceIDHeader, "")
+				req.Header.Set(spanIDHeader, "0020000000000001")
+				return req
+			},
+			wantSc: trace.SpanContext{},
+			wantOk: false,
+		},
+		{
+			name: "128-bit trace ID; invalid span ID; no sampling header",
+			makeReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "http://example.com", nil)
+				req.Header.Set(traceIDHeader, "463ac35c9f6413ad48485a3953bb6124")
+				req.Header.Set(spanIDHeader, "")
+				return req
+			},
+			wantSc: trace.SpanContext{},
+			wantOk: false,
+		},
+		{
+			name: "128-bit trace ID + 64-bit span ID; sampled=true",
+			makeReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "http://example.com", nil)
+				req.Header.Set(traceIDHeader, "463ac35c9f6413ad48485a3953bb6124")
+				req.Header.Set(spanIDHeader, "0020000000000001")
+				req.Header.Set(sampledHeader, "true")
+				return req
+			},
+			wantSc: trace.SpanContext{
+				TraceID:      trace.TraceID{70, 58, 195, 92, 159, 100, 19, 173, 72, 72, 90, 57, 83, 187, 97, 36},
+				SpanID:       trace.SpanID{0, 32, 0, 0, 0, 0, 0, 1},
+				TraceOptions: trace.TraceOptions(1),
+			},
+			wantOk: true,
+		},
+		{
+			name: "128-bit trace ID + 64-bit span ID; sampled=false",
+			makeReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "http://example.com", nil)
+				req.Header.Set(traceIDHeader, "463ac35c9f6413ad48485a3953bb6124")
+				req.Header.Set(spanIDHeader, "0020000000000001")
+				req.Header.Set(sampledHeader, "false")
+				return req
+			},
+			wantSc: trace.SpanContext{
+				TraceID:      trace.TraceID{70, 58, 195, 92, 159, 100, 19, 173, 72, 72, 90, 57, 83, 187, 97, 36},
+				SpanID:       trace.SpanID{0, 32, 0, 0, 0, 0, 0, 1},
+				TraceOptions: trace.TraceOptions(0),
+			},
+			wantOk: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &HTTPFormat{}
+			sc, ok := f.FromRequest(tt.makeReq())
+			if ok != tt.wantOk {
+				t.Errorf("HTTPFormat.FromRequest() got ok = %v, want %v", ok, tt.wantOk)
+			}
+			if !reflect.DeepEqual(sc, tt.wantSc) {
+				t.Errorf("HTTPFormat.FromRequest() got span context = %v, want %v", sc, tt.wantSc)
+			}
+		})
+	}
+}
+
+func TestHTTPFormat_ToRequest(t *testing.T) {
+	tests := []struct {
+		name        string
+		sc          trace.SpanContext
+		wantHeaders map[string]string
+	}{
+		{
+			name: "valid traceID, header ID, sampled=1",
+			sc: trace.SpanContext{
+				TraceID:      trace.TraceID{70, 58, 195, 92, 159, 100, 19, 173, 72, 72, 90, 57, 83, 187, 97, 36},
+				SpanID:       trace.SpanID{0, 32, 0, 0, 0, 0, 0, 1},
+				TraceOptions: trace.TraceOptions(1),
+			},
+			wantHeaders: map[string]string{
+				"X─B3─TraceId": "463ac35c9f6413ad48485a3953bb6124",
+				"X─B3─SpanId":  "0020000000000001",
+				"X─B3─Sampled": "1",
+			},
+		},
+		{
+			name: "valid traceID, header ID, sampled=0",
+			sc: trace.SpanContext{
+				TraceID:      trace.TraceID{70, 58, 195, 92, 159, 100, 19, 173, 72, 72, 90, 57, 83, 187, 97, 36},
+				SpanID:       trace.SpanID{0, 32, 0, 0, 0, 0, 0, 1},
+				TraceOptions: trace.TraceOptions(0),
+			},
+			wantHeaders: map[string]string{
+				"X─B3─TraceId": "463ac35c9f6413ad48485a3953bb6124",
+				"X─B3─SpanId":  "0020000000000001",
+				"X─B3─Sampled": "0",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &HTTPFormat{}
+			req, _ := http.NewRequest("GET", "http://example.com", nil)
+			f.ToRequest(tt.sc, req)
+
+			for k, v := range tt.wantHeaders {
+				if got, want := req.Header.Get(k), v; got != want {
+					t.Errorf("req.Header.Get(%q) = %q; want %q", k, got, want)
+				}
+			}
+		})
+	}
+}

--- a/plugin/http/propagation/google/google_test.go
+++ b/plugin/http/propagation/google/google_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestHTTPFormat(t *testing.T) {
-	format := HTTPFormat{}
+	format := &HTTPFormat{}
 
 	traceID := [16]byte{16, 84, 69, 170, 120, 67, 188, 139, 242, 6, 177, 32, 0, 16, 0, 0}
 	var spanID [8]byte


### PR DESCRIPTION
B3 spans have two parts: client and server. For this reason,
B3 headers can contain a client span ID and a parent ID of the
span at the same time.

OpenCensus trace context doesn't allow the same span ID to be
shared between client and server. This is why we are going
to assume the incoming span ID is the parent.

For similar reasons, outgoing requests will not set the parent
span ID and assume the receiver will accept the outgoing span
ID as the client side of the span.

Fixes #362.