### PR TITLE
Remove gRPC tag propagation for now.

### DIFF
--- a/plugin/grpc/grpcstats/client_handler.go
+++ b/plugin/grpc/grpcstats/client_handler.go
@@ -68,9 +68,7 @@ func (h *ClientStatsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo)
 	}
 
 	d := &rpcData{startTime: startTime}
-	ts := tag.FromContext(ctx)
-	encoded := tag.Encode(ts)
-	ctx = stats.SetTags(ctx, encoded)
+	// TODO: tag propagation
 	ctx, _ = tag.New(ctx,
 		tag.Upsert(keyMethod, methodName(info.FullMethodName)),
 	)

--- a/plugin/grpc/grpcstats/server_handler.go
+++ b/plugin/grpc/grpcstats/server_handler.go
@@ -16,7 +16,6 @@
 package grpcstats
 
 import (
-	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -153,12 +152,6 @@ func (h *ServerStatsHandler) createTags(ctx context.Context, fullinfo string) (c
 	mods := []tag.Mutator{
 		tag.Upsert(keyMethod, methodName(fullinfo)),
 	}
-	if tagsBin := stats.Tags(ctx); tagsBin != nil {
-		old, err := tag.Decode([]byte(tagsBin))
-		if err != nil {
-			return nil, fmt.Errorf("serverHandler.createTags failed to decode tagsBin %v: %v", tagsBin, err)
-		}
-		return tag.New(tag.NewContext(ctx, old), mods...)
-	}
+	// TODO: tag propagation
 	return tag.New(ctx, mods...)
 }


### PR DESCRIPTION
We need to investigate options around selective propagation. "propagate everything" is
a dangerous default, so let's propagate nothing for now.