### PR TITLE
Remove interval-related aggregation data methods

### DIFF
--- a/plugin/ocgrpc/server_stats_handler_test.go
+++ b/plugin/ocgrpc/server_stats_handler_test.go
@@ -361,7 +361,7 @@ func newCountData(v int) *view.CountData {
 	return &cav
 }
 
-func newMeanData(count, mean float64) *view.MeanData {
+func newMeanData(count int64, mean float64) *view.MeanData {
 	mav := view.MeanData{Count: count, Mean: mean}
 	return &mav
 }

--- a/stats/view/aggregation_data.go
+++ b/stats/view/aggregation_data.go
@@ -25,9 +25,6 @@ import (
 type AggregationData interface {
 	isAggregationData() bool
 	addSample(v interface{})
-	addOther(other AggregationData)
-	multiplyByFraction(fraction float64) AggregationData
-	clear()
 	clone() AggregationData
 	equal(other AggregationData) bool
 }
@@ -53,22 +50,6 @@ func (a *CountData) addSample(v interface{}) {
 
 func (a *CountData) clone() AggregationData {
 	return newCountData(int64(*a))
-}
-
-func (a *CountData) multiplyByFraction(fraction float64) AggregationData {
-	return newCountData(int64(float64(int64(*a))*fraction + 0.5)) // adding 0.5 because go runtime will take floor instead of rounding
-}
-
-func (a *CountData) addOther(av AggregationData) {
-	other, ok := av.(*CountData)
-	if !ok {
-		return
-	}
-	*a = *a + *other
-}
-
-func (a *CountData) clear() {
-	*a = 0
 }
 
 func (a *CountData) equal(other AggregationData) bool {
@@ -107,24 +88,8 @@ func (a *SumData) addSample(v interface{}) {
 	*a += SumData(f)
 }
 
-func (a *SumData) multiplyByFraction(fraction float64) AggregationData {
-	return newSumData(float64(*a) * fraction)
-}
-
 func (a *SumData) clone() AggregationData {
 	return newSumData(float64(*a))
-}
-
-func (a *SumData) addOther(av AggregationData) {
-	other, ok := av.(*SumData)
-	if !ok {
-		return
-	}
-	*a = *a + *other
-}
-
-func (a *SumData) clear() {
-	*a = 0
 }
 
 func (a *SumData) equal(other AggregationData) bool {
@@ -140,11 +105,11 @@ func (a *SumData) equal(other AggregationData) bool {
 //
 // Most users won't directly access mean data.
 type MeanData struct {
-	Count float64 // number of data points aggregated
+	Count int64   // number of data points aggregated
 	Mean  float64 // mean of all data points
 }
 
-func newMeanData(mean float64, count float64) *MeanData {
+func newMeanData(mean float64, count int64) *MeanData {
 	return &MeanData{
 		Mean:  mean,
 		Count: count,
@@ -177,30 +142,6 @@ func (a *MeanData) addSample(v interface{}) {
 
 func (a *MeanData) clone() AggregationData {
 	return newMeanData(a.Mean, a.Count)
-}
-
-// Only Count will be mutiplied by the fraction, Mean will remain the same.
-func (a *MeanData) multiplyByFraction(fraction float64) AggregationData {
-	return newMeanData(a.Mean, a.Count*fraction)
-}
-
-func (a *MeanData) addOther(av AggregationData) {
-	other, ok := av.(*MeanData)
-	if !ok {
-		return
-	}
-
-	if other.Count == 0 {
-		return
-	}
-
-	a.Mean = (a.Sum() + other.Sum()) / (a.Count + other.Count)
-	a.Count = a.Count + other.Count
-}
-
-func (a *MeanData) clear() {
-	a.Count = 0
-	a.Mean = 0
 }
 
 func (a *MeanData) equal(other AggregationData) bool {
@@ -289,59 +230,6 @@ func (a *DistributionData) incrementBucketCount(f float64) {
 		}
 	}
 	a.CountPerBucket[len(a.bounds)]++
-}
-
-// DistributionData will not multiply by the fraction for this type
-// of aggregation. The 'fraction' argument is there just to satisfy the
-// interface 'AggregationData'. For simplicity, we include the oldest partial
-// bucket in its entirety when the aggregation is a distribution. We do not try
-//  to multiply it by the fraction as it would make the calculation too complex
-// and will create inconsistencies between sumOfSquaredDev, min, max and the
-// various buckets of the histogram.
-func (a *DistributionData) multiplyByFraction(fraction float64) AggregationData {
-	ret := newDistributionData(a.bounds)
-	copy(ret.CountPerBucket, a.CountPerBucket)
-	ret.Count = a.Count
-	ret.Min = a.Min
-	ret.Max = a.Max
-	ret.Mean = a.Mean
-	ret.SumOfSquaredDev = a.SumOfSquaredDev
-	return ret
-}
-
-func (a *DistributionData) addOther(av AggregationData) {
-	other, ok := av.(*DistributionData)
-	if !ok {
-		return
-	}
-	if other.Count == 0 {
-		return
-	}
-	if other.Min < a.Min {
-		a.Min = other.Min
-	}
-	if other.Max > a.Max {
-		a.Max = other.Max
-	}
-	delta := other.Mean - a.Mean
-	a.SumOfSquaredDev = a.SumOfSquaredDev + other.SumOfSquaredDev + math.Pow(delta, 2)*float64(a.Count*other.Count)/(float64(a.Count+other.Count))
-
-	a.Mean = (a.Sum() + other.Sum()) / float64(a.Count+other.Count)
-	a.Count = a.Count + other.Count
-	for i := range other.CountPerBucket {
-		a.CountPerBucket[i] = a.CountPerBucket[i] + other.CountPerBucket[i]
-	}
-}
-
-func (a *DistributionData) clear() {
-	a.Count = 0
-	a.Min = math.MaxFloat64
-	a.Max = math.SmallestNonzeroFloat64
-	a.Mean = 0
-	a.SumOfSquaredDev = 0
-	for i := range a.CountPerBucket {
-		a.CountPerBucket[i] = 0
-	}
 }
 
 func (a *DistributionData) clone() AggregationData {

--- a/zpages/rpcz.go
+++ b/zpages/rpcz.go
@@ -307,7 +307,7 @@ func (s snapExporter) ExportView(vd *view.Data) {
 			count = float64(v.Count)
 		case *view.MeanData:
 			sum = v.Sum()
-			count = v.Count
+			count = float64(v.Count)
 		case *view.SumData:
 			sum = float64(*v)
 			count = float64(*v)


### PR DESCRIPTION
addOther, multipleByFraction and clear were planned to be used
for the interval window implementation. Given the interval
window is removed, we should remove the aggregation methods
related to them.

Also switch MeanData.Count back to int64 which was converted
to float64 for fractions.

Fixes #465.