### PR TITLE
Improve verbosity when creating trace attribute

### DIFF
--- a/exporter/stackdriver/trace.go
+++ b/exporter/stackdriver/trace.go
@@ -114,15 +114,16 @@ func (e *traceExporter) uploadSpans(spans []*trace.SpanData) {
 	for _, span := range spans {
 		req.Spans = append(req.Spans, protoFromSpanData(span, e.projectID))
 	}
-	// create a never-sampled span to prevent traces associated with exporter
+	// Create a never-sampled span to prevent traces associated with exporter.
 	span := trace.NewSpan("go.opencensus.io/exporter/stackdriver.uploadSpans", nil, trace.StartOptions{Sampler: trace.NeverSample()})
 	defer span.End()
-	span.SetAttributes(trace.Int64Attribute{Key: "num_spans", Value: int64(len(spans))})
+	span.SetAttributes(trace.Int64Attribute("num_spans", int64(len(spans))))
+
 	ctx := trace.WithSpan(context.Background(), span) // TODO: add timeouts
 	err := e.client.BatchWriteSpans(ctx, &req)
 	if err != nil {
 		span.SetStatus(trace.Status{Code: 2, Message: err.Error()})
-		//TODO: allow configuring a logger for exporters
+		// TODO: Allow configuring a logger for exporters.
 		log.Printf("OpenCensus Stackdriver exporter: failed to upload %d spans: %v", len(spans), err)
 	}
 }

