### PR TITLE
Don't force download all dependencies

### DIFF
--- a/internal/readme/source.md
+++ b/internal/readme/source.md
@@ -16,7 +16,7 @@ rapidly, vendoring is recommended.
 ## Installation
 
 ```
-$ go get -u go.opencensus.io/...
+$ go get -u go.opencensus.io
 ```
 
 ## Prerequisites


### PR DESCRIPTION
With https://github.com/census-instrumentation/opencensus-go/pull/85,
it became possible to go get the package without `...`.

Without the `...`, the dependencies is not going to be downloaded.