### PR TITLE
DistributionAggregation([]float64{...}) to DistributionAggregation{}

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ rapidly, vendoring is recommended.
 ## Installation
 
 ```
-$ go get -u go.opencensus.io/...
+$ go get -u go.opencensus.io
 ```
 
 ## Prerequisites
@@ -147,7 +147,7 @@ Currently four types of aggregations are supported:
 
 [embedmd]:# (stats.go aggs)
 ```go
-distAgg := view.DistributionAggregation([]float64{0, 1 << 32, 2 << 32, 3 << 32})
+distAgg := view.DistributionAggregation{0, 1 << 32, 2 << 32, 3 << 32}
 countAgg := view.CountAggregation{}
 sumAgg := view.SumAggregation{}
 meanAgg := view.MeanAggregation{}
@@ -163,10 +163,10 @@ err = view.Subscribe(&view.View{
 	Name:        "my.org/video_size_distribution",
 	Description: "distribution of processed video size over time",
 	Measure:     videoSize,
-	Aggregation: view.DistributionAggregation([]float64{0, 1 << 32, 2 << 32, 3 << 32}),
+	Aggregation: view.DistributionAggregation{0, 1 << 32, 2 << 32, 3 << 32},
 })
 if err != nil {
-	log.Fatal(err)
+	log.Fatalf("Failed to subscribe to view: %v", err)
 }
 ```
 

