### PR TITLE
initial take at opencensus opentracing implementation

### DIFF
--- a/contrib/opentracer/logger.go
+++ b/contrib/opentracer/logger.go
@@ -1,0 +1,43 @@
+package opentracer
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/opentracing/opentracing-go/log"
+)
+
+type Logger interface {
+	LogFields(fields ...log.Field)
+	LogFieldsTime(t time.Time, fields ...log.Field)
+}
+
+var (
+	Stdout Logger = writeLogger{w: os.Stdout}
+)
+
+type writeLogger struct {
+	w io.Writer
+}
+
+func (s writeLogger) LogFields(fields ...log.Field) {
+	s.LogFieldsTime(time.Now(), fields...)
+}
+
+func (s writeLogger) LogFieldsTime(t time.Time, fields ...log.Field) {
+	var buffer = bytes.NewBuffer(nil)
+
+	buffer.WriteString(t.Format(time.RFC822Z))
+	buffer.WriteString(" ")
+
+	for index, field := range fields {
+		if index > 0 {
+			buffer.WriteString(" ")
+		}
+		fmt.Fprintf(buffer, "%v=%v", field.Key(), field.Value())
+	}
+	fmt.Fprintln(s.w, buffer.String())
+}

--- a/contrib/opentracer/span.go
+++ b/contrib/opentracer/span.go
@@ -1,0 +1,311 @@
+package opentracer
+
+import (
+	"reflect"
+	"sync"
+	"time"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/log"
+	"go.opencensus.io/trace"
+)
+
+// Span represents an active, un-finished span in the OpenTracing system.
+//
+// Spans are created by the Tracer interface.
+type Span struct {
+	tracer *Tracer
+	ocSpan *trace.Span
+
+	mutex   sync.Mutex  // mutex guards baggage and tags; because you never know
+	baggage []log.Field // baggage contains local baggage
+	tags    []log.Field // array of tags
+}
+
+func (s *Span) mergeFields(fields ...log.Field) []log.Field {
+	var merged []log.Field
+	merged = upsert(merged, s.baggage...)
+	merged = upsert(merged, s.tags...)
+	merged = upsert(merged, fields...)
+	return merged
+}
+
+func (s *Span) logFields(fields ...log.Field) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	s.tracer.logger.LogFields(s.mergeFields(fields...)...)
+}
+
+func (s *Span) logFieldsTime(t time.Time, fields ...log.Field) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	s.tracer.logger.LogFieldsTime(t, s.mergeFields(fields...)...)
+}
+
+// Sets the end timestamp and finalizes Span state.
+//
+// With the exception of calls to Context() (which are always allowed),
+// Finish() must be the last call made to any span instance, and to do
+// otherwise leads to undefined behavior.
+func (s *Span) Finish() {
+	s.ocSpan.End()
+}
+
+// FinishWithOptions is like Finish() but with explicit control over
+// timestamps and log data.
+func (s *Span) FinishWithOptions(opts opentracing.FinishOptions) {
+	for _, record := range opts.LogRecords {
+		var t = record.Timestamp
+		if t.IsZero() {
+			t = time.Now()
+		}
+		s.logFieldsTime(record.Timestamp, record.Fields...)
+	}
+
+	if len(opts.BulkLogData) > 0 {
+		s.logFields(log.String("message", "BulkLogData is deprecated.  Please use LogRecords instead."))
+	}
+
+	s.ocSpan.End()
+}
+
+// ForeachBaggageItem grants access to all baggage items stored in the
+// SpanContext.
+// The handler function will be called for each baggage key/value pair.
+// The ordering of items is not guaranteed.
+//
+// The bool return value indicates if the handler wants to continue iterating
+// through the rest of the baggage items; for example if the handler is trying to
+// find some baggage item by pattern matching the name, it can return false
+// as soon as the item is found to stop further iterations.
+func (s *Span) ForeachBaggageItem(handler func(k, v string) bool) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	for _, field := range s.baggage {
+		if ok := handler(field.Key(), field.Value().(string)); !ok {
+			return
+		}
+	}
+}
+
+// Context() yields the SpanContext for this Span. Note that the return
+// value of Context() is still valid after a call to Span.Finish(), as is
+// a call to Span.Context() after a call to Span.Finish().
+func (s *Span) Context() opentracing.SpanContext {
+	return s
+}
+
+// Sets or changes the operation name.
+func (s *Span) SetOperationName(operationName string) opentracing.Span {
+	s.logFields(log.String("message", "SetOperationName is not supported.  operationName is immutable."))
+	return s
+}
+
+// Adds a tag to the span.
+//
+// If there is a pre-existing tag set for `key`, it is overwritten.
+//
+// Tag values can be numeric types, strings, or bools. The behavior of
+// other tag value types is undefined at the OpenTracing level. If a
+// tracing system does not know how to handle a particular value type, it
+// may ignore the tag, but shall not panic.
+func (s *Span) SetTag(key string, value interface{}) opentracing.Span {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	if isValidTagValue(value) {
+		for _, field := range makeLogFields(key, value) {
+			s.tags = upsert(s.tags, field)
+		}
+	}
+
+	return s
+}
+
+// LogFields is an efficient and type-checked way to record key:value
+// logging data about a Span, though the programming interface is a little
+// more verbose than LogKV(). Here's an example:
+//
+//    span.LogFields(
+//        log.String("event", "soft error"),
+//        log.String("type", "cache timeout"),
+//        log.Int("waited.millis", 1500))
+//
+// Also see Span.FinishWithOptions() and FinishOptions.BulkLogData.
+func (s *Span) LogFields(fields ...log.Field) {
+	s.logFields(fields...)
+}
+
+// LogKV is a concise, readable way to record key:value logging data about
+// a Span, though unfortunately this also makes it less efficient and less
+// type-safe than LogFields(). Here's an example:
+//
+//    span.LogKV(
+//        "event", "soft error",
+//        "type", "cache timeout",
+//        "waited.millis", 1500)
+//
+// For LogKV (as opposed to LogFields()), the parameters must appear as
+// key-value pairs, like
+//
+//    span.LogKV(key1, val1, key2, val2, key3, val3, ...)
+//
+// The keys must all be strings. The values may be strings, numeric types,
+// bools, Go error instances, or arbitrary structs.
+//
+// (Note to implementors: consider the log.InterleavedKVToFields() helper)
+func (s *Span) LogKV(alternatingKeyValues ...interface{}) {
+	s.logFields(makeLogFields(alternatingKeyValues...)...)
+}
+
+// SetBaggageItem sets a key:value pair on this Span and its SpanContext
+// that also propagates to descendants of this Span.
+//
+// SetBaggageItem() enables powerful functionality given a full-stack
+// opentracing integration (e.g., arbitrary application data from a mobile
+// app can make it, transparently, all the way into the depths of a storage
+// system), and with it some powerful costs: use this feature with care.
+//
+// IMPORTANT NOTE #1: SetBaggageItem() will only propagate baggage items to
+// *future* causal descendants of the associated Span.
+//
+// IMPORTANT NOTE #2: Use this thoughtfully and with care. Every key and
+// value is copied into every local *and remote* child of the associated
+// Span, and that can add up to a lot of network and cpu overhead.
+//
+// Returns a reference to this Span for chaining.
+func (s *Span) SetBaggageItem(restrictedKey, value string) opentracing.Span {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	s.baggage = upsert(s.baggage, log.String(restrictedKey, value))
+	return s
+}
+
+// Gets the value for a baggage item given its key. Returns the empty string
+// if the value isn't found in this Span.
+func (s *Span) BaggageItem(restrictedKey string) string {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	for _, item := range s.baggage {
+		if item.Key() == restrictedKey {
+			return item.Value().(string)
+		}
+	}
+	return ""
+}
+
+// Provides access to the Tracer that created this Span.
+func (s *Span) Tracer() opentracing.Tracer {
+	return s.tracer
+}
+
+// Deprecated: use LogFields or LogKV
+func (s *Span) LogEvent(event string) {
+	s.logFields(log.String("message", "deprecated LogEvent called"))
+}
+
+// Deprecated: use LogFields or LogKV
+func (s *Span) LogEventWithPayload(event string, payload interface{}) {
+	s.logFields(log.String("message", "deprecated LogEventWithPayload called"))
+}
+
+// Deprecated: use LogFields or LogKV
+func (s *Span) Log(data opentracing.LogData) {
+	s.logFields(log.String("message", "deprecated Log called"))
+}
+
+// isValidTagValue returns true if value is numeric, string, or bool
+func isValidTagValue(value interface{}) bool {
+	switch value.(type) {
+	case bool:
+		return true
+	case string:
+		return true
+	case int, int8, int16, int32, int64:
+		return true
+	case uint, uint8, uint16, uint32, uint64:
+		return true
+	case float32, float64:
+		return true
+	default:
+		return false
+	}
+}
+
+// makeLogFields converts key value pairs into log.Field values
+// odd number values will be dropped
+func makeLogFields(kvs ...interface{}) []log.Field {
+	var fields []log.Field
+
+	for i, length := 0, len(kvs); i < length; i += 2 {
+		var (
+			key, keyOk = kvs[i].(string)
+			value      = kvs[i+1]
+		)
+		if !keyOk {
+			continue
+		}
+
+		switch v := value.(type) {
+		case bool:
+			fields = append(fields, log.Bool(key, v))
+		case string:
+			fields = append(fields, log.String(key, v))
+		case int:
+			fields = append(fields, log.Int(key, v))
+		case int8:
+			fields = append(fields, log.Int(key, int(v)))
+		case int16:
+			fields = append(fields, log.Int(key, int(v)))
+		case int32:
+			fields = append(fields, log.Int32(key, v))
+		case int64:
+			fields = append(fields, log.Int64(key, v))
+		case uint:
+			fields = append(fields, log.Uint32(key, uint32(v)))
+		case uint8:
+			fields = append(fields, log.Uint32(key, uint32(v)))
+		case uint16:
+			fields = append(fields, log.Uint32(key, uint32(v)))
+		case uint32:
+			fields = append(fields, log.Uint32(key, v))
+		case uint64:
+			fields = append(fields, log.Uint64(key, v))
+		case float32:
+			fields = append(fields, log.Float32(key, v))
+		case float64:
+			fields = append(fields, log.Float64(key, v))
+		}
+	}
+
+	return fields
+}
+
+// upsert updates an existing field if changed or appends to the list
+// if this is a new field
+func upsert(original []log.Field, fields ...log.Field) []log.Field {
+loop:
+	for _, field := range fields {
+		for i, length := 0, len(original); i < length; i++ {
+			if f := original[i]; f.Key() == field.Key() {
+				if reflect.DeepEqual(f.Value(), field.Value()) {
+					continue loop
+
+				} else {
+					original = append(original[:i], original[i+1:]...)
+					original = append(original, field)
+					continue loop
+				}
+			}
+		}
+
+		original = append(original, field)
+	}
+
+	return original
+}

