### PR TITLE
Add an internal utility MonotonicTimeSince

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -14,6 +14,16 @@
 
 package internal
 
+import "time"
+
 // UserAgent is the user agent to be added to the outgoing
 // requests from the exporters.
 const UserAgent = "opencensus-go-v0.1.0"
+
+func MonoticTimeSince(start time.Time) time.Time {
+	// The monotonic clock is used in subtractions hence
+	// the duration since start added back to start gives
+	// end as a monotonic time.
+	// See https://golang.org/pkg/time/#hdr-Monotonic_Clocks
+	return start.Add(time.Now().Sub(start))
+}

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -20,10 +20,10 @@ import "time"
 // requests from the exporters.
 const UserAgent = "opencensus-go-v0.1.0"
 
+// The monotonic clock is used in subtractions hence
+// the duration since start added back to start gives
+// end as a monotonic time.
+// See https://golang.org/pkg/time/#hdr-Monotonic_Clocks
 func MonoticTimeSince(start time.Time) time.Time {
-	// The monotonic clock is used in subtractions hence
-	// the duration since start added back to start gives
-	// end as a monotonic time.
-	// See https://golang.org/pkg/time/#hdr-Monotonic_Clocks
 	return start.Add(time.Now().Sub(start))
 }

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -20,10 +20,13 @@ import "time"
 // requests from the exporters.
 const UserAgent = "opencensus-go-v0.1.0"
 
+// MonotonicEndTime returns the end time at present
+// but offset from start, monotonically.
+//
 // The monotonic clock is used in subtractions hence
 // the duration since start added back to start gives
 // end as a monotonic time.
 // See https://golang.org/pkg/time/#hdr-Monotonic_Clocks
-func MonoticTimeSince(start time.Time) time.Time {
+func MonotonicEndTime(start time.Time) time.Time {
 	return start.Add(time.Now().Sub(start))
 }

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -228,7 +228,7 @@ func (s *Span) End() {
 	s.exportOnce.Do(func() {
 		// TODO: optimize to avoid this call if sd won't be used.
 		sd := s.makeSpanData()
-		sd.EndTime = sd.StartTime.Add(time.Since(sd.StartTime))
+		sd.EndTime = internal.MonotonicTimeSince(sd.StartTime)
 		if s.spanStore != nil {
 			s.spanStore.finished(s, sd)
 		}

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -228,7 +228,7 @@ func (s *Span) End() {
 	s.exportOnce.Do(func() {
 		// TODO: optimize to avoid this call if sd won't be used.
 		sd := s.makeSpanData()
-		sd.EndTime = internal.MonotonicTimeSince(sd.StartTime)
+		sd.EndTime = internal.MonotonicEndTime(sd.StartTime)
 		if s.spanStore != nil {
 			s.spanStore.finished(s, sd)
 		}


### PR DESCRIPTION
Fixes #506

We added a monotonic time calculation but without
much context as to why, so by just looking at the code
the calculation seemed unnecessary but after a few
discussions and godoc readings, calculation of time
using the monotonic clock is achievable by subtractions
hence the startTime.Add(time.Now(startTime).
Extract that code into an internal helper for clarity
and since we'll be re-using that code later on, such as
for #508