### PR TITLE
Revert Prometheus PR #456 but instead register only once

### DIFF
--- a/examples/stats/prometheus/main.go
+++ b/examples/stats/prometheus/main.go
@@ -75,7 +75,7 @@ func main() {
 		"processed video size over time",
 		nil,
 		videoSize,
-		view.DistributionAggregation([]float64{1 << 10, 1<<15, 1 << 20, 1 << 25}),
+		view.DistributionAggregation([]float64{0, 1 << 16, 1 << 32}),
 	)
 	if err != nil {
 		log.Fatalf("Cannot create view: %v", err)
@@ -92,10 +92,9 @@ func main() {
 
 	// Record some data points...
 	go func() {
-		rand.Seed(time.Now().Unix())
 		for {
 			stats.Record(ctx, videoCount.M(1))
-			stats.Record(ctx, videoSize.M(int64(rand.ExpFloat64() * (1<<24))))
+			stats.Record(ctx, videoSize.M(rand.Int63()))
 			<-time.After(time.Millisecond * time.Duration(1+rand.Intn(400)))
 		}
 	}()

--- a/examples/stats/prometheus/main.go
+++ b/examples/stats/prometheus/main.go
@@ -75,7 +75,7 @@ func main() {
 		"processed video size over time",
 		nil,
 		videoSize,
-		view.DistributionAggregation([]float64{0, 1 << 16, 1 << 32}),
+		view.DistributionAggregation([]float64{1 << 10, 1<<15, 1 << 20, 1 << 25}),
 	)
 	if err != nil {
 		log.Fatalf("Cannot create view: %v", err)
@@ -92,9 +92,10 @@ func main() {
 
 	// Record some data points...
 	go func() {
+		rand.Seed(time.Now().Unix())
 		for {
 			stats.Record(ctx, videoCount.M(1))
-			stats.Record(ctx, videoSize.M(rand.Int63()))
+			stats.Record(ctx, videoSize.M(int64(rand.ExpFloat64() * (1<<24))))
 			<-time.After(time.Millisecond * time.Duration(1+rand.Intn(400)))
 		}
 	}()

--- a/exporter/prometheus/prometheus.go
+++ b/exporter/prometheus/prometheus.go
@@ -118,8 +118,8 @@ func (c *collector) registerViews(views ...*view.View) {
 
 // ensureRegisteredOnce invokes reg.Register on the collector itself
 // exactly once to ensure that we don't get errors such as
-//    cannot register the collector: descriptor Desc{fqName: *}
-//    already exists with the same fully-qualified name and const label values
+//  cannot register the collector: descriptor Desc{fqName: *}
+//  already exists with the same fully-qualified name and const label values
 // which is documented by Prometheus at
 //  https://github.com/prometheus/client_golang/blob/fcc130e101e76c5d303513d0e28f4b6d732845c7/prometheus/registry.go#L89-L101
 func (c *collector) ensureRegisteredOnce() {
@@ -271,7 +271,6 @@ func tagsToLabels(tags []tag.Tag) []string {
 
 func newCollector(opts Options, registrar *prometheus.Registry) *collector {
 	return &collector{
-		registerOnce:    sync.Once{},
 		reg:             registrar,
 		opts:            opts,
 		registeredViews: make(map[string]*prometheus.Desc),


### PR DESCRIPTION
Fixes #469
Reverts #456

Also ensures that we only register the collector exactly
once, of which we erraneously had assumed Unregister would
do but as documented at
https://github.com/prometheus/client_golang/blob/fcc130e101e76c5d303513d0e28f4b6d732845c7/prometheus/registry.go#L89-L101
which specifies that invoking Register again even after Unregister
will just spit out an error because a collector should only
be registered once.

PR #456 attempted to fix this but didn't maintain uniqueness of
registeredViews hence doubly or more registered Prometheus metrics.
Nonetheless it was a great attempt.

With this PR, we should never get back the error that prompted
the PR in revision.