### PR TITLE
Hide Measurement fields.

### DIFF
--- a/stats/measure.go
+++ b/stats/measure.go
@@ -43,7 +43,6 @@ type measure struct {
 	name        string
 	description string
 	unit        string
-	views       int32
 }
 
 // Name returns the name of the measure.
@@ -69,6 +68,7 @@ var (
 	errMeasureNameTooLong = fmt.Errorf("measure name cannot be longer than %v", internal.MaxNameLength)
 )
 
+// FindMeasure finds the Measure instance, if any, associated with the given name.
 func FindMeasure(name string) Measure {
 	mu.RLock()
 	m := measures[name]
@@ -91,8 +91,18 @@ func register(m Measure) (Measure, error) {
 // provides methods to create measurements of their kind. For example, Int64Measure
 // provides M to convert an int64 into a measurement.
 type Measurement struct {
-	Value   float64
-	Measure Measure
+	v float64
+	m Measure
+}
+
+// Value returns the value of the Measurement as a float64.
+func (m Measurement) Value() float64 {
+	return m.v
+}
+
+// Measure returns the Measure from which this Measurement was created.
+func (m Measurement) Measure() Measure {
+	return m.m
 }
 
 func checkName(name string) error {

--- a/stats/measure_float64.go
+++ b/stats/measure_float64.go
@@ -23,7 +23,7 @@ type Float64Measure struct {
 // M creates a new float64 measurement.
 // Use Record to record measurements.
 func (m *Float64Measure) M(v float64) Measurement {
-	return Measurement{Measure: m, Value: v}
+	return Measurement{m: m, v: v}
 }
 
 // Float64 creates a new measure of type Float64Measure. It returns

--- a/stats/measure_int64.go
+++ b/stats/measure_int64.go
@@ -23,7 +23,7 @@ type Int64Measure struct {
 // M creates a new int64 measurement.
 // Use Record to record measurements.
 func (m *Int64Measure) M(v int64) Measurement {
-	return Measurement{Measure: m, Value: float64(v)}
+	return Measurement{m: m, v: float64(v)}
 }
 
 // Int64 creates a new measure of type Int64Measure. It returns an

--- a/stats/measure_test.go
+++ b/stats/measure_test.go
@@ -26,6 +26,11 @@ func TestCheckMeasureName(t *testing.T) {
 			view:    "my.org/measures/\007",
 			wantErr: true,
 		},
+		{
+			name:    "no emoji for you!",
+			view:    "💩",
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/stats/record.go
+++ b/stats/record.go
@@ -24,20 +24,8 @@ import (
 
 // Record records one or multiple measurements with the same tags at once.
 // If there are any tags in the context, measurements will be tagged with them.
-//
-// Record returns fast and recorded measurements will have little overhead
-// if there are no views assicaiated with them.
 func Record(ctx context.Context, ms ...Measurement) {
 	if internal.DefaultRecorder != nil {
-		var record bool
-		for _, m := range ms {
-			if m.Measure != nil {
-				record = true
-			}
-		}
-		if !record {
-			return
-		}
 		internal.DefaultRecorder(tag.FromContext(ctx), ms)
 	}
 }

--- a/stats/view/worker_commands.go
+++ b/stats/view/worker_commands.go
@@ -135,9 +135,9 @@ type recordReq struct {
 
 func (cmd *recordReq) handleCommand(w *worker) {
 	for _, m := range cmd.ms {
-		ref := w.getMeasureRef(m.Measure.Name())
+		ref := w.getMeasureRef(m.Measure().Name())
 		for v := range ref.views {
-			v.addSample(cmd.tm, m.Value)
+			v.addSample(cmd.tm, m.Value())
 		}
 	}
 }


### PR DESCRIPTION
We don't want to expose Measurement fields or allow direct construction
of Measurement instances because we want to keep open the possibility
of adding new Measurement representations and also encourage users to
use the .M() method.

Also saw that we make some performance promises about Measure that are
not really true. Looks like there was the beginnings of an implementation
of the fast path for skipping recording but it was never fully hooked
up.