### PR TITLE
Improve RpcZ page

### DIFF
--- a/zpages/rpcz.go
+++ b/zpages/rpcz.go
@@ -31,6 +31,8 @@ import (
 	"go.opencensus.io/stats/view"
 )
 
+const bytesPerKb = 1024
+
 var (
 	programStartTime = time.Now()
 	mu               sync.Mutex // protects snaps
@@ -109,7 +111,7 @@ func WriteTextRpczPage(w io.Writer) {
 		fmt.Fprint(tw, "Method\tCount\t\t\tAvgLat\t\t\tMaxLat\t\t\tRate\t\t\tIn (MiB/s)\t\t\tOut (MiB/s)\t\t\tErrors\t\t\n")
 		fmt.Fprint(tw, "\tMin\tHr\tTot\tMin\tHr\tTot\tMin\tHr\tTot\tMin\tHr\tTot\tMin\tHr\tTot\tMin\tHr\tTot\tMin\tHr\tTot\n")
 		for _, s := range sg.Snapshots {
-			fmt.Fprintf(tw, "%s\t%d\t%d\t%d\t%v\t%v\t%v\t%v\t%v\t%v\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\t%d\t%d\t%d\n",
+			fmt.Fprintf(tw, "%s\t%d\t%d\t%d\t%v\t%v\t%v\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\t%d\t%d\t%d\n",
 				s.Method,
 				s.CountMinute,
 				s.CountHour,
@@ -117,18 +119,15 @@ func WriteTextRpczPage(w io.Writer) {
 				s.AvgLatencyMinute,
 				s.AvgLatencyHour,
 				s.AvgLatencyTotal,
-				s.MaxLatencyMinute,
-				s.MaxLatencyHour,
-				s.MaxLatencyTotal,
 				s.RPCRateMinute,
 				s.RPCRateHour,
 				s.RPCRateTotal,
-				s.InputRateMinute/1e6,
-				s.InputRateHour/1e6,
-				s.InputRateTotal/1e6,
-				s.OutputRateMinute/1e6,
-				s.OutputRateHour/1e6,
-				s.OutputRateTotal/1e6,
+				s.InputRateMinute/bytesPerKb,
+				s.InputRateHour/bytesPerKb,
+				s.InputRateTotal/bytesPerKb,
+				s.OutputRateMinute/bytesPerKb,
+				s.OutputRateHour/bytesPerKb,
+				s.OutputRateTotal/bytesPerKb,
 				s.ErrorsMinute,
 				s.ErrorsHour,
 				s.ErrorsTotal)
@@ -231,9 +230,6 @@ type statSnapshot struct {
 	AvgLatencyMinute time.Duration
 	AvgLatencyHour   time.Duration
 	AvgLatencyTotal  time.Duration
-	MaxLatencyMinute time.Duration
-	MaxLatencyHour   time.Duration
-	MaxLatencyTotal  time.Duration
 	RPCRateMinute    float64
 	RPCRateHour      float64
 	RPCRateTotal     float64
@@ -299,7 +295,6 @@ func (s snapExporter) ExportView(vd *view.Data) {
 		}
 
 		var (
-			dist  = &view.DistributionData{}
 			sum   float64
 			count float64
 		)
@@ -308,7 +303,6 @@ func (s snapExporter) ExportView(vd *view.Data) {
 			sum = float64(*v)
 			count = float64(*v)
 		case *view.DistributionData:
-			dist = v
 			sum = v.Sum()
 			count = float64(v.Count)
 		case *view.MeanData:
@@ -326,7 +320,6 @@ func (s snapExporter) ExportView(vd *view.Data) {
 
 		case grpcstats.RPCClientRoundTripLatencyView:
 			s.AvgLatencyTotal = convertTime(sum / count)
-			s.MaxLatencyTotal = convertTime(dist.Max)
 
 		case grpcstats.RPCClientRequestBytesView:
 			s.OutputRateTotal = computeRate(0, sum)
@@ -346,7 +339,6 @@ func (s snapExporter) ExportView(vd *view.Data) {
 
 		case grpcstats.RPCServerServerElapsedTimeView:
 			s.AvgLatencyTotal = convertTime(sum / count)
-			s.MaxLatencyTotal = convertTime(dist.Max)
 
 		case grpcstats.RPCServerResponseBytesView:
 			s.OutputRateTotal = computeRate(0, sum)

--- a/zpages/templates.go
+++ b/zpages/templates.go
@@ -102,7 +102,7 @@ When                       Elapsed (sec)
 {{range .Rows}}{{printf "%26s" (index .Fields 0)}} {{printf "%12s" (index .Fields 1)}} {{index .Fields 2}}{{.|traceid}}
 {{end}}</pre>
 <br>
-<p><b style="color:blue;">TraceId</b> means sampled request. 
+<p><b style="color:blue;">TraceId</b> means sampled request.
 <b style="color:black;">TraceId</b> means not sampled request.</p>
 `
 	statsTemplateString = `
@@ -114,16 +114,14 @@ When                       Elapsed (sec)
 <th></th><td></td>
 <th class="l1" colspan=3>Count</th><td></td>
 <th class="l1" colspan=3>Avg latency (ms)</th><td></td>
-<th class="l1" colspan=3>Max latency (ms)</th><td></td>
 <th class="l1" colspan=3>Rate (rpc/s)</th><td></td>
-<th class="l1" colspan=3>Input (MiB/s)</th><td></td>
-<th class="l1" colspan=3>Output (MiB/s)</th><td></td>
+<th class="l1" colspan=3>Input (kb/s)</th><td></td>
+<th class="l1" colspan=3>Output (kb/s)</th><td></td>
 <th class="l1" colspan=3>Errors</th>
 </tr>
 
 <tr bgcolor="#eee5de">
 <th align=left>Method</th><td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
-<th align=right>Min.</th><th align=right>Hr.</th><th align=right>Tot.</th><td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
 <th align=right>Min.</th><th align=right>Hr.</th><th align=right>Tot.</th><td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
 <th align=right>Min.</th><th align=right>Hr.</th><th align=right>Tot.</th><td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
 <th align=right>Min.</th><th align=right>Hr.</th><th align=right>Tot.</th><td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
@@ -144,9 +142,6 @@ When                       Elapsed (sec)
 <td align="right">{{.AvgLatencyMinute|ms}}</td>
 <td align="right">{{.AvgLatencyHour|ms}}</td>
 <td align="right">{{.AvgLatencyTotal|ms}}</td><td></td>
-<td align="right">{{.MaxLatencyMinute|ms}}</td>
-<td align="right">{{.MaxLatencyHour|ms}}</td>
-<td align="right">{{.MaxLatencyTotal|ms}}</td><td></td>
 <td align="right">{{.RPCRateMinute|rate}}</td>
 <td align="right">{{.RPCRateHour|rate}}</td>
 <td align="right">{{.RPCRateTotal|rate}}</td><td></td>


### PR DESCRIPTION
Closes #437 

Updated the unit for input/output rate to kb/s, since MiB/s seems too big.
Also removed the column MaxLatency, as suggested by @bogdandrutu in https://github.com/census-instrumentation/opencensus-specs/issues/47.