### PR TITLE
Add imports for packages known to depend on OpenCensus API

### DIFF
--- a/exporter/stackdriver/stackdriver_test.go
+++ b/exporter/stackdriver/stackdriver_test.go
@@ -27,6 +27,13 @@ import (
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/trace"
 	"golang.org/x/net/context/ctxhttp"
+
+	// Import some other packages known to integrate OpenCensus to check for compilation errors.
+	_ "cloud.google.com/go/datastore"
+	_ "cloud.google.com/go/pubsub"
+	_ "cloud.google.com/go/spanner"
+	_ "google.golang.org/api/transport/grpc"
+	_ "google.golang.org/api/transport/http"
 )
 
 func TestExport(t *testing.T) {


### PR DESCRIPTION
Stackdriver / GCP is an early adopter and even though we don't yet
support stable APIs, we want to try to avoid breaking them. Added
imports for packages we know are using our APIs to the Stackdriver
tests so that "go vet" PR check will pick up any incompatibilities.