--- a/examples/helloworld/main.go
+++ b/examples/helloworld/main.go
@@ -66,7 +66,7 @@ func main() {
 		Description: "processed video size over time",
 		TagKeys:     []tag.Key{frontendKey},
 		Measure:     videoSize,
-		Aggregation: view.DistributionAggregation([]float64{0, 1 << 16, 1 << 32}),
+		Aggregation: view.DistributionAggregation{0, 1 << 16, 1 << 32},
 	})
 	if err != nil {
 		log.Fatalf("Cannot subscribe to the view: %v", err)

--- a/examples/stats/prometheus/main.go
+++ b/examples/stats/prometheus/main.go
@@ -63,7 +63,7 @@ func main() {
 			Name:        "video_size",
 			Description: "processed video size over time",
 			Measure:     videoSize,
-			Aggregation: view.DistributionAggregation([]float64{0, 1 << 16, 1 << 32}),
+			Aggregation: view.DistributionAggregation{0, 1 << 16, 1 << 32},
 		},
 	)
 	if err != nil {

--- a/examples/stats/stackdriver/main.go
+++ b/examples/stats/stackdriver/main.go
@@ -66,7 +66,7 @@ func main() {
 		Name:        "my.org/views/video_size_cum",
 		Description: "processed video size over time",
 		Measure:     videoSize,
-		Aggregation: view.DistributionAggregation([]float64{0, 1 << 16, 1 << 32}),
+		Aggregation: view.DistributionAggregation{0, 1 << 16, 1 << 32},
 	})
 	if err != nil {
 		log.Fatalf("Cannot subscribe to the view: %v", err)

--- a/exporter/stackdriver/stats_test.go
+++ b/exporter/stackdriver/stats_test.go
@@ -94,7 +94,7 @@ func TestExporter_makeReq(t *testing.T) {
 		Name:        "distview",
 		Description: "desc",
 		Measure:     m,
-		Aggregation: view.DistributionAggregation([]float64{2, 4, 7}),
+		Aggregation: view.DistributionAggregation{2, 4, 7},
 	}
 
 	start := time.Now()

--- a/internal/readme/stats.go
+++ b/internal/readme/stats.go
@@ -48,7 +48,7 @@ func statsExamples() {
 	_ = m
 
 	// START aggs
-	distAgg := view.DistributionAggregation([]float64{0, 1 << 32, 2 << 32, 3 << 32})
+	distAgg := view.DistributionAggregation{0, 1 << 32, 2 << 32, 3 << 32}
 	countAgg := view.CountAggregation{}
 	sumAgg := view.SumAggregation{}
 	meanAgg := view.MeanAggregation{}
@@ -61,7 +61,7 @@ func statsExamples() {
 		Name:        "my.org/video_size_distribution",
 		Description: "distribution of processed video size over time",
 		Measure:     videoSize,
-		Aggregation: view.DistributionAggregation([]float64{0, 1 << 32, 2 << 32, 3 << 32}),
+		Aggregation: view.DistributionAggregation{0, 1 << 32, 2 << 32, 3 << 32},
 	})
 	if err != nil {
 		log.Fatalf("Failed to subscribe to view: %v", err)

--- a/plugin/ocgrpc/stats_common.go
+++ b/plugin/ocgrpc/stats_common.go
@@ -39,9 +39,9 @@ type rpcData struct {
 // The following variables define the default hard-coded auxiliary data used by
 // both the default GRPC client and GRPC server metrics.
 var (
-	DefaultBytesDistribution        = view.DistributionAggregation([]float64{0, 1024, 2048, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864, 268435456, 1073741824, 4294967296})
-	DefaultMillisecondsDistribution = view.DistributionAggregation([]float64{0, 1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 25, 30, 40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400, 500, 650, 800, 1000, 2000, 5000, 10000, 20000, 50000, 100000})
-	DefaultMessageCountDistribution = view.DistributionAggregation([]float64{0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536})
+	DefaultBytesDistribution        = view.DistributionAggregation{0, 1024, 2048, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864, 268435456, 1073741824, 4294967296}
+	DefaultMillisecondsDistribution = view.DistributionAggregation{0, 1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 25, 30, 40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400, 500, 650, 800, 1000, 2000, 5000, 10000, 20000, 50000, 100000}
+	DefaultMessageCountDistribution = view.DistributionAggregation{0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536}
 )
 
 var (

--- a/plugin/ochttp/stats.go
+++ b/plugin/ochttp/stats.go
@@ -55,8 +55,8 @@ var (
 )
 
 var (
-	DefaultSizeDistribution    = view.DistributionAggregation([]float64{0, 1024, 2048, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864, 268435456, 1073741824, 4294967296})
-	DefaultLatencyDistribution = view.DistributionAggregation([]float64{0, 1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 25, 30, 40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400, 500, 650, 800, 1000, 2000, 5000, 10000, 20000, 50000, 100000})
+	DefaultSizeDistribution    = view.DistributionAggregation{0, 1024, 2048, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864, 268435456, 1073741824, 4294967296}
+	DefaultLatencyDistribution = view.DistributionAggregation{0, 1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 25, 30, 40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400, 500, 650, 800, 1000, 2000, 5000, 10000, 20000, 50000, 100000}
 )
 
 // Package ochttp provides some convenience views.

--- a/stats/view/example_test.go
+++ b/stats/view/example_test.go
@@ -28,7 +28,7 @@ func Example() {
 		Name:        "my.org/views/openconns",
 		Description: "open connections",
 		Measure:     m,
-		Aggregation: view.DistributionAggregation([]float64{0, 1000, 2000}),
+		Aggregation: view.DistributionAggregation{0, 1000, 2000},
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/stats/view/view_test.go
+++ b/stats/view/view_test.go
@@ -27,7 +27,7 @@ func Test_View_MeasureFloat64_AggregationDistribution(t *testing.T) {
 	k1, _ := tag.NewKey("k1")
 	k2, _ := tag.NewKey("k2")
 	k3, _ := tag.NewKey("k3")
-	agg1 := DistributionAggregation([]float64{2})
+	agg1 := DistributionAggregation{2}
 	m, _ := stats.Int64("Test_View_MeasureFloat64_AggregationDistribution/m1", "", stats.UnitNone)
 	view1 := &View{
 		TagKeys:     []tag.Key{k1, k2},


### PR DESCRIPTION
DistributionAggregation's type declaration is
type DistributionAggregation []float64
therefore float64 values can be added to it directly
e.g:
  DistributionAggregation{0, 10, 25.3}