--- a/contrib/opentracer/span_test.go
+++ b/contrib/opentracer/span_test.go
@@ -1,0 +1,350 @@
+package opentracer
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/log"
+)
+
+func TestUpsert(t *testing.T) {
+	var (
+		a  = log.String("a", "apple")
+		b  = log.String("b", "boy")
+		c  = log.String("c", "cat")
+		a2 = log.String("a", "adam")
+		a3 = log.Int64("a", 1)
+	)
+
+	t.Run("nil", func(t *testing.T) {
+		var actual = upsert(nil, a)
+		if expected := []log.Field{a}; !reflect.DeepEqual(actual, expected) {
+			t.Errorf("expected %v; got %v", expected, actual)
+		}
+	})
+
+	t.Run("append", func(t *testing.T) {
+		var actual = upsert([]log.Field{a}, b)
+		if expected := []log.Field{a, b}; !reflect.DeepEqual(actual, expected) {
+			t.Errorf("expected %v; got %v", expected, actual)
+		}
+	})
+
+	t.Run("unchanged", func(t *testing.T) {
+		var actual = upsert([]log.Field{a}, a)
+		if expected := []log.Field{a}; !reflect.DeepEqual(actual, expected) {
+			t.Errorf("expected %v; got %v", expected, actual)
+		}
+	})
+
+	t.Run("replace same type", func(t *testing.T) {
+		var actual = upsert([]log.Field{a}, a2)
+		if expected := []log.Field{a2}; !reflect.DeepEqual(actual, expected) {
+			t.Errorf("expected %v; got %v", expected, actual)
+		}
+	})
+
+	t.Run("replace different type type", func(t *testing.T) {
+		var actual = upsert([]log.Field{a}, a3)
+		if expected := []log.Field{a3}; !reflect.DeepEqual(actual, expected) {
+			t.Errorf("expected %v; got %v", expected, actual)
+		}
+	})
+
+	t.Run("replace from head", func(t *testing.T) {
+		var actual = upsert([]log.Field{a, b, c}, a2)
+		if expected := []log.Field{b, c, a2}; !reflect.DeepEqual(actual, expected) {
+			t.Errorf("expected %v; got %v", expected, actual)
+		}
+	})
+
+	t.Run("upsert multiple", func(t *testing.T) {
+		var actual = upsert([]log.Field{a, b}, a2, c)
+		if expected := []log.Field{b, a2, c}; !reflect.DeepEqual(actual, expected) {
+			t.Errorf("expected %v; got %v", expected, actual)
+		}
+	})
+}
+
+type logCapturer struct {
+	logs [][]log.Field
+}
+
+func (l *logCapturer) LogFields(fields ...log.Field) {
+	l.logs = append(l.logs, fields)
+}
+
+func (l *logCapturer) LogFieldsTime(t time.Time, fields ...log.Field) {
+	l.logs = append(l.logs, fields)
+}
+
+func setup() *logCapturer {
+	var (
+		logger logCapturer
+		tracer = New(&logger)
+	)
+	opentracing.SetGlobalTracer(tracer)
+
+	return &logger
+}
+
+func TestSpan(t *testing.T) {
+	t.Run("basic log", func(t *testing.T) {
+		var (
+			ctx    = context.Background()
+			logger = setup()
+			field  = log.String("message", "hello world")
+		)
+
+		span, _ := opentracing.StartSpanFromContext(ctx, "span")
+		span.LogFields(field)
+		span.Finish()
+
+		if expected := 1; len(logger.logs) != expected {
+			t.Fatalf("expected %v; got %v", expected, len(logger.logs))
+		}
+		if expected := []log.Field{field}; !reflect.DeepEqual(expected, logger.logs[0]) {
+			t.Fatalf("expected %#v; got %#v", expected, logger.logs[0])
+		}
+	})
+
+	t.Run("logs tags", func(t *testing.T) {
+		var (
+			ctx    = context.Background()
+			logger = setup()
+			tag    = log.String("foo", "bar")
+			field  = log.String("message", "hello world")
+		)
+
+		span, _ := opentracing.StartSpanFromContext(ctx, "span")
+		span.SetTag(tag.Key(), tag.Value())
+		span.LogFields(field)
+		span.Finish()
+
+		if expected := 1; len(logger.logs) != expected {
+			t.Fatalf("expected %v; got %v", expected, len(logger.logs))
+		}
+		if expected := []log.Field{tag, field}; !reflect.DeepEqual(expected, logger.logs[0]) {
+			t.Fatalf("expected %#v; got %#v", expected, logger.logs[0])
+		}
+	})
+
+	t.Run("logs baggage", func(t *testing.T) {
+		var (
+			ctx     = context.Background()
+			logger  = setup()
+			baggage = log.String("foo", "bar")
+			field   = log.String("message", "hello world")
+		)
+
+		span, _ := opentracing.StartSpanFromContext(ctx, "span")
+		span.SetBaggageItem(baggage.Key(), baggage.Value().(string))
+		span.LogFields(field)
+		span.Finish()
+
+		if expected := 1; len(logger.logs) != expected {
+			t.Fatalf("expected %v; got %v", expected, len(logger.logs))
+		}
+		if expected := []log.Field{baggage, field}; !reflect.DeepEqual(expected, logger.logs[0]) {
+			t.Fatalf("expected %#v; got %#v", expected, logger.logs[0])
+		}
+	})
+
+	t.Run("tags override baggage", func(t *testing.T) {
+		var (
+			ctx     = context.Background()
+			logger  = setup()
+			baggage = log.String("key", "baggage")
+			tag     = log.String("key", "tag")
+			field   = log.String("message", "hello world")
+		)
+
+		span, _ := opentracing.StartSpanFromContext(ctx, "span")
+		span.SetTag(tag.Key(), tag.Value())
+		span.SetBaggageItem(baggage.Key(), baggage.Value().(string))
+		span.LogFields(field)
+		span.Finish()
+
+		if expected := 1; len(logger.logs) != expected {
+			t.Fatalf("expected %v; got %v", expected, len(logger.logs))
+		}
+		if expected := []log.Field{tag, field}; !reflect.DeepEqual(expected, logger.logs[0]) {
+			t.Fatalf("expected %#v; got %#v", expected, logger.logs[0])
+		}
+	})
+
+	t.Run("fields overrides tags", func(t *testing.T) {
+		var (
+			ctx    = context.Background()
+			logger = setup()
+			tag    = log.String("key", "tag")
+			field  = log.String("key", "hello world")
+		)
+
+		span, _ := opentracing.StartSpanFromContext(ctx, "span")
+		span.SetTag(tag.Key(), tag.Value())
+		span.LogFields(field)
+		span.Finish()
+
+		if expected := 1; len(logger.logs) != expected {
+			t.Fatalf("expected %v; got %v", expected, len(logger.logs))
+		}
+		if expected := []log.Field{field}; !reflect.DeepEqual(expected, logger.logs[0]) {
+			t.Fatalf("expected %#v; got %#v", expected, logger.logs[0])
+		}
+	})
+
+	t.Run("LogKV", func(t *testing.T) {
+		var (
+			ctx    = context.Background()
+			logger = setup()
+			field  = log.String("key", "hello world")
+		)
+
+		span, _ := opentracing.StartSpanFromContext(ctx, "span")
+		span.LogKV(field.Key(), field.Value())
+		span.Finish()
+
+		if expected := 1; len(logger.logs) != expected {
+			t.Fatalf("expected %v; got %v", expected, len(logger.logs))
+		}
+		if expected := []log.Field{field}; !reflect.DeepEqual(expected, logger.logs[0]) {
+			t.Fatalf("expected %#v; got %#v", expected, logger.logs[0])
+		}
+	})
+
+	t.Run("Tracer", func(t *testing.T) {
+		var (
+			ctx = context.Background()
+		)
+
+		span, _ := opentracing.StartSpanFromContext(ctx, "span")
+		if span.Tracer() == nil {
+			t.Errorf("expected Tracer; got nil")
+		}
+	})
+
+	t.Run("BaggageItem propagates to children", func(t *testing.T) {
+		var (
+			ctx   = context.Background()
+			key   = "key"
+			value = "value"
+		)
+
+		parent, ctx := opentracing.StartSpanFromContext(ctx, "parent")
+		parent.SetBaggageItem(key, value)
+
+		child, _ := opentracing.StartSpanFromContext(ctx, "child")
+
+		if expected := value; child.BaggageItem(key) != expected {
+			t.Errorf("expected %v; got %v", expected, child.BaggageItem(key))
+		}
+	})
+
+	t.Run("logs tags set during span initialization", func(t *testing.T) {
+		var (
+			ctx     = context.Background()
+			logger  = setup()
+			tag     = log.String("key", "value")
+			message = log.String("hello", "world")
+		)
+
+		span, ctx := opentracing.StartSpanFromContext(ctx, "span", opentracing.Tags{
+			tag.Key(): tag.Value(),
+		})
+		span.LogFields(message)
+		span.Finish()
+
+		if expected := 1; len(logger.logs) != expected {
+			t.Fatalf("expected %v; got %v", expected, len(logger.logs))
+		}
+		if expected := []log.Field{tag, message}; !reflect.DeepEqual(expected, logger.logs[0]) {
+			t.Errorf("expected %v; got %v", expected, logger.logs[0])
+		}
+	})
+
+	t.Run("ForeachBaggageItem", func(t *testing.T) {
+		var (
+			ctx   = context.Background()
+			key   = "key"
+			value = "value"
+		)
+
+		span, ctx := opentracing.StartSpanFromContext(ctx, "span")
+		span.SetBaggageItem(key, value)
+
+		var (
+			count = 0
+			seen  = false
+		)
+		span.Context().ForeachBaggageItem(func(k, v string) bool {
+			count++
+			if k == key {
+				seen = true
+				return false
+			}
+			return true
+		})
+
+		if count != 1 {
+			t.Errorf("expected 1 baggage item; got %v", count)
+		}
+		if !seen {
+			t.Errorf("expected our baggage item to be seen")
+		}
+	})
+
+	t.Run("ForeachBaggageItem", func(t *testing.T) {
+		var (
+			ctx    = context.Background()
+			logger = setup()
+		)
+
+		span, ctx := opentracing.StartSpanFromContext(ctx, "span")
+		span.SetOperationName("blah")
+
+		if expected := 1; len(logger.logs) != expected {
+			// no need to read message about it not being supported
+			t.Fatalf("expected %v; got %v", expected, len(logger.logs))
+		}
+	})
+	t.Run("ForeachBaggageItem", func(t *testing.T) {
+		var (
+			ctx    = context.Background()
+			logger = setup()
+			field  = log.String("message", "blah")
+		)
+
+		span, ctx := opentracing.StartSpanFromContext(ctx, "span")
+		span.FinishWithOptions(opentracing.FinishOptions{
+			LogRecords: []opentracing.LogRecord{
+				{
+					Timestamp: time.Now(),
+					Fields:    []log.Field{field},
+				},
+			},
+		})
+
+		if expected := 1; len(logger.logs) != expected {
+			t.Fatalf("expected %v; got %v", expected, len(logger.logs))
+		}
+		if expected := []log.Field{field}; !reflect.DeepEqual(expected, logger.logs[0]) {
+			t.Errorf("expected %v; got %v", expected, logger.logs[0])
+		}
+	})
+}
+
+func TestDeprecated(t *testing.T) {
+	var tracer = New(nil)
+	opentracing.SetGlobalTracer(tracer)
+
+	// just invoke the deprecated methods to ensure nothing blows up,
+	// we don't really care what happens
+	span := opentracing.StartSpan("span")
+	span.Log(opentracing.LogData{})
+	span.LogEvent("blah")
+	span.LogEventWithPayload("blah", nil)
+}

