### PR TITLE
Clean up ocgrpc: remove NewXXXStatsHandler methods

### DIFF
--- a/examples/grpc/helloworld_client/main.go
+++ b/examples/grpc/helloworld_client/main.go
@@ -44,7 +44,7 @@ func main() {
 
 	// Set up a connection to the server with the OpenCensus
 	// stats handler to enable stats and tracing.
-	conn, err := grpc.Dial(address, grpc.WithStatsHandler(ocgrpc.NewClientStatsHandler()), grpc.WithInsecure())
+	conn, err := grpc.Dial(address, grpc.WithStatsHandler(&ocgrpc.ClientHandler{}), grpc.WithInsecure())
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)
 	}

--- a/examples/grpc/helloworld_server/main.go
+++ b/examples/grpc/helloworld_server/main.go
@@ -59,7 +59,7 @@ func main() {
 
 	// Set up a new server with the OpenCensus
 	// stats handler to enable stats and tracing.
-	s := grpc.NewServer(grpc.StatsHandler(ocgrpc.NewServerStatsHandler()))
+	s := grpc.NewServer(grpc.StatsHandler(&ocgrpc.ServerHandler{}))
 	pb.RegisterGreeterServer(s, &server{})
 	// Register reflection service on gRPC server.
 	reflection.Register(s)

--- a/plugin/ocgrpc/client.go
+++ b/plugin/ocgrpc/client.go
@@ -20,12 +20,6 @@ import (
 	"google.golang.org/grpc/stats"
 )
 
-// NewClientStatsHandler enables OpenCensus stats and trace
-// for gRPC clients. Deprecated, construct a ClientHandler directly.
-func NewClientStatsHandler() stats.Handler {
-	return &ClientHandler{}
-}
-
 // ClientHandler implements a gRPC stats.Handler for recording OpenCensus stats and
 // traces. Use with gRPC clients only.
 type ClientHandler struct {

--- a/plugin/ocgrpc/grpc_test.go
+++ b/plugin/ocgrpc/grpc_test.go
@@ -26,11 +26,8 @@ import (
 	"google.golang.org/grpc/stats"
 )
 
-func TestNewClientStatsHandler(t *testing.T) {
+func TestClientHandler(t *testing.T) {
 	ctx := context.Background()
-
-	handler := NewClientStatsHandler()
-
 	te := &traceExporter{}
 	trace.RegisterExporter(te)
 	if err := ClientRequestCountView.Subscribe(); err != nil {
@@ -42,6 +39,7 @@ func TestNewClientStatsHandler(t *testing.T) {
 	})
 	ctx = trace.WithSpan(ctx, span)
 
+	var handler ClientHandler
 	ctx = handler.TagRPC(ctx, &stats.RPCTagInfo{
 		FullMethodName: "/service.foo/method",
 	})
@@ -71,21 +69,21 @@ func TestNewClientStatsHandler(t *testing.T) {
 	view.Unsubscribe(ClientErrorCountView)
 }
 
-func TestNewServerStatsHandler(t *testing.T) {
+func TestServerHandler(t *testing.T) {
 	ctx := context.Background()
-
-	handler := NewServerStatsHandler()
-
 	te := &traceExporter{}
 	trace.RegisterExporter(te)
 	if err := ServerRequestCountView.Subscribe(); err != nil {
 		t.Fatal(err)
 	}
 
+	// Ensure we start tracing.
 	span := trace.NewSpan("/foo", nil, trace.StartOptions{
 		Sampler: trace.AlwaysSample(),
 	})
 	ctx = trace.WithSpan(ctx, span)
+
+	handler := &ServerHandler{}
 	ctx = handler.TagRPC(ctx, &stats.RPCTagInfo{
 		FullMethodName: "/service.foo/method",
 	})

--- a/plugin/ocgrpc/server.go
+++ b/plugin/ocgrpc/server.go
@@ -20,12 +20,6 @@ import (
 	"google.golang.org/grpc/stats"
 )
 
-// NewServerStatsHandler enables OpenCensus stats and trace
-// for gRPC servers. Deprecated, construct a ServerHandler directly.
-func NewServerStatsHandler() stats.Handler {
-	return &ServerHandler{}
-}
-
 // ServerHandler implements gRPC stats.Handler recording OpenCensus stats and
 // traces. Use with gRPC servers.
 type ServerHandler struct {


### PR DESCRIPTION
Since we provide options on the ClientHandler and ServerHandler structs
and the NewXXX methods were trivial, it is better to have users use a
struct literal.