### PR TITLE
Reduce the pressure on event channel and avoid tag map alloc on the critical path

### DIFF
--- a/plugin/ocgrpc/client_stats_handler.go
+++ b/plugin/ocgrpc/client_stats_handler.go
@@ -45,8 +45,10 @@ func (h *clientStatsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo)
 
 	d := &rpcData{startTime: startTime}
 	ts := tag.FromContext(ctx)
-	encoded := tag.Encode(ts)
-	ctx = stats.SetTags(ctx, encoded)
+	if ts != nil {
+		encoded := tag.Encode(ts)
+		ctx = stats.SetTags(ctx, encoded)
+	}
 	ctx, _ = tag.New(ctx,
 		tag.Upsert(KeyMethod, methodName(info.FullMethodName)),
 	)

--- a/stats/benchmark_test.go
+++ b/stats/benchmark_test.go
@@ -1,3 +1,17 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package stats_test
 
 import (
@@ -7,14 +21,74 @@ import (
 
 	"go.opencensus.io/stats"
 	_ "go.opencensus.io/stats/view" // enable collection
+	"go.opencensus.io/tag"
 )
 
 var m = makeMeasure()
 
-func BenchmarkRecord(b *testing.B) {
-	var ctx = context.Background()
+func BenchmarkRecord0(b *testing.B) {
+	ctx := context.Background()
+	b.ResetTimer()
+
 	for i := 0; i < b.N; i++ {
-		stats.Record(ctx, m.M(1), m.M(1), m.M(1), m.M(1), m.M(1), m.M(1), m.M(1), m.M(1), m.M(1), m.M(1))
+		stats.Record(ctx)
+	}
+}
+
+func BenchmarkRecord1(b *testing.B) {
+	ctx := context.Background()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		stats.Record(ctx, m.M(1))
+	}
+}
+
+func BenchmarkRecord8(b *testing.B) {
+	ctx := context.Background()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		stats.Record(ctx, m.M(1), m.M(1), m.M(1), m.M(1), m.M(1), m.M(1), m.M(1), m.M(1))
+	}
+}
+
+func BenchmarkRecord8_Parallel(b *testing.B) {
+	ctx := context.Background()
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			stats.Record(ctx, m.M(1), m.M(1), m.M(1), m.M(1), m.M(1), m.M(1), m.M(1), m.M(1))
+		}
+	})
+}
+
+func BenchmarkRecord8_8Tags(b *testing.B) {
+	ctx := context.Background()
+	key1, _ := tag.NewKey("key1")
+	key2, _ := tag.NewKey("key2")
+	key3, _ := tag.NewKey("key3")
+	key4, _ := tag.NewKey("key4")
+	key5, _ := tag.NewKey("key5")
+	key6, _ := tag.NewKey("key6")
+	key7, _ := tag.NewKey("key7")
+	key8, _ := tag.NewKey("key8")
+
+	tag.New(ctx,
+		tag.Insert(key1, "value"),
+		tag.Insert(key2, "value"),
+		tag.Insert(key3, "value"),
+		tag.Insert(key4, "value"),
+		tag.Insert(key5, "value"),
+		tag.Insert(key6, "value"),
+		tag.Insert(key7, "value"),
+		tag.Insert(key8, "value"),
+	)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		stats.Record(ctx, m.M(1), m.M(1), m.M(1), m.M(1), m.M(1), m.M(1), m.M(1), m.M(1))
 	}
 }
 

--- a/stats/view/worker.go
+++ b/stats/view/worker.go
@@ -159,7 +159,7 @@ func newWorker() *worker {
 		views:      make(map[string]*View),
 		startTimes: make(map[*View]time.Time),
 		timer:      time.NewTicker(defaultReportingDuration),
-		c:          make(chan command),
+		c:          make(chan command, 1024),
 		quit:       make(chan bool),
 		done:       make(chan bool),
 	}

--- a/tag/context.go
+++ b/tag/context.go
@@ -22,7 +22,7 @@ func FromContext(ctx context.Context) *Map {
 	// The returned tag map shouldn't be mutated.
 	ts := ctx.Value(mapCtxKey)
 	if ts == nil {
-		return newMap(0)
+		return nil
 	}
 	return ts.(*Map)
 }

--- a/tag/map.go
+++ b/tag/map.go
@@ -36,11 +36,17 @@ type Map struct {
 // Value returns the value for the key if a value
 // for the key exists.
 func (m *Map) Value(k Key) (string, bool) {
+	if m == nil {
+		return "", false
+	}
 	v, ok := m.m[k]
 	return v, ok
 }
 
 func (m *Map) String() string {
+	if m == nil {
+		return "nil"
+	}
 	var keys []Key
 	for k := range m.m {
 		keys = append(keys, k)

--- a/tag/map_codec.go
+++ b/tag/map_codec.go
@@ -165,18 +165,16 @@ func Encode(m *Map) []byte {
 	eg := &encoderGRPC{
 		buf: make([]byte, len(m.m)),
 	}
-
 	eg.writeByte(byte(tagsVersionID))
 	for k, v := range m.m {
 		eg.writeByte(byte(keyTypeString))
 		eg.writeStringWithVarintLen(k.name)
 		eg.writeBytesWithVarintLen([]byte(v))
 	}
-
 	return eg.bytes()
 }
 
-// Decode  decodes the given []byte into a tag map.
+// Decode decodes the given []byte into a tag map.
 func Decode(bytes []byte) (*Map, error) {
 	ts := newMap(0)
 


### PR DESCRIPTION
The event channel was using a non-buffered channel that blocks until each
event is processed. Switch to a buffered channel to not the block the
writes.

tag.FromContext currently allocates a new tag map if there is none
in the current context. This creates an extra allocation on
the critical path.

Benchmarks before the change:
BenchmarkRecord0-8       2000000               786 ns/op             120 B/op          3 allocs/op
BenchmarkRecord1-8       2000000               950 ns/op             192 B/op          6 allocs/op
BenchmarkRecord8-8       1000000              1647 ns/op             472 B/op         13 allocs/op

Benchmarks after the change:
BenchmarkRecord0-8               5000000               361 ns/op              64 B/op          1 allocs/op
BenchmarkRecord1-8               5000000               366 ns/op             136 B/op          4 allocs/op
BenchmarkRecord8-8               3000000               526 ns/op             416 B/op         11 allocs/op
BenchmarkRecord8_Parallel-8      2000000               881 ns/op             416 B/op         11 allocs/op
BenchmarkRecord8_8Tags-8         3000000               540 ns/op             416 B/op         11 allocs/op