### PR TITLE
Begin moving Google Cloud Trace format to the stackdriver package

### DIFF
--- a/exporter/stackdriver/example_test.go
+++ b/exporter/stackdriver/example_test.go
@@ -19,8 +19,8 @@ import (
 	"net/http"
 
 	"go.opencensus.io/exporter/stackdriver"
+	"go.opencensus.io/exporter/stackdriver/propagation"
 	"go.opencensus.io/plugin/ochttp"
-	"go.opencensus.io/plugin/ochttp/propagation/google"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/trace"
 )
@@ -42,7 +42,7 @@ func Example() {
 	// Automatically add a Stackdriver trace header to outgoing requests:
 	client := &http.Client{
 		Transport: &ochttp.Transport{
-			Propagation: &google.HTTPFormat{},
+			Propagation: &propagation.HTTPFormat{},
 		},
 	}
 	_ = client // use client

--- a/exporter/stackdriver/propagation/http.go
+++ b/exporter/stackdriver/propagation/http.go
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package google is deprecated: Use go.opencensus.io/exporter/stackdriver/propagation.
-package google // import "go.opencensus.io/plugin/ochttp/propagation/google"
+// Package propagation implement X-Cloud-Trace-Context header propagation used
+// by Google Cloud products.
+package propagation // import "go.opencensus.io/exporter/stackdriver/propagation"
 
 import (
 	"encoding/binary"
@@ -24,6 +25,7 @@ import (
 	"strings"
 
 	"go.opencensus.io/trace"
+	"go.opencensus.io/trace/propagation"
 )
 
 const (
@@ -31,13 +33,16 @@ const (
 	httpHeader        = `X-Cloud-Trace-Context`
 )
 
-// Deprecated: Use go.opencensus.io/exporter/stackdriver/propagation.HTTPFormat
+var _ propagation.HTTPFormat = (*HTTPFormat)(nil)
+
+// HTTPFormat implements propagation.HTTPFormat to propagate
+// traces in HTTP headers for Google Cloud Platform and Stackdriver Trace.
 type HTTPFormat struct{}
 
 // SpanContextFromRequest extracts a Stackdriver Trace span context from incoming requests.
 func (f *HTTPFormat) SpanContextFromRequest(req *http.Request) (sc trace.SpanContext, ok bool) {
 	h := req.Header.Get(httpHeader)
-	// See https://cloud.google.com/trace/docs/faq for the header format.
+	// See https://cloud.google.com/trace/docs/faq for the header HTTPFormat.
 	// Return if the header is empty or missing, or if the header is unreasonably
 	// large, to avoid making unnecessary copies of a large string.
 	if h == "" || len(h) > httpHeaderMaxSize {

--- a/exporter/stackdriver/propagation/http_test.go
+++ b/exporter/stackdriver/propagation/http_test.go
@@ -1,0 +1,70 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package propagation
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+
+	"go.opencensus.io/trace"
+)
+
+func TestHTTPFormat(t *testing.T) {
+	format := &HTTPFormat{}
+	traceID := [16]byte{16, 84, 69, 170, 120, 67, 188, 139, 242, 6, 177, 32, 0, 16, 0, 0}
+	spanID1 := [8]byte{255, 0, 0, 0, 0, 0, 0, 123}
+	spanID2 := [8]byte{0, 0, 0, 0, 0, 0, 0, 123}
+	tests := []struct {
+		incoming        string
+		wantSpanContext trace.SpanContext
+	}{
+		{
+			incoming: "105445aa7843bc8bf206b12000100000/18374686479671623803;o=1",
+			wantSpanContext: trace.SpanContext{
+				TraceID:      traceID,
+				SpanID:       spanID1,
+				TraceOptions: 1,
+			},
+		},
+		{
+			incoming: "105445aa7843bc8bf206b12000100000/123;o=0",
+			wantSpanContext: trace.SpanContext{
+				TraceID:      traceID,
+				SpanID:       spanID2,
+				TraceOptions: 0,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.incoming, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", "http://example.com", nil)
+			req.Header.Add(httpHeader, tt.incoming)
+			sc, ok := format.SpanContextFromRequest(req)
+			if !ok {
+				t.Errorf("exporter.SpanContextFromRequest() = false; want true")
+			}
+			if got, want := sc, tt.wantSpanContext; !reflect.DeepEqual(got, want) {
+				t.Errorf("exporter.SpanContextFromRequest() returned span context %v; want %v", got, want)
+			}
+
+			req, _ = http.NewRequest("GET", "http://example.com", nil)
+			format.SpanContextToRequest(sc, req)
+			if got, want := req.Header.Get(httpHeader), tt.incoming; got != want {
+				t.Errorf("exporter.SpanContextToRequest() returned header %q; want %q", got, want)
+			}
+		})
+	}
+}

--- a/exporter/stackdriver/trace.go
+++ b/exporter/stackdriver/trace.go
@@ -30,8 +30,6 @@ import (
 // traceExporter is an implementation of trace.Exporter that uploads spans to
 // Stackdriver.
 //
-// traceExporter also implements trace/propagation.HTTPFormat and can
-// propagate Stackdriver Traces over HTTP requests.
 type traceExporter struct {
 	projectID string
 	bundler   *bundler.Bundler

--- a/plugin/ochttp/example_test.go
+++ b/plugin/ochttp/example_test.go
@@ -19,7 +19,7 @@ import (
 	"net/http"
 
 	"go.opencensus.io/plugin/ochttp"
-	"go.opencensus.io/plugin/ochttp/propagation/google"
+	"go.opencensus.io/plugin/ochttp/propagation/b3"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 )
@@ -63,6 +63,6 @@ func ExampleHandler_mux() {
 
 	log.Fatal(http.ListenAndServe("localhost:8080", &ochttp.Handler{
 		Handler:     mux,
-		Propagation: &google.HTTPFormat{}, // Uses Google's propagation format.
+		Propagation: &b3.HTTPFormat{},
 	}))
 }

--- a/plugin/ochttp/propagation_test.go
+++ b/plugin/ochttp/propagation_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 
 	"go.opencensus.io/plugin/ochttp/propagation/b3"
-	"go.opencensus.io/plugin/ochttp/propagation/google"
+	"go.opencensus.io/plugin/ochttp/propagation/tracecontext"
 	"go.opencensus.io/trace"
 	"go.opencensus.io/trace/propagation"
 )
@@ -32,7 +32,7 @@ func TestRoundTripAllFormats(t *testing.T) {
 	// TODO: test combinations of different formats for chains of calls
 	formats := []propagation.HTTPFormat{
 		&b3.HTTPFormat{},
-		&google.HTTPFormat{},
+		&tracecontext.HTTPFormat{},
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
Left the old package in place because it is used externally. We will
need to remove it in the next round of cleanups.