### PR TITLE
Remove NewMap, add New

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,13 @@ Currently, OpenCensus supports:
 
 ## Tags
 
-Tags represent propagated key-value pairs. They can be propagated using context.Context
+Tags represent propagated key-value pairs. They are propagated using context.Context
 in the same process or can be encoded to be transmitted on the wire and decoded back
 to a tag.Map at the destination.
 
 ### Getting a key by a name
 
 A key is defined by its name. To use a key, a user needs to know its name and type.
-Currently, only keys of type string are supported.
-Other types will be supported in the future.
 
 [embedmd]:# (tags.go stringKey)
 ```go
@@ -54,11 +52,15 @@ if err != nil {
 }
 ```
 
-### Creating a map of tags associated with keys
+### Creating tags and propagating them
 
-tag.Map is a map of tags. Package tags provide a builder to create tag maps.
+Package tag provides a builder to create tag maps and put it
+into the current context.
+To propagate a tag map to downstream methods and RPCs, New
+will add the produced tag map to the current context.
+If there is already a tag map in the current context, it will be replaced.
 
-[embedmd]:# (tags.go tagMap)
+[embedmd]:# (tags.go new)
 ```go
 osKey, err := tag.NewKey("my.org/keys/user-os")
 if err != nil {
@@ -69,7 +71,7 @@ if err != nil {
 	log.Fatal(err)
 }
 
-tagMap, err := tag.NewMap(ctx,
+ctx, err = tag.New(ctx,
 	tag.Insert(osKey, "macOS-10.12.5"),
 	tag.Upsert(userIDKey, "cde36753ed"),
 )
@@ -80,29 +82,26 @@ if err != nil {
 
 ### Propagating a tag map in a context
 
-To propagate a tag map to downstream methods and RPCs, add a tag map
-to the current context. NewContext will return a copy of the current context,
-and put the tag map into the returned one.
-If there is already a tag map in the current context, it will be replaced.
+If you have access to a tag.Map, you can also
+propagate it in the current context:
 
 [embedmd]:# (tags.go newContext)
 ```go
-ctx = tag.NewContext(ctx, tagMap)
+m := tag.FromContext(ctx)
 ```
 
-In order to update an existing tag map, get the tag map from the current context,
-use NewMap and put the new tag map back to the context.
+In order to update existing tags from the current context,
+use New and pass the returned context.
 
 [embedmd]:# (tags.go replaceTagMap)
 ```go
