### PR TITLE
Use microsecond precision for jaeger span StartTime and Timestamp

### DIFF
--- a/exporter/jaeger/jaeger.go
+++ b/exporter/jaeger/jaeger.go
@@ -123,7 +123,7 @@ func (e *Exporter) ExportSpan(data *trace.SpanData) {
 			}
 		}
 		logs = append(logs, &gen.Log{
-			Timestamp: a.Time.Unix() * 1000 * 1000,
+			Timestamp: a.Time.UnixNano() / 1000,
 			Fields:    fields,
 		})
 	}
@@ -142,7 +142,7 @@ func (e *Exporter) ExportSpan(data *trace.SpanData) {
 		ParentSpanId:  bytesToInt64(data.ParentSpanID[:]),
 		OperationName: data.Name,
 		Flags:         int32(data.TraceOptions),
-		StartTime:     data.StartTime.Unix() * 1000 * 1000, // Add nanosecs.
+		StartTime:     data.StartTime.UnixNano() / 1000,
 		Duration:      int64(data.EndTime.Sub(data.StartTime)),
 		Tags:          tags,
 		Logs:          logs,


### PR DESCRIPTION
Update to match the behavior of the jaeger golang client:

https://github.com/jaegertracing/jaeger-client-go/blob/b7bacc465f385658dd3586f58810226776d2a4bf/jaeger_thrift_span.go#L28

https://github.com/jaegertracing/jaeger-client-go/blob/0e91c43a6bfeb3d710aa053460c6862041046ed4/utils/utils.go#L78-L87