### PR TITLE
Rename Interval.Intervals to SubIntervals and set the correct default

### DIFF
--- a/plugin/grpc/grpcstats/grpcstats.go
+++ b/plugin/grpc/grpcstats/grpcstats.go
@@ -63,8 +63,8 @@ var (
 	aggDistCounts = istats.DistributionAggregation(rpcCountBucketBoundaries)
 
 	windowCumulative    = istats.Cumulative{}
-	windowSlidingHour   = istats.Interval{Duration: 1 * time.Hour, Intervals: 6}
-	windowSlidingMinute = istats.Interval{Duration: 1 * time.Minute, Intervals: 6}
+	windowSlidingHour   = istats.Interval{Duration: 1 * time.Hour, SubIntervals: 6}
+	windowSlidingMinute = istats.Interval{Duration: 1 * time.Minute, SubIntervals: 6}
 
 	keyMethod tag.Key
 	keyStatus tag.Key

--- a/stats/aggregation.go
+++ b/stats/aggregation.go
@@ -129,8 +129,13 @@ type aggregatorInterval struct {
 	idx             int
 }
 
+const defaultSubIntervals = 5
+
 // newAggregatorInterval creates an aggregatorSlidingTime.
 func newAggregatorInterval(now time.Time, d time.Duration, subIntervalsCount int, newAggregationValue func() AggregationData) *aggregatorInterval {
+	if subIntervalsCount == 0 {
+		subIntervalsCount = defaultSubIntervals
+	}
 	subDuration := d / time.Duration(subIntervalsCount)
 	start := now.Add(-subDuration * time.Duration(subIntervalsCount))
 	var entries []*timeSerieEntry

--- a/stats/window.go
+++ b/stats/window.go
@@ -44,12 +44,12 @@ func (w Cumulative) newAggregator(now time.Time, newAggregationData func() Aggre
 // Interval is a window that indicates that the aggregation occurs over a sliding
 // window of time: last n seconds, minutes, hours.
 type Interval struct {
-	Duration  time.Duration
-	Intervals int
+	Duration     time.Duration
+	SubIntervals int
 }
 
 func (w Interval) isWindow() {}
 
 func (w Interval) newAggregator(now time.Time, newAggregationData func() AggregationData) aggregator {
-	return newAggregatorInterval(now, w.Duration, w.Intervals, newAggregationData)
+	return newAggregatorInterval(now, w.Duration, w.SubIntervals, newAggregationData)
 }

--- a/stats/worker_test.go
+++ b/stats/worker_test.go
@@ -622,7 +622,7 @@ func TestReportUsage(t *testing.T) {
 
 	cum1, _ := NewView("cum1", "", nil, m, CountAggregation{}, Cumulative{})
 	cum2, _ := NewView("cum1", "", nil, m, CountAggregation{}, &Cumulative{})
-	interval, _ := NewView("cum1", "", nil, m, CountAggregation{}, Interval{Duration: 5 * time.Millisecond, Intervals: 1})
+	interval, _ := NewView("cum1", "", nil, m, CountAggregation{}, Interval{Duration: 5 * time.Millisecond, SubIntervals: 1})
 
 	tests := []struct {
 		name         string


### PR DESCRIPTION
Fixes #155.