### PR TITLE
Add HTTP example demonstrating how to propagate the incoming trace

### DIFF
--- a/examples/http/helloworld_client/main.go
+++ b/examples/http/helloworld_client/main.go
@@ -30,7 +30,7 @@ import (
 const server = "http://localhost:50030"
 
 func main() {
-	go func() { log.Fatal(http.ListenAndServe(":8080", zpages.Handler)) }()
+	go func() { log.Fatal(http.ListenAndServe(":9979", zpages.Handler)) }()
 
 	// Register stats and trace exporters to export the collected data.
 	exporter := &exporter.Exporter{}
@@ -43,9 +43,7 @@ func main() {
 	// Report stats at every second.
 	view.SetReportingPeriod(1 * time.Second)
 
-	client := &http.Client{
-		Transport: &ochttp.Transport{},
-	}
+	client := &http.Client{Transport: &ochttp.Transport{}}
 
 	resp, err := client.Get(server)
 	if err != nil {

--- a/examples/http/helloworld_server/main.go
+++ b/examples/http/helloworld_server/main.go
@@ -29,6 +29,8 @@ import (
 )
 
 func main() {
+	go func() { log.Fatal(http.ListenAndServe(":9979", zpages.Handler)) }()
+
 	// Register stats and trace exporters to export the collected data.
 	exporter := &exporter.Exporter{}
 	view.RegisterExporter(exporter)
@@ -40,10 +42,20 @@ func main() {
 	// Report stats at every second.
 	view.SetReportingPeriod(1 * time.Second)
 
+	client := &http.Client{Transport: &ochttp.Transport{}}
+
 	http.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
 		fmt.Fprintf(w, "hello world")
+
+		r, _ := http.NewRequest("GET", "https://example.com", nil)
+
+		// Propagate the trace header info in the outgoing requests.
+		r = req.WithContext(req.Context())
+		resp, err := client.Do(r)
+		if err != nil {
+			log.Println(err)
+		}
+		_ = resp // handle response
 	})
-	http.HandleFunc("/rpcz", zpages.RpczHandler)
-	http.HandleFunc("/tracez", zpages.TracezHandler)
 	log.Fatal(http.ListenAndServe(":50030", &ochttp.Handler{}))
 }


### PR DESCRIPTION
The current HTTP example doesn't contain snippets how to
propagate the incoming traces to the outgoing requests
started from the server.