### PR TITLE
Add instructions to the gRPC and net/http examples

### DIFF
--- a/examples/grpc/README.md
+++ b/examples/grpc/README.md
@@ -1,0 +1,31 @@
+# Example gRPC server and client with OpenCensus
+
+This example uses:
+
+* gRPC to create an RPC server and client.
+* The OpenCensus gRPC plugin to instrument the RPC server and client.
+* Debugging exporters to print stats and traces to stdout.
+
+```
+$ go get go.opencensus.io/examples/grpc
+```
+
+First, run the server:
+
+```
+$ go run $(go env GOPATH)/src/go.opencensus.io/examples/grpc/helloworld_server/main.go
+```
+
+Then, run the client:
+
+```
+$ go run $(go env GOPATH)/src/go.opencensus.io/examples/grpc/helloworld_client/main.go
+```
+
+You will see traces and stats exported on the stdout. You can use one of the
+[exporters](https://godoc.org/go.opencensus.io/exporter)
+to upload collected data to the backend of your choice.
+
+You can also see the z-pages provided from the server:
+* Traces: http://localhost:8081/tracez
+* RPCs: http://localhost:8081/rpcz

--- a/examples/grpc/helloworld_client/main.go
+++ b/examples/grpc/helloworld_client/main.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"log"
-	"net/http"
 	"os"
 	"time"
 
@@ -24,7 +23,6 @@ import (
 	pb "go.opencensus.io/examples/grpc/proto"
 	"go.opencensus.io/plugin/ocgrpc"
 	"go.opencensus.io/stats/view"
-	"go.opencensus.io/zpages"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
@@ -35,8 +33,6 @@ const (
 )
 
 func main() {
-	go func() { log.Fatal(http.ListenAndServe(":8080", zpages.Handler)) }()
-
 	// Register stats and trace exporters to export
 	// the collected data.
 	view.RegisterExporter(&exporter.Exporter{})

--- a/examples/http/README.md
+++ b/examples/http/README.md
@@ -1,0 +1,31 @@
+# Example net/http server and client with OpenCensus
+
+This example uses:
+
+* net/http to create a server and client.
+* The OpenCensus net/http plugin to instrument the server and client.
+* Debugging exporters to print stats and traces to stdout.
+
+```
+$ go get go.opencensus.io/examples/http
+```
+
+First, run the server:
+
+```
+$ go run $(go env GOPATH)/src/go.opencensus.io/examples/http/helloworld_server/main.go
+```
+
+Then, run the client:
+
+```
+$ go run $(go env GOPATH)/src/go.opencensus.io/examples/http/helloworld_client/main.go
+```
+
+You will see traces and stats exported on the stdout. You can use one of the
+[exporters](https://godoc.org/go.opencensus.io/exporter)
+to upload collected data to the backend of your choice.
+
+You can also see the z-pages provided from the server:
+* Traces: http://localhost:8081/tracez
+* RPCs: http://localhost:8081/rpcz

--- a/examples/http/helloworld_client/main.go
+++ b/examples/http/helloworld_client/main.go
@@ -24,14 +24,11 @@ import (
 
 	"go.opencensus.io/examples/exporter"
 	"go.opencensus.io/stats/view"
-	"go.opencensus.io/zpages"
 )
 
 const server = "http://localhost:50030"
 
 func main() {
-	go func() { log.Fatal(http.ListenAndServe(":9979", zpages.Handler)) }()
-
 	// Register stats and trace exporters to export the collected data.
 	exporter := &exporter.Exporter{}
 	view.RegisterExporter(exporter)

--- a/examples/http/helloworld_server/main.go
+++ b/examples/http/helloworld_server/main.go
@@ -29,7 +29,7 @@ import (
 )
 
 func main() {
-	go func() { log.Fatal(http.ListenAndServe(":9979", zpages.Handler)) }()
+	go func() { log.Fatal(http.ListenAndServe(":8081", zpages.Handler)) }()
 
 	// Register stats and trace exporters to export the collected data.
 	exporter := &exporter.Exporter{}


### PR DESCRIPTION
Also remove the z-pages from the clients, it is
more likely to install them on a server.