### PR TITLE
Fix stats new measure error handling style

### DIFF
--- a/exporter/prometheus/prometheus_test.go
+++ b/exporter/prometheus/prometheus_test.go
@@ -52,7 +52,7 @@ func TestOnlyCumulativeWindowSupported(t *testing.T) {
 			vds: &view.Data{
 				View: newView(view.CountAggregation{}),
 				Rows: []*view.Row{
-					{nil, &count1},
+					{Data: &count1},
 				},
 			},
 			want: 1,
@@ -61,7 +61,7 @@ func TestOnlyCumulativeWindowSupported(t *testing.T) {
 			vds: &view.Data{
 				View: newView(view.MeanAggregation{}),
 				Rows: []*view.Row{
-					{nil, &mean1},
+					{Data: &mean1},
 				},
 			},
 			want: 1,
@@ -131,8 +131,8 @@ func TestCollectNonRacy(t *testing.T) {
 			count1 := view.CountData(1)
 			mean1 := &view.MeanData{Mean: 4.5, Count: 5}
 			vds := []*view.Data{
-				{View: newView(view.MeanAggregation{}), Rows: []*view.Row{{nil, mean1}}},
-				{View: newView(view.CountAggregation{}), Rows: []*view.Row{{nil, &count1}}},
+				{View: newView(view.MeanAggregation{}), Rows: []*view.Row{{Data: mean1}}},
+				{View: newView(view.CountAggregation{}), Rows: []*view.Row{{Data: &count1}}},
 			}
 			for _, v := range vds {
 				exp.ExportView(v)

--- a/plugin/ocgrpc/client_stats_handler_test.go
+++ b/plugin/ocgrpc/client_stats_handler_test.go
@@ -76,10 +76,10 @@ func TestClientDefaultCollections(t *testing.T) {
 					func() *view.View { return ClientRequestCountView },
 					[]*view.Row{
 						{
-							[]tag.Tag{
+							Tags: []tag.Tag{
 								{Key: KeyMethod, Value: "package.service/method"},
 							},
-							newDistributionData([]int64{0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 1, 1, 1, 1, 0),
+							Data: newDistributionData([]int64{0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 1, 1, 1, 1, 0),
 						},
 					},
 				},
@@ -87,10 +87,10 @@ func TestClientDefaultCollections(t *testing.T) {
 					func() *view.View { return ClientResponseCountView },
 					[]*view.Row{
 						{
-							[]tag.Tag{
+							Tags: []tag.Tag{
 								{Key: KeyMethod, Value: "package.service/method"},
 							},
-							newDistributionData([]int64{0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 1, 1, 1, 1, 0),
+							Data: newDistributionData([]int64{0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 1, 1, 1, 1, 0),
 						},
 					},
 				},
@@ -98,10 +98,10 @@ func TestClientDefaultCollections(t *testing.T) {
 					func() *view.View { return ClientRequestBytesView },
 					[]*view.Row{
 						{
-							[]tag.Tag{
+							Tags: []tag.Tag{
 								{Key: KeyMethod, Value: "package.service/method"},
 							},
-							newDistributionData([]int64{0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 1, 10, 10, 10, 0),
+							Data: newDistributionData([]int64{0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 1, 10, 10, 10, 0),
 						},
 					},
 				},
@@ -109,10 +109,10 @@ func TestClientDefaultCollections(t *testing.T) {
 					func() *view.View { return ClientResponseBytesView },
 					[]*view.Row{
 						{
-							[]tag.Tag{
+							Tags: []tag.Tag{
 								{Key: KeyMethod, Value: "package.service/method"},
 							},
-							newDistributionData([]int64{0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 1, 10, 10, 10, 0),
+							Data: newDistributionData([]int64{0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 1, 10, 10, 10, 0),
 						},
 					},
 				},
@@ -153,11 +153,11 @@ func TestClientDefaultCollections(t *testing.T) {
 					func() *view.View { return ClientErrorCountView },
 					[]*view.Row{
 						{
-							[]tag.Tag{
+							Tags: []tag.Tag{
 								{Key: KeyStatus, Value: "Canceled"},
 								{Key: KeyMethod, Value: "package.service/method"},
 							},
-							newMeanData(1, 1),
+							Data: newMeanData(1, 1),
 						},
 					},
 				},
@@ -165,10 +165,10 @@ func TestClientDefaultCollections(t *testing.T) {
 					func() *view.View { return ClientRequestCountView },
 					[]*view.Row{
 						{
-							[]tag.Tag{
+							Tags: []tag.Tag{
 								{Key: KeyMethod, Value: "package.service/method"},
 							},
-							newDistributionData([]int64{0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 2, 2, 3, 2.5, 0.5),
+							Data: newDistributionData([]int64{0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 2, 2, 3, 2.5, 0.5),
 						},
 					},
 				},
@@ -176,10 +176,10 @@ func TestClientDefaultCollections(t *testing.T) {
 					func() *view.View { return ClientResponseCountView },
 					[]*view.Row{
 						{
-							[]tag.Tag{
+							Tags: []tag.Tag{
 								{Key: KeyMethod, Value: "package.service/method"},
 							},
-							newDistributionData([]int64{0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 2, 1, 2, 1.5, 0.5),
+							Data: newDistributionData([]int64{0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 2, 1, 2, 1.5, 0.5),
 						},
 					},
 				},
@@ -233,18 +233,18 @@ func TestClientDefaultCollections(t *testing.T) {
 					func() *view.View { return ClientErrorCountView },
 					[]*view.Row{
 						{
-							[]tag.Tag{
+							Tags: []tag.Tag{
 								{Key: KeyStatus, Value: "Canceled"},
 								{Key: KeyMethod, Value: "package.service/method"},
 							},
-							newMeanData(1, 1),
+							Data: newMeanData(1, 1),
 						},
 						{
-							[]tag.Tag{
+							Tags: []tag.Tag{
 								{Key: KeyStatus, Value: "Aborted"},
 								{Key: KeyMethod, Value: "package.service/method"},
 							},
-							newMeanData(1, 1),
+							Data: newMeanData(1, 1),
 						},
 					},
 				},
@@ -252,10 +252,10 @@ func TestClientDefaultCollections(t *testing.T) {
 					func() *view.View { return ClientRequestCountView },
 					[]*view.Row{
 						{
-							[]tag.Tag{
+							Tags: []tag.Tag{
 								{Key: KeyMethod, Value: "package.service/method"},
 							},
-							newDistributionData([]int64{0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 3, 2, 3, 2.666666666, 0.333333333*2),
+							Data: newDistributionData([]int64{0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 3, 2, 3, 2.666666666, 0.333333333*2),
 						},
 					},
 				},
@@ -263,10 +263,10 @@ func TestClientDefaultCollections(t *testing.T) {
 					func() *view.View { return ClientResponseCountView },
 					[]*view.Row{
 						{
-							[]tag.Tag{
+							Tags: []tag.Tag{
 								{Key: KeyMethod, Value: "package.service/method"},
 							},
-							newDistributionData([]int64{0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 3, 1, 2, 1.333333333, 0.333333333*2),
+							Data: newDistributionData([]int64{0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 3, 1, 2, 1.333333333, 0.333333333*2),
 						},
 					},
 				},
@@ -274,10 +274,10 @@ func TestClientDefaultCollections(t *testing.T) {
 					func() *view.View { return ClientRequestBytesView },
 					[]*view.Row{
 						{
-							[]tag.Tag{
+							Tags: []tag.Tag{
 								{Key: KeyMethod, Value: "package.service/method"},
 							},
-							newDistributionData([]int64{0, 1, 1, 1, 2, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0}, 8, 1, 65536, 13696.125, 481423542.982143*7),
+							Data: newDistributionData([]int64{0, 1, 1, 1, 2, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0}, 8, 1, 65536, 13696.125, 481423542.982143*7),
 						},
 					},
 				},
@@ -285,10 +285,10 @@ func TestClientDefaultCollections(t *testing.T) {
 					func() *view.View { return ClientResponseBytesView },
 					[]*view.Row{
 						{
-							[]tag.Tag{
+							Tags: []tag.Tag{
 								{Key: KeyMethod, Value: "package.service/method"},
 							},
-							newDistributionData([]int64{0, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 4, 1, 16384, 4864.25, 59678208.25*3),
+							Data: newDistributionData([]int64{0, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 4, 1, 16384, 4864.25, 59678208.25*3),
 						},
 					},
 				},

--- a/plugin/ocgrpc/server_stats_handler_test.go
+++ b/plugin/ocgrpc/server_stats_handler_test.go
@@ -75,10 +75,10 @@ func TestServerDefaultCollections(t *testing.T) {
 					func() *view.View { return ServerRequestCountView },
 					[]*view.Row{
 						{
-							[]tag.Tag{
+							Tags: []tag.Tag{
 								{Key: KeyMethod, Value: "package.service/method"},
 							},
-							newDistributionData([]int64{0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 1, 1, 1, 1, 0),
+							Data: newDistributionData([]int64{0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 1, 1, 1, 1, 0),
 						},
 					},
 				},
@@ -86,10 +86,10 @@ func TestServerDefaultCollections(t *testing.T) {
 					func() *view.View { return ServerResponseCountView },
 					[]*view.Row{
 						{
-							[]tag.Tag{
+							Tags: []tag.Tag{
 								{Key: KeyMethod, Value: "package.service/method"},
 							},
-							newDistributionData([]int64{0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 1, 1, 1, 1, 0),
+							Data: newDistributionData([]int64{0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 1, 1, 1, 1, 0),
 						},
 					},
 				},
@@ -97,10 +97,10 @@ func TestServerDefaultCollections(t *testing.T) {
 					func() *view.View { return ServerRequestBytesView },
 					[]*view.Row{
 						{
-							[]tag.Tag{
+							Tags: []tag.Tag{
 								{Key: KeyMethod, Value: "package.service/method"},
 							},
-							newDistributionData([]int64{0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 1, 10, 10, 10, 0),
+							Data: newDistributionData([]int64{0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 1, 10, 10, 10, 0),
 						},
 					},
 				},
@@ -108,10 +108,10 @@ func TestServerDefaultCollections(t *testing.T) {
 					func() *view.View { return ServerResponseBytesView },
 					[]*view.Row{
 						{
-							[]tag.Tag{
+							Tags: []tag.Tag{
 								{Key: KeyMethod, Value: "package.service/method"},
 							},
-							newDistributionData([]int64{0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 1, 10, 10, 10, 0),
+							Data: newDistributionData([]int64{0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 1, 10, 10, 10, 0),
 						},
 					},
 				},
@@ -152,11 +152,11 @@ func TestServerDefaultCollections(t *testing.T) {
 					func() *view.View { return ServerErrorCountView },
 					[]*view.Row{
 						{
-							[]tag.Tag{
+							Tags: []tag.Tag{
 								{Key: KeyStatus, Value: "Canceled"},
 								{Key: KeyMethod, Value: "package.service/method"},
 							},
-							newCountData(1),
+							Data: newCountData(1),
 						},
 					},
 				},
@@ -164,10 +164,10 @@ func TestServerDefaultCollections(t *testing.T) {
 					func() *view.View { return ServerRequestCountView },
 					[]*view.Row{
 						{
-							[]tag.Tag{
+							Tags: []tag.Tag{
 								{Key: KeyMethod, Value: "package.service/method"},
 							},
-							newDistributionData([]int64{0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 2, 1, 2, 1.5, 0.5),
+							Data: newDistributionData([]int64{0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 2, 1, 2, 1.5, 0.5),
 						},
 					},
 				},
@@ -175,10 +175,10 @@ func TestServerDefaultCollections(t *testing.T) {
 					func() *view.View { return ServerResponseCountView },
 					[]*view.Row{
 						{
-							[]tag.Tag{
+							Tags: []tag.Tag{
 								{Key: KeyMethod, Value: "package.service/method"},
 							},
-							newDistributionData([]int64{0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 2, 2, 3, 2.5, 0.5),
+							Data: newDistributionData([]int64{0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 2, 2, 3, 2.5, 0.5),
 						},
 					},
 				},
@@ -232,18 +232,18 @@ func TestServerDefaultCollections(t *testing.T) {
 					func() *view.View { return ServerErrorCountView },
 					[]*view.Row{
 						{
-							[]tag.Tag{
+							Tags: []tag.Tag{
 								{Key: KeyStatus, Value: "Canceled"},
 								{Key: KeyMethod, Value: "package.service/method"},
 							},
-							newCountData(1),
+							Data: newCountData(1),
 						},
 						{
-							[]tag.Tag{
+							Tags: []tag.Tag{
 								{Key: KeyStatus, Value: "Aborted"},
 								{Key: KeyMethod, Value: "package.service/method"},
 							},
-							newCountData(1),
+							Data: newCountData(1),
 						},
 					},
 				},
@@ -251,10 +251,10 @@ func TestServerDefaultCollections(t *testing.T) {
 					func() *view.View { return ServerRequestCountView },
 					[]*view.Row{
 						{
-							[]tag.Tag{
+							Tags: []tag.Tag{
 								{Key: KeyMethod, Value: "package.service/method"},
 							},
-							newDistributionData([]int64{0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 3, 1, 2, 1.333333333, 0.333333333*2),
+							Data: newDistributionData([]int64{0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 3, 1, 2, 1.333333333, 0.333333333*2),
 						},
 					},
 				},
@@ -262,10 +262,10 @@ func TestServerDefaultCollections(t *testing.T) {
 					func() *view.View { return ServerResponseCountView },
 					[]*view.Row{
 						{
-							[]tag.Tag{
+							Tags: []tag.Tag{
 								{Key: KeyMethod, Value: "package.service/method"},
 							},
-							newDistributionData([]int64{0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 3, 2, 3, 2.666666666, 0.333333333*2),
+							Data: newDistributionData([]int64{0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 3, 2, 3, 2.666666666, 0.333333333*2),
 						},
 					},
 				},
@@ -273,10 +273,10 @@ func TestServerDefaultCollections(t *testing.T) {
 					func() *view.View { return ServerRequestBytesView },
 					[]*view.Row{
 						{
-							[]tag.Tag{
+							Tags: []tag.Tag{
 								{Key: KeyMethod, Value: "package.service/method"},
 							},
-							newDistributionData([]int64{0, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 4, 1, 16384, 4864.25, 59678208.25*3),
+							Data: newDistributionData([]int64{0, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 4, 1, 16384, 4864.25, 59678208.25*3),
 						},
 					},
 				},
@@ -284,10 +284,10 @@ func TestServerDefaultCollections(t *testing.T) {
 					func() *view.View { return ServerResponseBytesView },
 					[]*view.Row{
 						{
-							[]tag.Tag{
+							Tags: []tag.Tag{
 								{Key: KeyMethod, Value: "package.service/method"},
 							},
-							newDistributionData([]int64{0, 1, 1, 1, 2, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0}, 8, 1, 65536, 13696.125, 481423542.982143*7),
+							Data: newDistributionData([]int64{0, 1, 1, 1, 2, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0}, 8, 1, 65536, 13696.125, 481423542.982143*7),
 						},
 					},
 				},

--- a/stats/measure.go
+++ b/stats/measure.go
@@ -43,6 +43,8 @@ var (
 	mu           sync.RWMutex
 	measures     = make(map[string]Measure)
 	errDuplicate = errors.New("duplicate measure name")
+
+	errMeasureNameTooLong = fmt.Errorf("measure name cannot be longer than %v", internal.MaxNameLength)
 )
 
 func FindMeasure(name string) Measure {
@@ -73,7 +75,7 @@ type Measurement struct {
 
 func checkName(name string) error {
 	if len(name) > internal.MaxNameLength {
-		return fmt.Errorf("measure name cannot be larger than %v", internal.MaxNameLength)
+		return errMeasureNameTooLong
 	}
 	if !internal.IsPrintable(name) {
 		return errors.New("measure name needs to be an ASCII string")

--- a/stats/measure.go
+++ b/stats/measure.go
@@ -47,11 +47,9 @@ var (
 
 func FindMeasure(name string) Measure {
 	mu.RLock()
-	defer mu.RUnlock()
-	if m, ok := measures[name]; ok {
-		return m
-	}
-	return nil
+	m := measures[name]
+	mu.RUnlock()
+	return m
 }
 
 func register(m Measure) (Measure, error) {
@@ -78,7 +76,7 @@ func checkName(name string) error {
 		return fmt.Errorf("measure name cannot be larger than %v", internal.MaxNameLength)
 	}
 	if !internal.IsPrintable(name) {
-		return fmt.Errorf("measure name needs to be an ASCII string")
+		return errors.New("measure name needs to be an ASCII string")
 	}
 	return nil
 }

--- a/stats/measure_float64.go
+++ b/stats/measure_float64.go
@@ -54,10 +54,8 @@ func Float64(name, description, unit string) (*Float64Measure, error) {
 		description: description,
 		unit:        unit,
 	}
-	_, err := register(m)
-	if err != nil {
+	if _, err := register(m); err != nil {
 		return nil, err
-	} else {
-		return m, err
 	}
+	return m, nil
 }

--- a/stats/measure_int64.go
+++ b/stats/measure_int64.go
@@ -54,10 +54,8 @@ func Int64(name, description, unit string) (*Int64Measure, error) {
 		description: description,
 		unit:        unit,
 	}
-	_, err := register(m)
-	if err != nil {
+	if _, err := register(m); err != nil {
 		return nil, err
-	} else {
-		return m, err
 	}
+	return m, nil
 }


### PR DESCRIPTION
instead of

```go
_, err := foo()
if err != nil {
    return nil, err
} else {
    return m, err
}
```

simplify that to the idiomatic style
```go
if _, err := foo(); err != nil {
    return nil, err
}
return m, nil
```
and notice that in the return we no longer do `return m, err`
where err is nil to begin with, so be more explicit and return
nil for better readability and consistency.