### PR TITLE
 Collect float64 in Measurement

### DIFF
--- a/stats/benchmark_test.go
+++ b/stats/benchmark_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"go.opencensus.io/stats"
-	_ "go.opencensus.io/stats/view"
+	_ "go.opencensus.io/stats/view" // enable collection
 )
 
 var m = makeMeasure()

--- a/stats/measure.go
+++ b/stats/measure.go
@@ -39,6 +39,28 @@ type Measure interface {
 	Unit() string
 }
 
+type measure struct {
+	name        string
+	description string
+	unit        string
+	views       int32
+}
+
+// Name returns the name of the measure.
+func (m *measure) Name() string {
+	return m.name
+}
+
+// Description returns the description of the measure.
+func (m *measure) Description() string {
+	return m.description
+}
+
+// Unit returns the unit of the measure.
+func (m *measure) Unit() string {
+	return m.unit
+}
+
 var (
 	mu           sync.RWMutex
 	measures     = make(map[string]Measure)
@@ -69,7 +91,7 @@ func register(m Measure) (Measure, error) {
 // provides methods to create measurements of their kind. For example, Int64Measure
 // provides M to convert an int64 into a measurement.
 type Measurement struct {
-	Value   interface{} // int64 or float64
+	Value   float64
 	Measure Measure
 }
 

--- a/stats/measure_float64.go
+++ b/stats/measure_float64.go
@@ -17,24 +17,7 @@ package stats
 
 // Float64Measure is a measure of type float64.
 type Float64Measure struct {
-	name        string
-	unit        string
-	description string
-}
-
-// Name returns the name of the measure.
-func (m *Float64Measure) Name() string {
-	return m.name
-}
-
-// Description returns the description of the measure.
-func (m *Float64Measure) Description() string {
-	return m.description
-}
-
-// Unit returns the unit of the measure.
-func (m *Float64Measure) Unit() string {
-	return m.unit
+	measure
 }
 
 // M creates a new float64 measurement.
@@ -50,9 +33,11 @@ func Float64(name, description, unit string) (*Float64Measure, error) {
 		return nil, err
 	}
 	m := &Float64Measure{
-		name:        name,
-		description: description,
-		unit:        unit,
+		measure: measure{
+			name:        name,
+			description: description,
+			unit:        unit,
+		},
 	}
 	_, err := register(m)
 	if err != nil {

--- a/stats/measure_int64.go
+++ b/stats/measure_int64.go
@@ -17,30 +17,13 @@ package stats
 
 // Int64Measure is a measure of type int64.
 type Int64Measure struct {
-	name        string
-	unit        string
-	description string
-}
-
-// Name returns the name of the measure.
-func (m *Int64Measure) Name() string {
-	return m.name
-}
-
-// Description returns the description of the measure.
-func (m *Int64Measure) Description() string {
-	return m.description
-}
-
-// Unit returns the unit of the measure.
-func (m *Int64Measure) Unit() string {
-	return m.unit
+	measure
 }
 
 // M creates a new int64 measurement.
 // Use Record to record measurements.
 func (m *Int64Measure) M(v int64) Measurement {
-	return Measurement{Measure: m, Value: v}
+	return Measurement{Measure: m, Value: float64(v)}
 }
 
 // Int64 creates a new measure of type Int64Measure. It returns an
@@ -50,9 +33,11 @@ func Int64(name, description, unit string) (*Int64Measure, error) {
 		return nil, err
 	}
 	m := &Int64Measure{
-		name:        name,
-		description: description,
-		unit:        unit,
+		measure: measure{
+			name:        name,
+			description: description,
+			unit:        unit,
+		},
 	}
 	_, err := register(m)
 	if err != nil {

--- a/stats/record.go
+++ b/stats/record.go
@@ -27,6 +27,15 @@ import (
 // If there are any tags in the context, measurements will be tagged with them.
 func Record(ctx context.Context, ms ...Measurement) {
 	if internal.DefaultRecorder != nil {
+		var record bool
+		for _, m := range ms {
+			if m.Measure != nil {
+				record = true
+			}
+		}
+		if !record {
+			return
+		}
 		internal.DefaultRecorder(tag.FromContext(ctx), time.Now(), ms)
 	}
 }

--- a/stats/view/aggregation_data.go
+++ b/stats/view/aggregation_data.go
@@ -24,7 +24,7 @@ import (
 // Mosts users won't directly access aggregration data.
 type AggregationData interface {
 	isAggregationData() bool
-	addSample(v interface{})
+	addSample(v float64)
 	addOther(other AggregationData)
 	multiplyByFraction(fraction float64) AggregationData
 	clear()
@@ -47,7 +47,7 @@ func newCountData(v int64) *CountData {
 
 func (a *CountData) isAggregationData() bool { return true }
 
-func (a *CountData) addSample(v interface{}) {
+func (a *CountData) addSample(_ float64) {
 	*a = *a + 1
 }
 
@@ -93,17 +93,7 @@ func newSumData(v float64) *SumData {
 
 func (a *SumData) isAggregationData() bool { return true }
 
-func (a *SumData) addSample(v interface{}) {
-	// Both float64 and int64 values will be cast to float64
-	var f float64
-	switch x := v.(type) {
-	case int64:
-		f = float64(x)
-	case float64:
-		f = x
-	default:
-		return
-	}
+func (a *SumData) addSample(f float64) {
 	*a += SumData(f)
 }
 
@@ -156,17 +146,7 @@ func (a *MeanData) Sum() float64 { return a.Mean * float64(a.Count) }
 
 func (a *MeanData) isAggregationData() bool { return true }
 
-func (a *MeanData) addSample(v interface{}) {
-	var f float64
-	switch x := v.(type) {
-	case int64:
-		f = float64(x)
-	case float64:
-		f = x
-	default:
-		return
-	}
-
+func (a *MeanData) addSample(f float64) {
 	a.Count++
 	if a.Count == 1 {
 		a.Mean = f
@@ -246,17 +226,7 @@ func (a *DistributionData) variance() float64 {
 
 func (a *DistributionData) isAggregationData() bool { return true }
 
-func (a *DistributionData) addSample(v interface{}) {
-	var f float64
-	switch x := v.(type) {
-	case int64:
-		f = float64(x)
-	case float64:
-		f = x
-	default:
-		return
-	}
-
+func (a *DistributionData) addSample(f float64) {
 	if f < a.Min {
 		a.Min = f
 	}

--- a/stats/view/collector.go
+++ b/stats/view/collector.go
@@ -32,7 +32,7 @@ type collector struct {
 	a Aggregation
 }
 
-func (c *collector) addSample(s string, v interface{}, now time.Time) {
+func (c *collector) addSample(s string, v float64, now time.Time) {
 	aggregator, ok := c.signatures[s]
 	if !ok {
 		aggregator = c.a.newData()

--- a/stats/view/view.go
+++ b/stats/view/view.go
@@ -123,7 +123,7 @@ func (v *View) collectedRows(now time.Time) []*Row {
 	return v.collector.collectedRows(v.tagKeys, now)
 }
 
-func (v *View) addSample(m *tag.Map, val interface{}, now time.Time) {
+func (v *View) addSample(m *tag.Map, val float64, now time.Time) {
 	if !v.isSubscribed() {
 		return
 	}


### PR DESCRIPTION
This reduces allocations per stats.Record operation substantially:
```
git describe && go test  -run=^$ -benchmem -bench=.
v0.1.0-103-g23a8069
goos: darwin
goarch: amd64
pkg: go.opencensus.io/stats
BenchmarkRecord-8   	  500000	      2239 ns/op	     392 B/op	       5 allocs/op
PASS
ok  	go.opencensus.io/stats	1.163s
```
Compare: https://github.com/census-instrumentation/opencensus-go/wiki/stats-Benchmarks