--- a/contrib/opentracer/tracer.go
+++ b/contrib/opentracer/tracer.go
@@ -1,0 +1,404 @@
+package opentracer
+
+import (
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/log"
+	"go.opencensus.io/trace"
+	"go.opencensus.io/trace/propagation"
+)
+
+const (
+	httpHeader = "X-Opencensus-Trace"
+)
+
+// Tracer is a simple, thin interface for Span creation and SpanContext
+// propagation.
+type Tracer struct {
+	logger Logger
+}
+
+// New returns an opentracing.Tracer backed by OpenCensus
+func New(logger Logger) *Tracer {
+	if logger == nil {
+		logger = Stdout
+	}
+
+	return &Tracer{
+		logger: logger,
+	}
+}
+
+// Create, start, and return a new Span with the given `operationName` and
+// incorporate the given StartSpanOption `opts`. (Note that `opts` borrows
+// from the "functional options" pattern, per
+// http://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis)
+//
+// A Span with no SpanReference options (e.g., opentracing.ChildOf() or
+// opentracing.FollowsFrom()) becomes the root of its own trace.
+//
+// Examples:
+//
+//     var tracer opentracing.Tracer = ...
+//
+//     // The root-span case:
+//     sp := tracer.StartSpan("GetFeed")
+//
+//     // The vanilla child span case:
+//     sp := tracer.StartSpan(
+//         "GetFeed",
+//         opentracing.ChildOf(parentSpan.Context()))
+//
+//     // All the bells and whistles:
+//     sp := tracer.StartSpan(
+//         "GetFeed",
+//         opentracing.ChildOf(parentSpan.Context()),
+//         opentracing.Tag{"user_agent", loggedReq.UserAgent},
+//         opentracing.StartTime(loggedReq.Timestamp),
+//     )
+//
+func (t *Tracer) StartSpan(operationName string, opts ...opentracing.StartSpanOption) opentracing.Span {
+	var options opentracing.StartSpanOptions
+	for _, opt := range opts {
+		opt.Apply(&options)
+	}
+
+	var (
+		parentSpan   *Span
+		ocParentSpan *trace.Span
+	)
+
+	for _, ref := range options.References {
+		if ref.Type == opentracing.ChildOfRef {
+			if v, ok := ref.ReferencedContext.(*Span); ok {
+				parentSpan = v
+				ocParentSpan = v.ocSpan
+				break
+			}
+
+			// implementation assumes same opentracing.Tracer implementation used by all
+		}
+	}
+
+	var (
+		ocSpan  = trace.NewSpan(operationName, ocParentSpan, trace.StartOptions{})
+		baggage = makeBaggage(parentSpan)
+		tags    = makeTags(options.Tags)
+		span    = Span{
+			tracer:  t,
+			ocSpan:  ocSpan,
+			baggage: baggage,
+			tags:    tags,
+		}
+	)
+
+	return &span
+}
+
+// Inject() takes the `sm` SpanContext instance and injects it for
+// propagation within `carrier`. The actual type of `carrier` depends on
+// the value of `format`.
+//
+// OpenTracing defines a common set of `format` values (see BuiltinFormat),
+// and each has an expected carrier type.
+//
+// Other packages may declare their own `format` values, much like the keys
+// used by `context.Context` (see
+// https://godoc.org/golang.org/x/net/context#WithValue).
+//
+// Example usage (sans error handling):
+//
+//     carrier := opentracing.HTTPHeadersCarrier(httpReq.Header)
+//     err := tracer.Inject(
+//         span.Context(),
+//         opentracing.HTTPHeaders,
+//         carrier)
+//
+// NOTE: All opentracing.Tracer implementations MUST support all
+// BuiltinFormats.
+//
+// Implementations may return opentracing.ErrUnsupportedFormat if `format`
+// is not supported by (or not known by) the implementation.
+//
+// Implementations may return opentracing.ErrInvalidCarrier or any other
+// implementation-specific error if the format is supported but injection
+// fails anyway.
+//
+// See Tracer.Extract().
+func (t *Tracer) Inject(sm opentracing.SpanContext, format interface{}, carrier interface{}) error {
+	span, ok := sm.(*Span)
+	if !ok {
+		return opentracing.ErrInvalidSpanContext
+	}
+
+	if carrier == nil {
+		return opentracing.ErrInvalidCarrier
+	}
+
+	header := marshal(span)
+
+	if format == opentracing.Binary {
+		w, ok := carrier.(io.Writer)
+		if !ok {
+			return opentracing.ErrInvalidCarrier
+		}
+		io.WriteString(w, header)
+
+	} else if format == opentracing.TextMap || format == opentracing.HTTPHeaders {
+		m, ok := carrier.(opentracing.TextMapWriter)
+		if !ok {
+			return opentracing.ErrInvalidCarrier
+		}
+		m.Set(httpHeader, header)
+
+	} else {
+		return opentracing.ErrUnsupportedFormat
+	}
+
+	return nil
+}
+
+// Extract() returns a SpanContext instance given `format` and `carrier`.
+//
+// OpenTracing defines a common set of `format` values (see BuiltinFormat),
+// and each has an expected carrier type.
+//
+// Other packages may declare their own `format` values, much like the keys
+// used by `context.Context` (see
+// https://godoc.org/golang.org/x/net/context#WithValue).
+//
+// Example usage (with StartSpan):
+//
+//
+//     carrier := opentracing.HTTPHeadersCarrier(httpReq.Header)
+//     clientContext, err := tracer.Extract(opentracing.HTTPHeaders, carrier)
+//
+//     // ... assuming the ultimate goal here is to resume the trace with a
+//     // server-side Span:
+//     var serverSpan opentracing.Span
+//     if err == nil {
+//         span = tracer.StartSpan(
+//             rpcMethodName, ext.RPCServerOption(clientContext))
+//     } else {
+//         span = tracer.StartSpan(rpcMethodName)
+//     }
+//
+//
+// NOTE: All opentracing.Tracer implementations MUST support all
+// BuiltinFormats.
+//
+// Return values:
+//  - A successful Extract returns a SpanContext instance and a nil error
+//  - If there was simply no SpanContext to extract in `carrier`, Extract()
+//    returns (nil, opentracing.ErrSpanContextNotFound)
+//  - If `format` is unsupported or unrecognized, Extract() returns (nil,
+//    opentracing.ErrUnsupportedFormat)
+//  - If there are more fundamental problems with the `carrier` object,
+//    Extract() may return opentracing.ErrInvalidCarrier,
+//    opentracing.ErrSpanContextCorrupted, or implementation-specific
+//    errors.
+//
+// See Tracer.Inject().
+func (t *Tracer) Extract(format interface{}, carrier interface{}) (opentracing.SpanContext, error) {
+	var spanContext opentracing.SpanContext
+	var err error
+
+	if format == opentracing.Binary {
+		spanContext, err = extractBinary(t, carrier)
+		if err != nil {
+			return nil, err
+		}
+
+	} else if format == opentracing.TextMap {
+		spanContext, err = extractTextMap(t, carrier)
+		if err != nil {
+			return nil, err
+		}
+
+	} else if format == opentracing.HTTPHeaders {
+		spanContext, err = extractHTTPHeaders(t, carrier)
+		if err != nil {
+			return nil, err
+		}
+
+	} else {
+		return nil, fmt.Errorf("unhandled format, %v", format)
+	}
+
+	return spanContext, nil
+}
+
+// makeBaggage create a baggage from the span provided; if no span is provided,
+// an empty map wll be returned
+func makeBaggage(span *Span) []log.Field {
+	var baggage []log.Field
+	if span != nil {
+		baggage = append(baggage, span.baggage...)
+	}
+	return baggage
+}
+
+func makeTags(tags map[string]interface{}) []log.Field {
+	var fields []log.Field
+	for k, v := range tags {
+		fields = append(fields, makeLogFields(k, v)...)
+	}
+	return fields
+}
+
+const (
+	version   = "1"
+	separator = "-"
+)
+
+// marshal encodes to 1-{identifier}-{baggage}
+func marshal(span *Span) string {
+	values := url.Values{}
+	for _, field := range span.baggage {
+		values.Set(field.Key(), field.Value().(string))
+	}
+
+	var (
+		spanContext = span.ocSpan.SpanContext()
+		binary      = propagation.Binary(spanContext)
+		identifier  = hex.EncodeToString(binary)
+	)
+	return version + separator +
+		identifier + separator +
+		values.Encode()
+}
+
+// unmarshal decodes to 1-{identifier}-{baggage}
+func unmarshal(tracer *Tracer, value string) (opentracing.SpanContext, error) {
+	segments := strings.SplitN(value, separator, 3)
+	if len(segments) != 3 {
+		return nil, opentracing.ErrSpanContextCorrupted
+	}
+	if segments[0] != version {
+		return nil, opentracing.ErrSpanContextCorrupted
+	}
+
+	binary, err := hex.DecodeString(segments[1])
+	if err != nil {
+		return nil, opentracing.ErrSpanContextCorrupted
+	}
+
+	parentContext, ok := propagation.FromBinary(binary)
+	if !ok {
+		return nil, opentracing.ErrSpanContextCorrupted
+	}
+
+	var baggage []log.Field
+	if encoded := segments[2]; len(encoded) > 0 {
+		values, err := url.ParseQuery(encoded)
+		if err != nil {
+			return nil, opentracing.ErrSpanContextCorrupted
+		}
+
+		for key := range values {
+			value := values.Get(key)
+			baggage = upsert(baggage, log.String(key, value))
+		}
+	}
+
+	var (
+		ocSpan = trace.NewSpanWithRemoteParent("remote", parentContext, trace.StartOptions{})
+		span   = Span{
+			tracer:  tracer,
+			ocSpan:  ocSpan,
+			baggage: baggage,
+		}
+	)
+
+	return &span, nil
+}
+
+func extractBinary(tracer *Tracer, carrier interface{}) (opentracing.SpanContext, error) {
+	r, ok := carrier.(io.Reader)
+	if !ok {
+		return nil, opentracing.ErrInvalidCarrier
+	}
+	data, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, opentracing.ErrSpanContextCorrupted
+	}
+	return unmarshal(tracer, string(data))
+}
+
+func extractTextMap(tracer *Tracer, carrier interface{}) (opentracing.SpanContext, error) {
+	var spanContext opentracing.SpanContext
+
+	m, ok := carrier.(opentracing.TextMapReader)
+	if !ok {
+		return nil, opentracing.ErrInvalidCarrier
+	}
+
+	fn := func(key, value string) error {
+		if key == httpHeader {
+			v, err := unmarshal(tracer, value)
+			if err != nil {
+				return opentracing.ErrSpanContextCorrupted
+			}
+			spanContext = v
+		}
+		return nil
+	}
+
+	if err := m.ForeachKey(fn); err != nil {
+		return nil, err
+	}
+
+	if spanContext == nil {
+		return nil, opentracing.ErrSpanContextCorrupted
+	}
+
+	return spanContext, nil
+}
+
+type mapCarrier interface {
+	ForeachKey(handler func(key, val string) error) error
+	Set(key, val string)
+}
+
+func extractHTTPHeaders(tracer *Tracer, carrier interface{}) (opentracing.SpanContext, error) {
+	var spanContext opentracing.SpanContext
+	var mc mapCarrier
+
+	if m, ok := carrier.(mapCarrier); !ok {
+		if v, ok := carrier.(http.Header); ok {
+			mc = opentracing.HTTPHeadersCarrier(v)
+		} else {
+			return nil, opentracing.ErrInvalidCarrier
+		}
+	} else {
+		mc = m
+	}
+
+	fn := func(key, value string) error {
+		if key == httpHeader {
+			v, err := unmarshal(tracer, value)
+			if err != nil {
+				return opentracing.ErrSpanContextCorrupted
+			}
+			spanContext = v
+		}
+		return nil
+	}
+
+	if err := mc.ForeachKey(fn); err != nil {
+		return nil, err
+	}
+
+	if spanContext == nil {
+		return nil, opentracing.ErrSpanContextCorrupted
+	}
+
+	return spanContext, nil
+}