-tagMap, err = tag.NewMap(ctx,
+ctx, err = tag.New(ctx,
 	tag.Insert(osKey, "macOS-10.12.5"),
 	tag.Upsert(userIDKey, "fff0989878"),
 )
 if err != nil {
 	log.Fatal(err)
 }
-ctx = tag.NewContext(ctx, tagMap)
 ```
 
 
@@ -281,14 +280,13 @@ for users who are on Go 1.9 and above.
 
 [embedmd]:# (tags.go profiler)
 ```go
-tagMap, err = tag.NewMap(ctx,
+ctx, err = tag.New(ctx,
 	tag.Insert(osKey, "macOS-10.12.5"),
 	tag.Insert(userIDKey, "fff0989878"),
 )
 if err != nil {
 	log.Fatal(err)
 }
-ctx = tag.NewContext(ctx, tagMap)
 tag.Do(ctx, func(ctx context.Context) {
 	// Do work.
 	// When profiling is on, samples will be
@@ -311,8 +309,8 @@ A screenshot of the CPU profile from the program above:
 [gitter-url]: https://gitter.im/census-instrumentation/lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
 
 
-[newtags-ex]: https://godoc.org/go.opencensus.io/tag#example-NewMap
-[newtags-replace-ex]: https://godoc.org/go.opencensus.io/tag#example-NewMap--Replace
+[new-ex]: https://godoc.org/go.opencensus.io/tag#example-NewMap
+[new-replace-ex]: https://godoc.org/go.opencensus.io/tag#example-NewMap--Replace
 
 [exporter-prom]: https://godoc.org/go.opencensus.io/exporter/prometheus
 [exporter-stackdriver]: https://godoc.org/go.opencensus.io/exporter/stackdriver

--- a/internal/readme/source.md
+++ b/internal/readme/source.md
@@ -35,35 +35,35 @@ Currently, OpenCensus supports:
 
 ## Tags
 
-Tags represent propagated key-value pairs. They can be propagated using context.Context
+Tags represent propagated key-value pairs. They are propagated using context.Context
 in the same process or can be encoded to be transmitted on the wire and decoded back
 to a tag.Map at the destination.
 
 ### Getting a key by a name
 
 A key is defined by its name. To use a key, a user needs to know its name and type.
-Currently, only keys of type string are supported.
-Other types will be supported in the future.
 
 [embedmd]:# (tags.go stringKey)
 
-### Creating a map of tags associated with keys
+### Creating tags and propagating them
 
-tag.Map is a map of tags. Package tags provide a builder to create tag maps.
+Package tag provides a builder to create tag maps and put it
+into the current context.
+To propagate a tag map to downstream methods and RPCs, New
+will add the produced tag map to the current context.
+If there is already a tag map in the current context, it will be replaced.
 
-[embedmd]:# (tags.go tagMap)
+[embedmd]:# (tags.go new)
 
 ### Propagating a tag map in a context
 
-To propagate a tag map to downstream methods and RPCs, add a tag map
-to the current context. NewContext will return a copy of the current context,
-and put the tag map into the returned one.
-If there is already a tag map in the current context, it will be replaced.
+If you have access to a tag.Map, you can also
+propagate it in the current context:
 
 [embedmd]:# (tags.go newContext)
 
-In order to update an existing tag map, get the tag map from the current context,
-use NewMap and put the new tag map back to the context.
+In order to update existing tags from the current context,
+use New and pass the returned context.
 
 [embedmd]:# (tags.go replaceTagMap)
 
@@ -176,8 +176,8 @@ A screenshot of the CPU profile from the program above:
 [gitter-url]: https://gitter.im/census-instrumentation/lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
 
 
-[newtags-ex]: https://godoc.org/go.opencensus.io/tag#example-NewMap
-[newtags-replace-ex]: https://godoc.org/go.opencensus.io/tag#example-NewMap--Replace
+[new-ex]: https://godoc.org/go.opencensus.io/tag#example-NewMap
+[new-replace-ex]: https://godoc.org/go.opencensus.io/tag#example-NewMap--Replace
 
 [exporter-prom]: https://godoc.org/go.opencensus.io/exporter/prometheus
 [exporter-stackdriver]: https://godoc.org/go.opencensus.io/exporter/stackdriver

--- a/internal/readme/tags.go
+++ b/internal/readme/tags.go
@@ -33,7 +33,7 @@ func tagsExamples() {
 	// END stringKey
 	_ = key
 
-	// START tagMap
+	// START new
 	osKey, err := tag.NewKey("my.org/keys/user-os")
 	if err != nil {
 		log.Fatal(err)
@@ -43,39 +43,39 @@ func tagsExamples() {
 		log.Fatal(err)
 	}
 
-	tagMap, err := tag.NewMap(ctx,
+	ctx, err = tag.New(ctx,
 		tag.Insert(osKey, "macOS-10.12.5"),
 		tag.Upsert(userIDKey, "cde36753ed"),
 	)
 	if err != nil {
 		log.Fatal(err)
 	}
-	// END tagMap
+	// END new
 
 	// START newContext
-	ctx = tag.NewContext(ctx, tagMap)
+	m := tag.FromContext(ctx)
 	// END newContext
 
+	_ = m
+
 	// START replaceTagMap
-	tagMap, err = tag.NewMap(ctx,
+	ctx, err = tag.New(ctx,
 		tag.Insert(osKey, "macOS-10.12.5"),
 		tag.Upsert(userIDKey, "fff0989878"),
 	)
 	if err != nil {
 		log.Fatal(err)
 	}
-	ctx = tag.NewContext(ctx, tagMap)
 	// END replaceTagMap
 
 	// START profiler
-	tagMap, err = tag.NewMap(ctx,
+	ctx, err = tag.New(ctx,
 		tag.Insert(osKey, "macOS-10.12.5"),
 		tag.Insert(userIDKey, "fff0989878"),
 	)
 	if err != nil {
 		log.Fatal(err)
 	}
-	ctx = tag.NewContext(ctx, tagMap)
 	tag.Do(ctx, func(ctx context.Context) {
 		// Do work.
 		// When profiling is on, samples will be

--- a/plugin/grpc/grpcstats/client_handler.go
+++ b/plugin/grpc/grpcstats/client_handler.go
@@ -71,12 +71,9 @@ func (h *ClientStatsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo)
 	ts := tag.FromContext(ctx)
 	encoded := tag.Encode(ts)
 	ctx = stats.SetTags(ctx, encoded)
-	tagMap, err := tag.NewMap(ctx,
+	ctx, _ = tag.New(ctx,
 		tag.Upsert(keyMethod, methodName(info.FullMethodName)),
 	)
-	if err == nil {
-		ctx = tag.NewContext(ctx, tagMap)
-	}
 	// TODO(acetechnologist): should we be recording this later? What is the
 	// point of updating d.reqLen & d.reqCount if we update now?
 	istats.Record(ctx, RPCClientStartedCount.M(1))
@@ -149,12 +146,9 @@ func (h *ClientStatsHandler) handleRPCEnd(ctx context.Context, s *stats.End) {
 	if s.Error != nil {
 		s, ok := status.FromError(s.Error)
 		if ok {
-			newTagMap, err := tag.NewMap(ctx,
+			ctx, _ = tag.New(ctx,
 				tag.Upsert(keyStatus, s.Code().String()),
 			)
-			if err == nil {
-				ctx = tag.NewContext(ctx, newTagMap)
-			}
 		}
 		m = append(m, RPCClientErrorCount.M(1))
 	}

--- a/plugin/grpc/grpcstats/client_handler_test.go
+++ b/plugin/grpc/grpcstats/client_handler_test.go
@@ -310,12 +310,12 @@ func TestClientDefaultCollections(t *testing.T) {
 			for _, t := range rpc.tags {
 				mods = append(mods, tag.Upsert(t.k, t.v))
 			}
-			tm, err := tag.NewMap(context.Background(), mods...)
+			ctx, err := tag.New(context.Background(), mods...)
 			if err != nil {
 				t.Errorf("%q: NewMap = %v", tc.label, err)
 			}
-			encoded := tag.Encode(tm)
-			ctx := stats.SetTags(context.Background(), encoded)
+			encoded := tag.Encode(tag.FromContext(ctx))
+			ctx = stats.SetTags(context.Background(), encoded)
 			ctx = h.TagRPC(ctx, rpc.tagInfo)
 			for _, out := range rpc.outPayloads {
 				h.HandleRPC(ctx, out)

--- a/plugin/grpc/grpcstats/server_handler_test.go
+++ b/plugin/grpc/grpcstats/server_handler_test.go
@@ -308,13 +308,12 @@ func TestServerDefaultCollections(t *testing.T) {
 			for _, t := range rpc.tags {
 				mods = append(mods, tag.Upsert(t.k, t.v))
 			}
-			ts, err := tag.NewMap(context.Background(), mods...)
+			ctx, err := tag.New(context.Background(), mods...)
 			if err != nil {
 				t.Errorf("%q: NewMap = %v", tc.label, err)
 			}
-			encoded := tag.Encode(ts)
-			ctx := stats.SetTags(context.Background(), encoded)
-
+			encoded := tag.Encode(tag.FromContext(ctx))
+			ctx = stats.SetTags(context.Background(), encoded)
 			ctx = h.TagRPC(ctx, rpc.tagInfo)
 
 			for _, in := range rpc.inPayloads {

--- a/stats/collector_test.go
+++ b/stats/collector_test.go
@@ -42,10 +42,15 @@ func TestEncodeDecodeTags(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m1, _ := tag.NewMap(ctx)
-	m2, _ := tag.NewMap(ctx, tag.Insert(k2, "v2"))
-	m3, _ := tag.NewMap(ctx, tag.Insert(k1, "v1"), tag.Insert(k2, "v2"))
-	m4, _ := tag.NewMap(ctx, tag.Insert(k1, "v1"), tag.Insert(k2, "v2"), tag.Insert(k3, "v3"))
+	ctx1, _ := tag.New(ctx)
+	ctx2, _ := tag.New(ctx, tag.Insert(k2, "v2"))
+	ctx3, _ := tag.New(ctx, tag.Insert(k1, "v1"), tag.Insert(k2, "v2"))
+	ctx4, _ := tag.New(ctx, tag.Insert(k1, "v1"), tag.Insert(k2, "v2"), tag.Insert(k3, "v3"))
+
+	m1 := tag.FromContext(ctx1)
+	m2 := tag.FromContext(ctx2)
+	m3 := tag.FromContext(ctx3)
+	m4 := tag.FromContext(ctx4)
 
 	tests := []testData{
 		{

--- a/stats/view_test.go
+++ b/stats/view_test.go
@@ -163,11 +163,11 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowCumulative(t *testin
 			for _, t := range r.tags {
 				mods = append(mods, tag.Insert(t.k, t.v))
 			}
-			ts, err := tag.NewMap(context.Background(), mods...)
+			ctx, err := tag.New(context.Background(), mods...)
 			if err != nil {
 				t.Errorf("%v: NewMap = %v", tc.label, err)
 			}
-			view.addSample(ts, r.f, time.Now())
+			view.addSample(tag.FromContext(ctx), r.f, time.Now())
 		}
 
 		gotRows := view.collectedRows(time.Now())
@@ -355,11 +355,11 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowSlidingTime(t *testi
 			for _, t := range r.tags {
 				mods = append(mods, tag.Insert(t.k, t.v))
 			}
-			ts, err := tag.NewMap(context.Background(), mods...)
+			ctx, err := tag.New(context.Background(), mods...)
 			if err != nil {
-				t.Errorf("%v: NewMap = %v", tc.label, err)
+				t.Errorf("%v: New = %v", tc.label, err)
 			}
-			view.addSample(ts, r.f, r.now)
+			view.addSample(tag.FromContext(ctx), r.f, r.now)
 		}
 
 		for _, wantRows := range tc.wantRows {
@@ -555,11 +555,11 @@ func Test_View_MeasureFloat64_AggregationCount_WindowSlidingTime(t *testing.T) {
 			for _, t := range r.tags {
 				mods = append(mods, tag.Insert(t.k, t.v))
 			}
-			ts, err := tag.NewMap(context.Background(), mods...)
+			ctx, err := tag.New(context.Background(), mods...)
 			if err != nil {
-				t.Errorf("%v: NewMap = %v", tc.label, err)
+				t.Errorf("%v: New = %v", tc.label, err)
 			}
-			view.addSample(ts, r.f, r.now)
+			view.addSample(tag.FromContext(ctx), r.f, r.now)
 		}
 
 		for _, wantRows := range tc.wantRows {
@@ -674,11 +674,11 @@ func Test_View_MeasureFloat64_AggregationSum_WindowCumulative(t *testing.T) {
 			for _, t := range r.tags {
 				mods = append(mods, tag.Insert(t.k, t.v))
 			}
-			ts, err := tag.NewMap(context.Background(), mods...)
+			ctx, err := tag.New(context.Background(), mods...)
 			if err != nil {
-				t.Errorf("%v: NewMap = %v", tt.label, err)
+				t.Errorf("%v: New = %v", tt.label, err)
 			}
-			view.addSample(ts, r.f, time.Now())
+			view.addSample(tag.FromContext(ctx), r.f, time.Now())
 		}
 
 		gotRows := view.collectedRows(time.Now())
@@ -791,11 +791,11 @@ func Test_View_MeasureFloat64_AggregationMean_WindowCumulative(t *testing.T) {
 			for _, t := range r.tags {
 				mods = append(mods, tag.Insert(t.k, t.v))
 			}
-			ts, err := tag.NewMap(context.Background(), mods...)
+			ctx, err := tag.New(context.Background(), mods...)
 			if err != nil {
-				t.Errorf("%v: NewMap = %v", tt.label, err)
+				t.Errorf("%v: New = %v", tt.label, err)
 			}
-			view.addSample(ts, r.f, time.Now())
+			view.addSample(tag.FromContext(ctx), r.f, time.Now())
 		}
 
 		gotRows := view.collectedRows(time.Now())

--- a/stats/worker_test.go
+++ b/stats/worker_test.go
@@ -473,14 +473,13 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 
 	k1, _ := tag.NewKey("k1")
 	k2, _ := tag.NewKey("k2")
-	ts, err := tag.NewMap(context.Background(),
+	ctx, err := tag.New(context.Background(),
 		tag.Insert(k1, "v1"),
 		tag.Insert(k2, "v2"),
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
-	ctx := tag.NewContext(context.Background(), ts)
 
 	v1, err := NewView("VF1", "desc VF1", []tag.Key{k1, k2}, m, CountAggregation{}, Cumulative{})
 	if err != nil {

--- a/tag/example_test.go
+++ b/tag/example_test.go
@@ -37,7 +37,7 @@ func ExampleNewKey() {
 	_ = key // use key
 }
 
-func ExampleNewMap() {
+func ExampleNew() {
 	osKey, err := tag.NewKey("my.org/keys/user-os")
 	if err != nil {
 		log.Fatal(err)
@@ -47,25 +47,25 @@ func ExampleNewMap() {
 		log.Fatal(err)
 	}
 
-	tagMap, err := tag.NewMap(ctx,
+	ctx, err := tag.New(ctx,
 		tag.Insert(osKey, "macOS-10.12.5"),
 		tag.Upsert(userIDKey, "cde36753ed"),
 	)
 	if err != nil {
 		log.Fatal(err)
 	}
-	_ = tagMap // use the tag map
+
+	_ = ctx // use context
 }
 
-func ExampleNewMap_replace() {
-	tagMap, err := tag.NewMap(ctx,
+func ExampleNew_replace() {
+	ctx, err := tag.New(ctx,
 		tag.Insert(key, "macOS-10.12.5"),
 		tag.Upsert(key, "macOS-10.12.7"),
 	)
 	if err != nil {
 		log.Fatal(err)
 	}
-	ctx = tag.NewContext(ctx, tagMap)
 
 	_ = ctx // use context
 }
@@ -84,14 +84,13 @@ func ExampleFromContext() {
 }
 
 func ExampleDo() {
-	tagMap, err := tag.NewMap(ctx,
+	ctx, err := tag.New(ctx,
 		tag.Insert(key, "macOS-10.12.5"),
 		tag.Upsert(key, "macOS-10.12.7"),
 	)
 	if err != nil {
 		log.Fatal(err)
 	}
-	ctx = tag.NewContext(ctx, tagMap)
 	tag.Do(ctx, func(ctx context.Context) {
 		_ = ctx // use context
 	})

--- a/tag/map.go
+++ b/tag/map.go
@@ -143,18 +143,19 @@ func Delete(k Key) Mutator {
 	}
 }
 
-// NewMap returns a new tag map originated from the incoming context
-// and modified with the provided mutators.
-func NewMap(ctx context.Context, mutator ...Mutator) (*Map, error) {
+// New returns a new context that contains a tag map
+// originated from the incoming context and modified
+// with the provided mutators.
+func New(ctx context.Context, mutator ...Mutator) (context.Context, error) {
 	m := newMap(0)
 	orig := FromContext(ctx)
 	if orig != nil {
 		for k, v := range orig.m {
 			if !checkKeyName(k.Name()) {
-				return nil, fmt.Errorf("key:%q: %v", k, errInvalidKeyName)
+				return ctx, fmt.Errorf("key:%q: %v", k, errInvalidKeyName)
 			}
 			if !checkValue(v) {
-				return nil, fmt.Errorf("key:%q value:%q: %v", k.Name(), v, errInvalidValue)
+				return ctx, fmt.Errorf("key:%q value:%q: %v", k.Name(), v, errInvalidValue)
 			}
 			m.insert(k, v)
 		}
@@ -163,10 +164,10 @@ func NewMap(ctx context.Context, mutator ...Mutator) (*Map, error) {
 	for _, mod := range mutator {
 		m, err = mod.Mutate(m)
 		if err != nil {
-			return nil, err
+			return ctx, err
 		}
 	}
-	return m, nil
+	return NewContext(ctx, m), nil
 }
 
 // Do is similar to pprof.Do: a convenience for installing the tags

--- a/tag/map_codec_test.go
+++ b/tag/map_codec_test.go
@@ -78,12 +78,12 @@ func TestEncodeDecode(t *testing.T) {
 		for i, pair := range tc.pairs {
 			mods[i] = Upsert(pair.k, pair.v)
 		}
-		ts, err := NewMap(context.Background(), mods...)
+		ctx, err := New(context.Background(), mods...)
 		if err != nil {
 			t.Errorf("%v: NewMap = %v", tc.label, err)
 		}
 
-		encoded := Encode(ts)
+		encoded := Encode(FromContext(ctx))
 		decoded, err := Decode(encoded)
 		if err != nil {
 			t.Errorf("%v: decoding encoded tag map failed: %v", tc.label, err)
@@ -106,7 +106,7 @@ func TestEncodeDecode(t *testing.T) {
 
 func TestDecode(t *testing.T) {
 	k1, _ := NewKey("k1")
-	m, _ := NewMap(context.Background(), Insert(k1, "v1"))
+	ctx, _ := New(context.Background(), Insert(k1, "v1"))
 
 	tests := []struct {
 		name    string
@@ -117,7 +117,7 @@ func TestDecode(t *testing.T) {
 		{
 			name:    "valid",
 			bytes:   []byte{0, 0, 2, 107, 49, 2, 118, 49},
-			want:    m,
+			want:    FromContext(ctx),
 			wantErr: false,
 		},
 		{


### PR DESCRIPTION
Common case is to propagate tags in the context. Replace NewMap
with New.
In the case of an error, the old context should be preserved.

Fixes #346.