### PR TITLE
Remove dead code from collector

### DIFF
--- a/stats/internal/record.go
+++ b/stats/internal/record.go
@@ -15,12 +15,10 @@
 package internal
 
 import (
-	"time"
-
 	"go.opencensus.io/tag"
 )
 
-type Recorder func(*tag.Map, time.Time, interface{})
+type Recorder func(*tag.Map, interface{})
 
 // DefaultRecorder will be called for each Record call.
 var DefaultRecorder Recorder = nil

--- a/stats/record.go
+++ b/stats/record.go
@@ -17,7 +17,6 @@ package stats
 
 import (
 	"context"
-	"time"
 
 	"go.opencensus.io/stats/internal"
 	"go.opencensus.io/tag"
@@ -36,6 +35,6 @@ func Record(ctx context.Context, ms ...Measurement) {
 		if !record {
 			return
 		}
-		internal.DefaultRecorder(tag.FromContext(ctx), time.Now(), ms)
+		internal.DefaultRecorder(tag.FromContext(ctx), ms)
 	}
 }

--- a/stats/view/collector.go
+++ b/stats/view/collector.go
@@ -17,7 +17,6 @@ package view
 
 import (
 	"sort"
-	"time"
 
 	"go.opencensus.io/internal/tagencoding"
 	"go.opencensus.io/tag"
@@ -32,7 +31,7 @@ type collector struct {
 	a Aggregation
 }
 
-func (c *collector) addSample(s string, v float64, now time.Time) {
+func (c *collector) addSample(s string, v float64) {
 	aggregator, ok := c.signatures[s]
 	if !ok {
 		aggregator = c.a.newData()
@@ -41,7 +40,7 @@ func (c *collector) addSample(s string, v float64, now time.Time) {
 	aggregator.addSample(v)
 }
 
-func (c *collector) collectedRows(keys []tag.Key, now time.Time) []*Row {
+func (c *collector) collectedRows(keys []tag.Key) []*Row {
 	var rows []*Row
 	for sig, aggregator := range c.signatures {
 		tags := decodeTags([]byte(sig), keys)

--- a/stats/view/view.go
+++ b/stats/view/view.go
@@ -119,16 +119,16 @@ func (v *View) Measure() stats.Measure {
 	return v.m
 }
 
-func (v *View) collectedRows(now time.Time) []*Row {
-	return v.collector.collectedRows(v.tagKeys, now)
+func (v *View) collectedRows() []*Row {
+	return v.collector.collectedRows(v.tagKeys)
 }
 
-func (v *View) addSample(m *tag.Map, val float64, now time.Time) {
+func (v *View) addSample(m *tag.Map, val float64) {
 	if !v.isSubscribed() {
 		return
 	}
 	sig := string(encodeWithKeys(m, v.tagKeys))
-	v.collector.addSample(sig, val, now)
+	v.collector.addSample(sig, val)
 }
 
 // A Data is a set of rows about usage of the single measure associated

--- a/stats/view/view_test.go
+++ b/stats/view/view_test.go
@@ -18,7 +18,6 @@ package view
 import (
 	"context"
 	"testing"
-	"time"
 
 	"go.opencensus.io/tag"
 )
@@ -167,10 +166,10 @@ func Test_View_MeasureFloat64_AggregationDistribution_WindowCumulative(t *testin
 			if err != nil {
 				t.Errorf("%v: NewMap = %v", tc.label, err)
 			}
-			view.addSample(tag.FromContext(ctx), r.f, time.Now())
+			view.addSample(tag.FromContext(ctx), r.f)
 		}
 
-		gotRows := view.collectedRows(time.Now())
+		gotRows := view.collectedRows()
 		for i, got := range gotRows {
 			if !containsRow(tc.wantRows, got) {
 				t.Errorf("%v-%d: got row %v; want none", tc.label, i, got)
@@ -282,10 +281,10 @@ func Test_View_MeasureFloat64_AggregationSum(t *testing.T) {
 			if err != nil {
 				t.Errorf("%v: New = %v", tt.label, err)
 			}
-			view.addSample(tag.FromContext(ctx), r.f, time.Now())
+			view.addSample(tag.FromContext(ctx), r.f)
 		}
 
-		gotRows := view.collectedRows(time.Now())
+		gotRows := view.collectedRows()
 		for i, got := range gotRows {
 			if !containsRow(tt.wantRows, got) {
 				t.Errorf("%v-%d: got row %v; want none", tt.label, i, got)
@@ -399,10 +398,10 @@ func Test_View_MeasureFloat64_AggregationMean_WindowCumulative(t *testing.T) {
 			if err != nil {
 				t.Errorf("%v: New = %v", tt.label, err)
 			}
-			view.addSample(tag.FromContext(ctx), r.f, time.Now())
+			view.addSample(tag.FromContext(ctx), r.f)
 		}
 
-		gotRows := view.collectedRows(time.Now())
+		gotRows := view.collectedRows()
 		for i, got := range gotRows {
 			if !containsRow(tt.wantRows, got) {
 				t.Errorf("%v-%d: got row %v; want none", tt.label, i, got)

--- a/stats/view/worker_commands.go
+++ b/stats/view/worker_commands.go
@@ -146,7 +146,7 @@ func (cmd *retrieveDataReq) handleCommand(w *worker) {
 		return
 	}
 	cmd.c <- &retrieveDataResp{
-		cmd.v.collectedRows(cmd.now),
+		cmd.v.collectedRows(),
 		nil,
 	}
 }
@@ -154,16 +154,15 @@ func (cmd *retrieveDataReq) handleCommand(w *worker) {
 // recordReq is the command to record data related to multiple measures
 // at once.
 type recordReq struct {
-	now time.Time
-	tm  *tag.Map
-	ms  []stats.Measurement
+	tm *tag.Map
+	ms []stats.Measurement
 }
 
 func (cmd *recordReq) handleCommand(w *worker) {
 	for _, m := range cmd.ms {
 		ref := w.getMeasureRef(m.Measure)
 		for v := range ref.views {
-			v.addSample(cmd.tm, m.Value, cmd.now)
+			v.addSample(cmd.tm, m.Value)
 		}
 	}
 }


### PR DESCRIPTION
The data point no longer have to collected with a time-stamp
because cumulative view is the only collection window.

ViewData should always report the initial starting time for a view.