### PR TITLE
Avoid creating spans around Stackdriver submit

### DIFF
--- a/exporter/stackdriver/stackdriver_test.go
+++ b/exporter/stackdriver/stackdriver_test.go
@@ -76,4 +76,8 @@ func TestExport(t *testing.T) {
 	if want, got := "Hello, world!", string(body); want != got {
 		t.Fatalf("resp.Body = %q; want %q", want, got)
 	}
+
+	// Flush twice to expose issue of exporter creating traces internally (#557)
+	exporter.Flush()
+	exporter.Flush()
 }


### PR DESCRIPTION
The Stackdriver exporter uses a gRPC client that's instrumented with
OpenCensus. This means that there's normally a chance that traces will
be started from the span submission method. In the worst case, with
AlwaysSample, this adds an unbounded number of useless Spans.

This PR follows @bogdandrutu's advice and wraps the upload method in
a Span with NeverSample.

Fixes: #557