--- a/contrib/opentracer/tracer_test.go
+++ b/contrib/opentracer/tracer_test.go
@@ -1,0 +1,178 @@
+package opentracer
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/log"
+	"go.opencensus.io/trace"
+)
+
+func TestImplementsTracer(t *testing.T) {
+	var tracer opentracing.Tracer = New(nil)
+	if tracer == nil {
+		t.Fatalf("should never occur")
+	}
+}
+
+type spanCapturer struct {
+	spans []*trace.SpanData
+}
+
+func (c *spanCapturer) ExportSpan(s *trace.SpanData) {
+	c.spans = append(c.spans, s)
+}
+
+func TestTracer(t *testing.T) {
+	var exporter spanCapturer
+	trace.RegisterExporter(&exporter)
+	trace.SetDefaultSampler(trace.AlwaysSample()) // Always trace for this demo.
+
+	var (
+		ctx    = context.Background()
+		tracer = New(nil)
+	)
+
+	opentracing.SetGlobalTracer(tracer)
+
+	parent, ctx := opentracing.StartSpanFromContext(ctx, "parent")
+	child, _ := opentracing.StartSpanFromContext(ctx, "child")
+	child.Finish()
+	parent.Finish()
+
+	if expected := 2; len(exporter.spans) != expected {
+		t.Fatalf("expected %v spans; got %v", expected, len(exporter.spans))
+	}
+
+	var (
+		c = exporter.spans[0]
+		p = exporter.spans[1]
+	)
+
+	if expected := "child"; c.Name != expected {
+		t.Fatalf("expected %v; got %v", expected, c.Name)
+	}
+	if expected := "parent"; p.Name != expected {
+		t.Fatalf("expected %v; got %v", expected, p.Name)
+	}
+}
+
+func TestUnmarshal(t *testing.T) {
+	var (
+		tracer = New(nil)
+		span   = tracer.StartSpan("span")
+	)
+
+	t.Run("TextMap", func(t *testing.T) {
+		var (
+			carrier = opentracing.TextMapCarrier{}
+		)
+
+		err := tracer.Inject(span.Context(), opentracing.TextMap, carrier)
+		if err != nil {
+			t.Fatalf("expected nil; got %v", err)
+		}
+
+		spanContext, err := tracer.Extract(opentracing.TextMap, carrier)
+		if err != nil {
+			t.Fatalf("expected nil; got %v", err)
+		}
+
+		if reflect.DeepEqual(span, spanContext) {
+			t.Fatalf("expected %#v; got %#v", span, spanContext)
+		}
+	})
+
+	t.Run("Binary", func(t *testing.T) {
+		var (
+			carrier = bytes.NewBuffer(nil)
+		)
+
+		err := tracer.Inject(span.Context(), opentracing.Binary, carrier)
+		if err != nil {
+			t.Fatalf("expected nil; got %v", err)
+		}
+
+		spanContext, err := tracer.Extract(opentracing.Binary, carrier)
+		if err != nil {
+			t.Fatalf("expected nil; got %v", err)
+		}
+
+		if reflect.DeepEqual(span, spanContext) {
+			t.Fatalf("expected %#v; got %#v", span, spanContext)
+		}
+	})
+
+	t.Run("HTTPHeaders", func(t *testing.T) {
+		var (
+			values  = url.Values{}
+			carrier = opentracing.HTTPHeadersCarrier(values)
+		)
+
+		err := tracer.Inject(span.Context(), opentracing.HTTPHeaders, carrier)
+		if err != nil {
+			t.Fatalf("expected nil; got %v", err)
+		}
+
+		spanContext, err := tracer.Extract(opentracing.HTTPHeaders, carrier)
+		if err != nil {
+			t.Fatalf("expected nil; got %v", err)
+		}
+
+		if reflect.DeepEqual(span, spanContext) {
+			t.Fatalf("expected %#v; got %#v", span, spanContext)
+		}
+	})
+
+	t.Run("HTTPHeaders - via http.Header", func(t *testing.T) {
+		var (
+			carrier = http.Header{}
+		)
+
+		err := tracer.Inject(span.Context(), opentracing.HTTPHeaders, carrier)
+		if err != nil {
+			t.Fatalf("expected nil; got %v", err)
+		}
+
+		spanContext, err := tracer.Extract(opentracing.HTTPHeaders, carrier)
+		if err != nil {
+			t.Fatalf("expected nil; got %v", err)
+		}
+
+		if reflect.DeepEqual(span, spanContext) {
+			t.Fatalf("expected %#v; got %#v", span, spanContext)
+		}
+	})
+
+	t.Run("propagates baggage", func(t *testing.T) {
+		opentracing.SetGlobalTracer(tracer)
+
+		var (
+			carrier = http.Header{}
+			span, _ = opentracing.StartSpanFromContext(context.Background(), "span")
+			baggage = log.String("key", "value")
+		)
+
+		span.SetBaggageItem(baggage.Key(), baggage.Value().(string))
+
+		err := tracer.Inject(span.Context(), opentracing.HTTPHeaders, carrier)
+		if err != nil {
+			t.Fatalf("expected nil; got %v", err)
+		}
+
+		spanContext, err := tracer.Extract(opentracing.HTTPHeaders, carrier)
+		if err != nil {
+			t.Fatalf("expected nil; got %v", err)
+		}
+
+		remoteSpan := spanContext.(*Span)
+		if expected := []log.Field{baggage}; !reflect.DeepEqual(expected, remoteSpan.baggage) {
+			t.Fatalf("expected %#v; got %v", expected, remoteSpan.baggage)
+		}
+	})
+}


### PR DESCRIPTION
Implementation allows users to provide external Logger implementation.  Tags and baggage will be published to logger, but will not interact with opencensus trace.