### PR TITLE
Use underlying slice in String() hex formatting for TraceID and SpanID

### DIFF
--- a/trace/basetypes.go
+++ b/trace/basetypes.go
@@ -27,11 +27,11 @@ type (
 )
 
 func (t TraceID) String() string {
-	return fmt.Sprintf("%02x", [16]byte(t))
+	return fmt.Sprintf("%02x", t[:])
 }
 
 func (s SpanID) String() string {
-	return fmt.Sprintf("%02x", [8]byte(s))
+	return fmt.Sprintf("%02x", s[:])
 }
 
 // Annotation represents a text annotation with a set of attributes and a timestamp.

--- a/trace/benchmark_test.go
+++ b/trace/benchmark_test.go
@@ -64,10 +64,10 @@ func BenchmarkSpanWithAnnotations_6(b *testing.B) {
 
 func BenchmarkTraceID_DotString(b *testing.B) {
 	b.ReportAllocs()
-	t1 := TraceID{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0B, 0x0D, 0x0A, 0x0E, 0x0D}
+	t := TraceID{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0B, 0x0D, 0x0A, 0x0E, 0x0D}
 	want := "0d0e0a0d0b0e0e0f0f0e0e0b0d0a0e0d"
 	for i := 0; i < b.N; i++ {
-		if got := t1.String(); got != want {
+		if got := t.String(); got != want {
 			b.Fatalf("got = %q want = %q", got, want)
 		}
 	}
@@ -75,10 +75,10 @@ func BenchmarkTraceID_DotString(b *testing.B) {
 
 func BenchmarkSpanID_DotString(b *testing.B) {
 	b.ReportAllocs()
-	s1 := SpanID{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F}
+	s := SpanID{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F}
 	want := "0d0e0a0d0b0e0e0f"
 	for i := 0; i < b.N; i++ {
-		if got := s1.String(); got != want {
+		if got := s.String(); got != want {
 			b.Fatalf("got = %q want = %q", got, want)
 		}
 	}

--- a/trace/benchmark_test.go
+++ b/trace/benchmark_test.go
@@ -61,3 +61,25 @@ func BenchmarkSpanWithAnnotations_6(b *testing.B) {
 		span.End()
 	}
 }
+
+func BenchmarkTraceID_DotString(b *testing.B) {
+	b.ReportAllocs()
+	t1 := TraceID{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0B, 0x0D, 0x0A, 0x0E, 0x0D}
+	want := "0d0e0a0d0b0e0e0f0f0e0e0b0d0a0e0d"
+	for i := 0; i < b.N; i++ {
+		if got := t1.String(); got != want {
+			b.Fatalf("got = %q want = %q", got, want)
+		}
+	}
+}
+
+func BenchmarkSpanID_DotString(b *testing.B) {
+	b.ReportAllocs()
+	s1 := SpanID{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F}
+	want := "0d0e0a0d0b0e0e0f"
+	for i := 0; i < b.N; i++ {
+		if got := s1.String(); got != want {
+			b.Fatalf("got = %q want = %q", got, want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #480

Avoid the cast [16]byte and [8]byte for TraceID and SpanID
respectively when invoking their String methods and instead
take the underlying slice of each using [:] instead of
falling back to their arrays and then letting fmt.Sprintf
take their slices for us.

Empirical benchmarks produced
```shell
$ benchstat old.txt new.txt
name    old time/op    new time/op    delta
With-4     422ns ± 1%     187ns ± 1%  -55.60%          (p=0.008 n=5+5)

name    old alloc/op   new alloc/op   delta
With-4     64.0B ± 0%     64.0B ± 0%     ~     (all samples are equal)

name    old allocs/op  new allocs/op  delta
With-4      3.00 ± 0%      2.00 ± 0%  -33.33%          (p=0.008 n=5+5)
```

Final benchmarks still showed huge reductions in  ns/op
but discrepancies in throughput i.e bytes processed/op but overall
the same number of allocations so not a problem.

```shell
$ benchstat old.txt new.txt
name                 old time/op    new time/op    delta
TraceID_DotString-4     478ns ± 2%     260ns ± 1%  -45.60% (p=0.000 n=10+8)
SpanID_DotString-4      345ns ± 1%     225ns ± 2%  -34.83% (p=0.000 n=8+9)

name                 old alloc/op   new alloc/op   delta
TraceID_DotString-4     64.0B ± 0%     80.0B ± 0%  +25.00% (p=0.000 n=10+10)
SpanID_DotString-4      32.0B ± 0%     56.0B ± 0%  +75.00% (p=0.000 n=10+10)

name                 old allocs/op  new allocs/op  delta
TraceID_DotString-4      3.00 ± 0%      3.00 ± 0%     ~     (all samples are equal)
SpanID_DotString-4       3.00 ± 0%      3.00 ± 0%     ~     (all samples are equal)
```