### PR TITLE
Don't record annotations other than payload event for gRPC

### DIFF
--- a/plugin/ocgrpc/trace_common.go
+++ b/plugin/ocgrpc/trace_common.go
@@ -88,16 +88,8 @@ func handleRPC(ctx context.Context, rs stats.RPCStats) {
 			trace.BoolAttribute{Key: "FailFast", Value: rs.FailFast})
 	case *stats.InPayload:
 		span.AddMessageReceiveEvent(0 /* TODO: messageID */, int64(rs.Length), int64(rs.WireLength))
-	case *stats.InHeader:
-		span.AddMessageReceiveEvent(0, int64(rs.WireLength), int64(rs.WireLength))
-	case *stats.InTrailer:
-		span.AddMessageReceiveEvent(0, int64(rs.WireLength), int64(rs.WireLength))
 	case *stats.OutPayload:
 		span.AddMessageSendEvent(0, int64(rs.Length), int64(rs.WireLength))
-	case *stats.OutHeader:
-		span.AddMessageSendEvent(0, 0, 0)
-	case *stats.OutTrailer:
-		span.AddMessageSendEvent(0, int64(rs.WireLength), int64(rs.WireLength))
 	case *stats.End:
 		if rs.Error != nil {
 			code, desc := grpc.Code(rs.Error), grpc.ErrorDesc(rs.Error)


### PR DESCRIPTION
The overhead of collecting header events adds an additional 4%
overhead to gRPC trace integration. Given users won't be primarily
interested in these events, remove them for now.

Benchmarks before for unary call:
Unary-traceMode_false-latency_0s-kbps_0-MTU_0-maxConcurrentCalls_1-reqSize_1B-respSize_1B-Compressor_true:
50_Latency: 171.7710 µs 	90_Latency: 243.8820 µs 	99_Latency: 410.1710 µs 	Avg latency: 188.6830 µs 	Count: 52930 	17075 Bytes/op	257 Allocs/op
Histogram (unit: µs)
Count: 52930  Min: 121.0  Max: 4594.5  Avg: 188.68
------------------------------------------------------------
[    121.001000,     121.002000)      1    0.0%    0.0%
[    121.002000,     121.006482)      0    0.0%    0.0%
[    121.006482,     121.031055)      0    0.0%    0.0%
[    121.031055,     121.165772)      0    0.0%    0.0%
[    121.165772,     121.904328)      0    0.0%    0.0%
[    121.904328,     125.953296)     13    0.0%    0.0%
[    125.953296,     148.150881)   2720    5.1%    5.2%  #
[    148.150881,     269.844290)  47214   89.2%   94.4%  #########
[    269.844290,     937.001800)   2974    5.6%  100.0%  #
[    937.001800,    4594.547000)      7    0.0%  100.0%
[   4594.547000,            inf)      1    0.0%  100.0%

Benchmarks after for unary call:
Unary-traceMode_false-latency_0s-kbps_0-MTU_0-maxConcurrentCalls_1-reqSize_1B-respSize_1B-Compressor_true:
50_Latency: 169.9840 µs 	90_Latency: 234.3350 µs 	99_Latency: 376.8170 µs 	Avg latency: 184.3160 µs 	Count: 54181 	16402 Bytes/op	255 Allocs/op
Histogram (unit: µs)
Count: 54181  Min: 116.4  Max: 764.2  Avg: 184.32
------------------------------------------------------------
[   116.359000,    116.360000)      1    0.0%    0.0%
[   116.360000,    116.363423)      0    0.0%    0.0%
[   116.363423,    116.378563)      0    0.0%    0.0%
[   116.378563,    116.445528)      0    0.0%    0.0%
[   116.445528,    116.741713)      0    0.0%    0.0%
[   116.741713,    118.051746)      0    0.0%    0.0%
[   118.051746,    123.846038)     14    0.0%    0.0%
[   123.846038,    149.474277)   4086    7.5%    7.6%  #
[   149.474277,    262.828344)  47474   87.6%   95.2%  #########
[   262.828344,    764.195000)   2605    4.8%  100.0%
[   764.195000,           inf)      1    0.0%  100.0%