### PR TITLE
Make starting a custom span more straightforward.

### DIFF
--- a/exporter/stackdriver/trace_proto_test.go
+++ b/exporter/stackdriver/trace_proto_test.go
@@ -61,13 +61,15 @@ func TestExportTrace(t *testing.T) {
 	trace.RegisterExporter(&te)
 	defer trace.UnregisterExporter(&te)
 
-	ctx, span0 := trace.StartSpanWithRemoteParent(context.Background(), "span0",
+	span0 := trace.NewSpanWithRemoteParent(
+		"span0",
 		trace.SpanContext{
 			TraceID:      traceID,
 			SpanID:       spanID,
 			TraceOptions: 1,
 		},
 		trace.StartOptions{})
+	ctx := trace.WithSpan(context.Background(), span0)
 	{
 		ctx1, span1 := trace.StartSpan(ctx, "span1")
 		{

--- a/internal/traceinternals.go
+++ b/internal/traceinternals.go
@@ -14,11 +14,15 @@
 
 package internal
 
-import "time"
+import (
+	"time"
+)
 
 // Trace allows internal access to some trace functionality.
 // TODO(#412): remove this
 var Trace interface{}
+
+var LocalSpanStoreEnabled bool
 
 // BucketConfiguration stores the number of samples to store for span buckets
 // for successful and failed spans for a particular span name.

--- a/plugin/ocgrpc/grpctrace/grpc.go
+++ b/plugin/ocgrpc/grpctrace/grpc.go
@@ -67,7 +67,7 @@ const traceContextKey = "grpc-trace-bin"
 // SpanContext added to the outgoing gRPC metadata.
 func (c *ClientStatsHandler) TagRPC(ctx context.Context, rti *stats.RPCTagInfo) context.Context {
 	name := "Sent" + strings.Replace(rti.FullMethodName, "/", ".", -1)
-	ctx, _ = trace.StartSpanWithOptions(ctx, name, trace.StartOptions{RecordEvents: true, RegisterNameForLocalSpanStore: true})
+	ctx, _ = trace.StartSpan(ctx, name)
 	traceContextBinary := propagation.Binary(trace.FromContext(ctx).SpanContext())
 	if len(traceContextBinary) == 0 {
 		return ctx
@@ -84,14 +84,13 @@ func (c *ClientStatsHandler) TagRPC(ctx context.Context, rti *stats.RPCTagInfo) 
 func (s *ServerStatsHandler) TagRPC(ctx context.Context, rti *stats.RPCTagInfo) context.Context {
 	md, _ := metadata.FromIncomingContext(ctx)
 	name := "Recv" + strings.Replace(rti.FullMethodName, "/", ".", -1)
-	opt := trace.StartOptions{RecordEvents: true, RegisterNameForLocalSpanStore: true}
 	if s := md[traceContextKey]; len(s) > 0 {
 		if parent, ok := propagation.FromBinary([]byte(s[0])); ok {
-			ctx, _ = trace.StartSpanWithRemoteParent(ctx, name, parent, opt)
+			ctx, _ = trace.StartSpanWithRemoteParent(ctx, name, parent, trace.StartOptions{})
 			return ctx
 		}
 	}
-	ctx, _ = trace.StartSpanWithOptions(ctx, name, opt)
+	ctx, _ = trace.StartSpan(ctx, name)
 	return ctx
 }
 

--- a/plugin/ochttp/trace_test.go
+++ b/plugin/ochttp/trace_test.go
@@ -175,12 +175,13 @@ func TestEndToEnd(t *testing.T) {
 	trace.RegisterExporter(&spans)
 	defer trace.UnregisterExporter(&spans)
 
-	ctx, _ := trace.StartSpanWithOptions(context.Background(),
+	span := trace.NewSpan(
 		"top-level",
+		nil,
 		trace.StartOptions{
-			RecordEvents: true,
-			Sampler:      trace.AlwaysSample(),
+			Sampler: trace.AlwaysSample(),
 		})
+	ctx := trace.WithSpan(context.Background(), span)
 
 	serverDone := make(chan struct{})
 	serverReturn := make(chan time.Time)

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -102,13 +102,7 @@ func WithSpan(parent context.Context, s *Span) context.Context {
 
 // StartOptions contains options concerning how a span is started.
 type StartOptions struct {
-	// Deprecated: this option has no effect.
-	RecordEvents bool
-
 	Sampler Sampler // if non-nil, the Sampler to consult for this span.
-
-	// Deprecated: this option has no effect.
-	RegisterNameForLocalSpanStore bool
 }
 
 // TODO(jbd): Remove start options.
@@ -129,7 +123,7 @@ func StartSpan(ctx context.Context, name string) (context.Context, *Span) {
 //
 // If there is no span in the context, creates a new trace and span.
 //
-// Deprecated: use StartSpan(...), or WithSpan(ctx, NewSpan(...)).
+// Deprecated: Use StartSpan(...), or WithSpan(ctx, NewSpan(...)).
 func StartSpanWithOptions(ctx context.Context, name string, o StartOptions) (context.Context, *Span) {
 	parentSpan, _ := ctx.Value(contextKey{}).(*Span)
 	span := NewSpan(name, parentSpan, o)
@@ -141,7 +135,7 @@ func StartSpanWithOptions(ctx context.Context, name string, o StartOptions) (con
 // If there is an existing span in ctx, it is ignored -- the returned Span is a
 // child of the span specified by parent.
 //
-// Deprecated: use WithSpan(ctx, NewSpanWithRemoteParent(...)).
+// Deprecated: Use WithSpan(ctx, NewSpanWithRemoteParent(...)).
 func StartSpanWithRemoteParent(ctx context.Context, name string, parent SpanContext, o StartOptions) (context.Context, *Span) {
 	span := NewSpanWithRemoteParent(name, parent, o)
 	return WithSpan(ctx, span), span

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -22,6 +22,8 @@ import (
 	"math/rand"
 	"sync"
 	"time"
+
+	"go.opencensus.io/internal"
 )
 
 // Span represents a span of a trace.  It has an associated SpanContext, and
@@ -44,6 +46,8 @@ type Span struct {
 }
 
 // IsRecordingEvents returns true if events are being recorded for this span.
+// Use this check to avoid computing expensive annotations when they will never
+// be used.
 func (s *Span) IsRecordingEvents() bool {
 	if s == nil {
 		return false
@@ -98,24 +102,23 @@ func WithSpan(parent context.Context, s *Span) context.Context {
 
 // StartOptions contains options concerning how a span is started.
 type StartOptions struct {
-	// RecordEvents indicates whether to record data for this span, and include
-	// the span in a local span store.
-	// Events will also be recorded if the span will be exported.
+	// Deprecated: this option has no effect.
 	RecordEvents bool
 
 	Sampler Sampler // if non-nil, the Sampler to consult for this span.
 
-	// RegisterNameForLocalSpanStore indicates that a local span store for spans
-	// of this name should be created, if one does not exist.
-	// If RecordEvents is false, this option has no effect.
+	// Deprecated: this option has no effect.
 	RegisterNameForLocalSpanStore bool
 }
 
 // TODO(jbd): Remove start options.
 
-// StartSpan starts a new child span of the current span in the context.
+// StartSpan starts a new child span of the current span in the context. If
+// there is no span in the context, creates a new trace and span.
 //
-// If there is no span in the context, creates a new trace and span.
+// This is provided as a convenience for WithSpan(ctx, NewSpan(...)). Use it
+// if you require custom spans in addition to the default spans provided by
+// ocgrpc, ochttp or similar framework integration.
 func StartSpan(ctx context.Context, name string) (context.Context, *Span) {
 	parentSpan, _ := ctx.Value(contextKey{}).(*Span)
 	span := NewSpan(name, parentSpan, StartOptions{})
@@ -125,6 +128,8 @@ func StartSpan(ctx context.Context, name string) (context.Context, *Span) {
 // StartSpanWithOptions starts a new child span of the current span in the context.
 //
 // If there is no span in the context, creates a new trace and span.
+//
+// Deprecated: use StartSpan(...), or WithSpan(ctx, NewSpan(...)).
 func StartSpanWithOptions(ctx context.Context, name string, o StartOptions) (context.Context, *Span) {
 	parentSpan, _ := ctx.Value(contextKey{}).(*Span)
 	span := NewSpan(name, parentSpan, o)
@@ -135,6 +140,8 @@ func StartSpanWithOptions(ctx context.Context, name string, o StartOptions) (con
 //
 // If there is an existing span in ctx, it is ignored -- the returned Span is a
 // child of the span specified by parent.
+//
+// Deprecated: use WithSpan(ctx, NewSpanWithRemoteParent(...)).
 func StartSpanWithRemoteParent(ctx context.Context, name string, parent SpanContext, o StartOptions) (context.Context, *Span) {
 	span := NewSpanWithRemoteParent(name, parent, o)
 	return WithSpan(ctx, span), span
@@ -186,7 +193,7 @@ func startSpanInternal(name string, hasParent bool, parent SpanContext, remotePa
 			HasRemoteParent: remoteParent}).Sample)
 	}
 
-	if !o.RecordEvents && !span.spanContext.IsSampled() {
+	if !internal.LocalSpanStoreEnabled && !span.spanContext.IsSampled() {
 		return span
 	}
 
@@ -199,13 +206,9 @@ func startSpanInternal(name string, hasParent bool, parent SpanContext, remotePa
 	if hasParent {
 		span.data.ParentSpanID = parent.SpanID
 	}
-	if o.RecordEvents {
+	if internal.LocalSpanStoreEnabled {
 		var ss *spanStore
-		if o.RegisterNameForLocalSpanStore {
-			ss = spanStoreForNameCreateIfNew(name)
-		} else {
-			ss = spanStoreForName(name)
-		}
+		ss = spanStoreForNameCreateIfNew(name)
 		if ss != nil {
 			span.spanStore = ss
 			ss.add(span)

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -203,7 +203,7 @@ func TestStartSpanWithRemoteParent(t *testing.T) {
 		t.Error(err)
 	}
 
-	ctx, _ = StartSpanWithRemoteParent(context.Background(), "StartSpanWithRemoteParent", sc, StartOptions{RecordEvents: true})
+	ctx, _ = StartSpanWithRemoteParent(context.Background(), "StartSpanWithRemoteParent", sc, StartOptions{})
 	if err := checkChild(sc, FromContext(ctx)); err != nil {
 		t.Error(err)
 	}
@@ -218,7 +218,7 @@ func TestStartSpanWithRemoteParent(t *testing.T) {
 		t.Error(err)
 	}
 
-	ctx, _ = StartSpanWithRemoteParent(context.Background(), "StartSpanWithRemoteParent", sc, StartOptions{RecordEvents: true})
+	ctx, _ = StartSpanWithRemoteParent(context.Background(), "StartSpanWithRemoteParent", sc, StartOptions{})
 	if err := checkChild(sc, FromContext(ctx)); err != nil {
 		t.Error(err)
 	}

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -57,7 +57,7 @@ func (f foo) String() string {
 }
 
 // checkChild tests that c has fields set appropriately, given that it is a child span of p.
-func checkChild(p SpanContext, c *Span, expectRecordingEvents bool) error {
+func checkChild(p SpanContext, c *Span) error {
 	if c == nil {
 		return fmt.Errorf("got nil child span, want non-nil")
 	}
@@ -69,18 +69,6 @@ func checkChild(p SpanContext, c *Span, expectRecordingEvents bool) error {
 	}
 	if got, want := c.spanContext.TraceOptions, p.TraceOptions; got != want {
 		return fmt.Errorf("got child trace options %d, want %d", got, want)
-	}
-	if expectRecordingEvents {
-		if c.data == nil {
-			return fmt.Errorf("child span is not recording events")
-		}
-		if got, want := c.data.ParentSpanID, p.SpanID; got != want {
-			return fmt.Errorf("got ParentSpanID %s, want %s", got, want)
-		}
-	} else {
-		if c.data != nil {
-			return fmt.Errorf("child span is recording events")
-		}
 	}
 	return nil
 }
@@ -94,40 +82,25 @@ func TestStartSpan(t *testing.T) {
 
 func TestSampling(t *testing.T) {
 	for _, test := range []struct {
-		remoteParent        bool
-		localParent         bool
-		parentTraceOptions  TraceOptions
-		recordEvents        bool
-		sampler             Sampler
-		wantRecordingEvents bool
-		wantTraceOptions    TraceOptions
+		remoteParent       bool
+		localParent        bool
+		parentTraceOptions TraceOptions
+		sampler            Sampler
+		wantTraceOptions   TraceOptions
 	}{
-		{true, false, 0, false, nil, false, 0},
-		{true, false, 0, true, nil, true, 0},
-		{true, false, 1, false, nil, true, 1},
-		{true, false, 1, true, nil, true, 1},
-		{true, false, 0, false, NeverSample(), false, 0},
-		{true, false, 0, true, NeverSample(), true, 0},
-		{true, false, 1, false, NeverSample(), false, 0},
-		{true, false, 1, true, NeverSample(), true, 0},
-		{true, false, 0, false, AlwaysSample(), true, 1},
-		{true, false, 0, true, AlwaysSample(), true, 1},
-		{true, false, 1, false, AlwaysSample(), true, 1},
-		{true, false, 1, true, AlwaysSample(), true, 1},
-		{false, true, 0, false, NeverSample(), false, 0},
-		{false, true, 0, true, NeverSample(), true, 0},
-		{false, true, 1, false, NeverSample(), false, 0},
-		{false, true, 1, true, NeverSample(), true, 0},
-		{false, true, 0, false, AlwaysSample(), true, 1},
-		{false, true, 0, true, AlwaysSample(), true, 1},
-		{false, true, 1, false, AlwaysSample(), true, 1},
-		{false, true, 1, true, AlwaysSample(), true, 1},
-		{false, false, 0, false, nil, false, 0},
-		{false, false, 0, true, nil, true, 0},
-		{false, false, 0, false, NeverSample(), false, 0},
-		{false, false, 0, true, NeverSample(), true, 0},
-		{false, false, 0, false, AlwaysSample(), true, 1},
-		{false, false, 0, true, AlwaysSample(), true, 1},
+		{true, false, 0, nil, 0},
+		{true, false, 1, nil, 1},
+		{true, false, 0, NeverSample(), 0},
+		{true, false, 1, NeverSample(), 0},
+		{true, false, 0, AlwaysSample(), 1},
+		{true, false, 1, AlwaysSample(), 1},
+		{false, true, 0, NeverSample(), 0},
+		{false, true, 1, NeverSample(), 0},
+		{false, true, 0, AlwaysSample(), 1},
+		{false, true, 1, AlwaysSample(), 1},
+		{false, false, 0, nil, 0},
+		{false, false, 0, NeverSample(), 0},
+		{false, false, 0, AlwaysSample(), 1},
 	} {
 		var ctx context.Context
 		if test.remoteParent {
@@ -137,8 +110,7 @@ func TestSampling(t *testing.T) {
 				TraceOptions: test.parentTraceOptions,
 			}
 			ctx, _ = StartSpanWithRemoteParent(context.Background(), "foo", sc, StartOptions{
-				RecordEvents: test.recordEvents,
-				Sampler:      test.sampler,
+				Sampler: test.sampler,
 			})
 		} else if test.localParent {
 			sampler := NeverSample()
@@ -147,13 +119,11 @@ func TestSampling(t *testing.T) {
 			}
 			ctx2, _ := StartSpanWithOptions(context.Background(), "foo", StartOptions{Sampler: sampler})
 			ctx, _ = StartSpanWithOptions(ctx2, "foo", StartOptions{
-				RecordEvents: test.recordEvents,
-				Sampler:      test.sampler,
+				Sampler: test.sampler,
 			})
 		} else {
 			ctx, _ = StartSpanWithOptions(context.Background(), "foo", StartOptions{
-				RecordEvents: test.recordEvents,
-				Sampler:      test.sampler,
+				Sampler: test.sampler,
 			})
 		}
 		sc := FromContext(ctx).SpanContext()
@@ -164,9 +134,6 @@ func TestSampling(t *testing.T) {
 		if sc.SpanID == (SpanID{}) {
 			t.Errorf("case %#v: starting new span: got zero SpanID, want nonzero", test)
 		}
-		if recording := FromContext(ctx).data != nil; recording != test.wantRecordingEvents {
-			t.Errorf("case %#v: starting new span: recording events is %t, want %t", test, recording, test.wantRecordingEvents)
-		}
 		if sc.TraceOptions != test.wantTraceOptions {
 			t.Errorf("case %#v: starting new span: got TraceOptions %x, want %x", test, sc.TraceOptions, test.wantTraceOptions)
 		}
@@ -174,15 +141,13 @@ func TestSampling(t *testing.T) {
 
 	// Test that for children of local spans, the default sampler has no effect.
 	for _, test := range []struct {
-		parentTraceOptions  TraceOptions
-		recordEvents        bool
-		wantRecordingEvents bool
-		wantTraceOptions    TraceOptions
+		parentTraceOptions TraceOptions
+		wantTraceOptions   TraceOptions
 	}{
-		{0, false, false, 0},
-		{0, true, true, 0},
-		{1, false, true, 1},
-		{1, true, true, 1},
+		{0, 0},
+		{0, 0},
+		{1, 1},
+		{1, 1},
 	} {
 		for _, defaultSampler := range []Sampler{
 			NeverSample(),
@@ -195,9 +160,7 @@ func TestSampling(t *testing.T) {
 				sampler = AlwaysSample()
 			}
 			ctx2, _ := StartSpanWithOptions(context.Background(), "foo", StartOptions{Sampler: sampler})
-			ctx, _ := StartSpanWithOptions(ctx2, "foo", StartOptions{
-				RecordEvents: test.recordEvents,
-			})
+			ctx, _ := StartSpan(ctx2, "foo")
 			sc := FromContext(ctx).SpanContext()
 			if (sc == SpanContext{}) {
 				t.Errorf("case %#v: starting new child of local span: no span in context", test)
@@ -205,9 +168,6 @@ func TestSampling(t *testing.T) {
 			}
 			if sc.SpanID == (SpanID{}) {
 				t.Errorf("case %#v: starting new child of local span: got zero SpanID, want nonzero", test)
-			}
-			if recording := FromContext(ctx).data != nil; recording != test.wantRecordingEvents {
-				t.Errorf("case %#v: starting new child of local span: recording events is %t, want %t", test, recording, test.wantRecordingEvents)
 			}
 			if sc.TraceOptions != test.wantTraceOptions {
 				t.Errorf("case %#v: starting new child of local span: got TraceOptions %x, want %x", test, sc.TraceOptions, test.wantTraceOptions)
@@ -239,12 +199,12 @@ func TestStartSpanWithRemoteParent(t *testing.T) {
 		TraceOptions: 0x0,
 	}
 	ctx, _ := StartSpanWithRemoteParent(context.Background(), "StartSpanWithRemoteParent", sc, StartOptions{})
-	if err := checkChild(sc, FromContext(ctx), false); err != nil {
+	if err := checkChild(sc, FromContext(ctx)); err != nil {
 		t.Error(err)
 	}
 
 	ctx, _ = StartSpanWithRemoteParent(context.Background(), "StartSpanWithRemoteParent", sc, StartOptions{RecordEvents: true})
-	if err := checkChild(sc, FromContext(ctx), true); err != nil {
+	if err := checkChild(sc, FromContext(ctx)); err != nil {
 		t.Error(err)
 	}
 
@@ -254,18 +214,18 @@ func TestStartSpanWithRemoteParent(t *testing.T) {
 		TraceOptions: 0x1,
 	}
 	ctx, _ = StartSpanWithRemoteParent(context.Background(), "StartSpanWithRemoteParent", sc, StartOptions{})
-	if err := checkChild(sc, FromContext(ctx), true); err != nil {
+	if err := checkChild(sc, FromContext(ctx)); err != nil {
 		t.Error(err)
 	}
 
 	ctx, _ = StartSpanWithRemoteParent(context.Background(), "StartSpanWithRemoteParent", sc, StartOptions{RecordEvents: true})
-	if err := checkChild(sc, FromContext(ctx), true); err != nil {
+	if err := checkChild(sc, FromContext(ctx)); err != nil {
 		t.Error(err)
 	}
 
 	ctx2, _ := StartSpan(ctx, "StartSpan")
 	parent := FromContext(ctx).SpanContext()
-	if err := checkChild(parent, FromContext(ctx2), true); err != nil {
+	if err := checkChild(parent, FromContext(ctx2)); err != nil {
 		t.Error(err)
 	}
 }
@@ -278,9 +238,7 @@ func startSpan() *Span {
 			SpanID:       sid,
 			TraceOptions: 1,
 		},
-		StartOptions{
-			RecordEvents: true,
-		})
+		StartOptions{})
 }
 
 type testExporter struct {

--- a/zpages/tracez.go
+++ b/zpages/tracez.go
@@ -75,6 +75,10 @@ var (
 	}
 )
 
+func init() {
+	internal.LocalSpanStoreEnabled = true
+}
+
 func canonicalCodeString(code int32) string {
 	if code < 0 || int(code) >= len(canonicalCodes) {
 		return "error code " + strconv.FormatInt(int64(code), 10)

--- a/zpages/zpages.go
+++ b/zpages/zpages.go
@@ -27,6 +27,13 @@
 //
 // zpages are currrently work-in-process and cannot display minutely and
 // hourly stats correctly.
+//
+// Performance
+//
+// Installing the zpages has a performance overhead because additional traces
+// and stats will be collected in-process. In most cases, we expect this
+// overhead will not be significant but it depends on many factors, including
+// how many spans your process creates and how richly annotated they are.
 package zpages // import "go.opencensus.io/zpages"
 
 import (


### PR DESCRIPTION
* Deprecate convenience methods for starting a span that
  are unlikely to be useful to the average user.
* Turn on the local spanstore for all spans (including custom
  spans) when the z-Pages are imported.
* Add documentation about the performance impact of z-Pages

Fixes: #424