--- a/exporter/stackdriver/trace_proto_test.go
+++ b/exporter/stackdriver/trace_proto_test.go
@@ -78,9 +78,9 @@ func TestExportTrace(t *testing.T) {
 			span2.Annotatef(nil, "in span%d", 2)
 			span2.Annotate(nil, big.NewRat(2, 4).String())
 			span2.SetAttributes(
-				trace.StringAttribute{Key: "key1", Value: "value1"},
-				trace.StringAttribute{Key: "key2", Value: "value2"})
-			span2.SetAttributes(trace.Int64Attribute{Key: "key1", Value: 100})
+				trace.StringAttribute("key1", "value1"),
+				trace.StringAttribute("key2", "value2"))
+			span2.SetAttributes(trace.Int64Attribute("key1", 100))
 			span2.End()
 		}
 		{
@@ -92,9 +92,9 @@ func TestExportTrace(t *testing.T) {
 			{
 				_, span4 := trace.StartSpan(ctx3, "span4")
 				x := 42
-				a1 := []trace.Attribute{trace.StringAttribute{Key: "k1", Value: "v1"}}
-				a2 := []trace.Attribute{trace.StringAttribute{Key: "k2", Value: "v2"}}
-				a3 := []trace.Attribute{trace.StringAttribute{Key: "k3", Value: "v3"}}
+				a1 := []trace.Attribute{trace.StringAttribute("k1", "v1")}
+				a2 := []trace.Attribute{trace.StringAttribute("k2", "v2")}
+				a3 := []trace.Attribute{trace.StringAttribute("k3", "v3")}
 				a4 := map[string]interface{}{"k4": "v4"}
 				r := big.NewRat(2, 4)
 				span4.Annotate(a1, r.String())

--- a/plugin/ocgrpc/trace_common.go
+++ b/plugin/ocgrpc/trace_common.go
@@ -79,8 +79,8 @@ func handleRPC(ctx context.Context, rs stats.RPCStats) {
 	switch rs := rs.(type) {
 	case *stats.Begin:
 		span.SetAttributes(
-			trace.BoolAttribute{Key: "Client", Value: rs.Client},
-			trace.BoolAttribute{Key: "FailFast", Value: rs.FailFast})
+			trace.BoolAttribute("Client", rs.Client),
+			trace.BoolAttribute("FailFast", rs.FailFast))
 	case *stats.InPayload:
 		span.AddMessageReceiveEvent(0 /* TODO: messageID */, int64(rs.Length), int64(rs.WireLength))
 	case *stats.OutPayload:

--- a/plugin/ochttp/trace.go
+++ b/plugin/ochttp/trace.go
@@ -146,15 +146,15 @@ func spanNameFromURL(prefix string, u *url.URL) string {
 
 func requestAttrs(r *http.Request) []trace.Attribute {
 	return []trace.Attribute{
-		trace.StringAttribute{Key: PathAttribute, Value: r.URL.Path},
-		trace.StringAttribute{Key: HostAttribute, Value: r.URL.Host},
-		trace.StringAttribute{Key: MethodAttribute, Value: r.Method},
-		trace.StringAttribute{Key: UserAgentAttribute, Value: r.UserAgent()},
+		trace.StringAttribute(PathAttribute, r.URL.Path),
+		trace.StringAttribute(HostAttribute, r.URL.Host),
+		trace.StringAttribute(MethodAttribute, r.Method),
+		trace.StringAttribute(UserAgentAttribute, r.UserAgent()),
 	}
 }
 
 func responseAttrs(resp *http.Response) []trace.Attribute {
 	return []trace.Attribute{
-		trace.Int64Attribute{Key: StatusCodeAttribute, Value: int64(resp.StatusCode)},
+		trace.Int64Attribute(StatusCodeAttribute, int64(resp.StatusCode)),
 	}
 }

--- a/plugin/ochttp/trace_test.go
+++ b/plugin/ochttp/trace_test.go
@@ -347,10 +347,10 @@ func TestRequestAttributes(t *testing.T) {
 				return req
 			},
 			wantAttrs: []trace.Attribute{
-				trace.StringAttribute{Key: "http.path", Value: "/hello"},
-				trace.StringAttribute{Key: "http.host", Value: "example.com"},
-				trace.StringAttribute{Key: "http.method", Value: "GET"},
-				trace.StringAttribute{Key: "http.user_agent", Value: "ua"},
+				trace.StringAttribute("http.path", "/hello"),
+				trace.StringAttribute("http.host", "example.com"),
+				trace.StringAttribute("http.method", "GET"),
+				trace.StringAttribute("http.user_agent", "ua"),
 			},
 		},
 	}
@@ -376,14 +376,14 @@ func TestResponseAttributes(t *testing.T) {
 			name: "non-zero HTTP 200 response",
 			resp: &http.Response{StatusCode: 200},
 			wantAttrs: []trace.Attribute{
-				trace.Int64Attribute{Key: "http.status_code", Value: 200},
+				trace.Int64Attribute("http.status_code", 200),
 			},
 		},
 		{
 			name: "zero HTTP 500 response",
 			resp: &http.Response{StatusCode: 500},
 			wantAttrs: []trace.Attribute{
-				trace.Int64Attribute{Key: "http.status_code", Value: 500},
+				trace.Int64Attribute("http.status_code", 500),
 			},
 		},
 	}

--- a/trace/basetypes.go
+++ b/trace/basetypes.go
@@ -47,29 +47,41 @@ type Attribute interface {
 	isAttribute()
 }
 
-// BoolAttribute represents a bool-valued attribute.
-type BoolAttribute struct {
-	Key   string
-	Value bool
+// BoolAttribute returns a bool-valued attribute.
+func BoolAttribute(key string, value bool) Attribute {
+	return boolAttribute{key: key, value: value}
 }
 
-func (b BoolAttribute) isAttribute() {}
-
-// Int64Attribute represents an int64-valued attribute.
-type Int64Attribute struct {
-	Key   string
-	Value int64
+type boolAttribute struct {
+	key   string
+	value bool
 }
 
-func (i Int64Attribute) isAttribute() {}
+func (b boolAttribute) isAttribute() {}
 
-// StringAttribute represents a string-valued attribute.
-type StringAttribute struct {
-	Key   string
-	Value string
+type int64Attribute struct {
+	key   string
+	value int64
 }
 
-func (s StringAttribute) isAttribute() {}
+func (i int64Attribute) isAttribute() {}
+
+// Int64Attribute returns an int64-valued attribute.
+func Int64Attribute(key string, value int64) Attribute {
+	return int64Attribute{key: key, value: value}
+}
+
+type stringAttribute struct {
+	key   string
+	value string
+}
+
+func (s stringAttribute) isAttribute() {}
+
+// StringAttribute returns a string-valued attribute.
+func StringAttribute(key string, value string) Attribute {
+	return stringAttribute{key: key, value: value}
+}
 
 // LinkType specifies the relationship between the span that had the link
 // added, and the linked span.

--- a/trace/benchmark_test.go
+++ b/trace/benchmark_test.go
@@ -36,9 +36,9 @@ func BenchmarkSpanWithAnnotations_3(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_, span := StartSpan(ctx, "/foo")
 		span.SetAttributes(
-			BoolAttribute{Key: "key1", Value: false},
-			StringAttribute{Key: "key2", Value: "hello"},
-			Int64Attribute{Key: "key3", Value: 123},
+			BoolAttribute("key1", false),
+			StringAttribute("key2", "hello"),
+			Int64Attribute("key3", 123),
 		)
 		span.End()
 	}
@@ -51,12 +51,12 @@ func BenchmarkSpanWithAnnotations_6(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_, span := StartSpan(ctx, "/foo")
 		span.SetAttributes(
-			BoolAttribute{Key: "key1", Value: false},
-			BoolAttribute{Key: "key2", Value: true},
-			StringAttribute{Key: "key3", Value: "hello"},
-			StringAttribute{Key: "key4", Value: "hello"},
-			Int64Attribute{Key: "key5", Value: 123},
-			Int64Attribute{Key: "key6", Value: 456},
+			BoolAttribute("key1", false),
+			BoolAttribute("key2", true),
+			StringAttribute("key3", "hello"),
+			StringAttribute("key4", "hello"),
+			Int64Attribute("key5", 123),
+			Int64Attribute("key6", 456),
 		)
 		span.End()
 	}

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -274,12 +274,12 @@ func (s *Span) SetAttributes(attributes ...Attribute) {
 func copyAttributes(m map[string]interface{}, attributes []Attribute) {
 	for _, a := range attributes {
 		switch a := a.(type) {
-		case BoolAttribute:
-			m[a.Key] = a.Value
-		case Int64Attribute:
-			m[a.Key] = a.Value
-		case StringAttribute:
-			m[a.Key] = a.Value
+		case boolAttribute:
+			m[a.key] = a.value
+		case int64Attribute:
+			m[a.key] = a.value
+		case stringAttribute:
+			m[a.key] = a.value
 		}
 	}
 }

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -297,7 +297,7 @@ func checkTime(x *time.Time) bool {
 
 func TestSetSpanAttributes(t *testing.T) {
 	span := startSpan()
-	span.SetAttributes(StringAttribute{"key1", "value1"})
+	span.SetAttributes(StringAttribute("key1", "value1"))
 	got, err := endSpan(span)
 	if err != nil {
 		t.Fatal(err)
@@ -321,8 +321,8 @@ func TestSetSpanAttributes(t *testing.T) {
 
 func TestAnnotations(t *testing.T) {
 	span := startSpan()
-	span.Annotatef([]Attribute{StringAttribute{"key1", "value1"}}, "%f", 1.5)
-	span.Annotate([]Attribute{StringAttribute{"key2", "value2"}}, "Annotate")
+	span.Annotatef([]Attribute{StringAttribute("key1", "value1")}, "%f", 1.5)
+	span.Annotate([]Attribute{StringAttribute("key2", "value2")}, "Annotate")
 	got, err := endSpan(span)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Provide constructors to create string, int64 and bool attributes
instead of exporting the attribute types.

Attribute is kept as an interface to avoid users creating new
Attributes with invalid value types.

Fixes #550.