### PR TITLE
Don't propagate method and canonical_status for gRPC requests

### DIFF
--- a/plugin/ocgrpc/server_stats_handler_test.go
+++ b/plugin/ocgrpc/server_stats_handler_test.go
@@ -54,6 +54,7 @@ func TestServerDefaultCollections(t *testing.T) {
 		rpcs  []*rpc
 		wants []*wantData
 	}
+
 	tcs := []testCase{
 		{
 			"1",
@@ -296,10 +297,8 @@ func TestServerDefaultCollections(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		for _, v := range DefaultServerViews {
-			if err := v.Subscribe(); err != nil {
-				t.Error(err)
-			}
+		if err := view.Subscribe(DefaultServerViews...); err != nil {
+			t.Fatal(err)
 		}
 
 		h := &ServerHandler{NoTrace: true}


### PR DESCRIPTION
These tags should be created at the node and applied when recording
measurements. They shouldn't be propagated.

Fixes #541.