### PR TITLE
Use HTTP and gRPC guides as the entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,26 +34,28 @@ Currently, OpenCensus supports:
 * [Jaeger][exporter-jaeger] for traces
 * [AWS X-Ray][exporter-xray] for traces
 
+
+## Overview
+
+![OpenCensus Overview](https://i.imgur.com/cf4ElHE.jpg)
+
+In a microservices environment, a user request may go through
+multiple services until there is a response. OpenCensus allows
+you to instrument your services and collect diagnostics data all
+through your services end-to-end.
+
+Start with instrumenting HTTP and gRPC clients and servers,
+then add additional custom instrumentation.
+
+* [HTTP guide](https://github.com/census-instrumentation/opencensus-go/tree/master/examples/http)
+* [gRPC guide](https://github.com/census-instrumentation/opencensus-go/tree/master/examples/grpc)
+
+
 ## Tags
 
 Tags represent propagated key-value pairs. They are propagated using context.Context
 in the same process or can be encoded to be transmitted on the wire and decoded back
 to a tag.Map at the destination.
-
-### Getting a key by a name
-
-A key is defined by its name. To use a key, a user needs to know its name and type.
-
-[embedmd]:# (tags.go stringKey)
-```go
-// Get a key to represent user OS.
-key, err := tag.NewKey("my.org/keys/user-os")
-if err != nil {
-	log.Fatal(err)
-}
-```
-
-### Creating tags and propagating them
 
 Package tag provides a builder to create tag maps and put it
 into the current context.
@@ -63,15 +65,6 @@ If there is already a tag map in the current context, it will be replaced.
 
 [embedmd]:# (tags.go new)
 ```go
-osKey, err := tag.NewKey("my.org/keys/user-os")
-if err != nil {
-	log.Fatal(err)
-}
-userIDKey, err := tag.NewKey("my.org/keys/user-id")
-if err != nil {
-	log.Fatal(err)
-}
-
 ctx, err = tag.New(ctx,
 	tag.Insert(osKey, "macOS-10.12.5"),
 	tag.Upsert(userIDKey, "cde36753ed"),
@@ -81,49 +74,20 @@ if err != nil {
 }
 ```
 
-### Propagating a tag map in a context
-
-If you have access to a tag.Map, you can also
-propagate it in the current context:
-
-[embedmd]:# (tags.go newContext)
-```go
-m := tag.FromContext(ctx)
-```
-
-In order to update existing tags from the current context,
-use New and pass the returned context.
-
-[embedmd]:# (tags.go replaceTagMap)
-```go
-ctx, err = tag.New(ctx,
-	tag.Insert(osKey, "macOS-10.12.5"),
-	tag.Upsert(userIDKey, "fff0989878"),
-)
-if err != nil {
-	log.Fatal(err)
-}
-```
-
-
 ## Stats
 
-### Measures
+OpenCensus is a low-overhead framework even if instrumentation is always enabled.
+In order to be so, it is optimized to make recording of data points fast
+and separate from the data aggregation.
 
-Measures are used for recording data points with associated units.
-Creating a Measure:
+OpenCensus stats collection happens in two stages:
 
-[embedmd]:# (stats.go measure)
-```go
-videoSize, err := stats.Int64("my.org/video_size", "processed video size", "MB")
-if err != nil {
-	log.Fatal(err)
-}
-```
+* Definition of measures and recording of data points
+* Definition of views and aggregation of the recorded data
 
-### Recording Measurements
+### Recording
 
-Measurements are data points associated with Measures.
+Measurements are data points associated with a measure.
 Recording implicitly tags the set of Measurements with the tags from the
 provided context:
 
@@ -135,7 +99,7 @@ stats.Record(ctx, videoSize.M(102478))
 ### Views
 
 Views are how Measures are aggregated. You can think of them as queries over the
-set of recorded data points (Measurements).
+set of recorded data points (measurements).
 
 Views have two parts: the tags to group by and the aggregation type used.
 
@@ -153,9 +117,7 @@ sumAgg := view.SumAggregation{}
 meanAgg := view.MeanAggregation{}
 ```
 
-Here we create a view with the DistributionAggregation over our Measure.
-All Measurements will be aggregated together irrespective of their tags,
-i.e. no grouping by tag.
+Here we create a view with the DistributionAggregation over our measure.
 
 [embedmd]:# (stats.go view)
 ```go
@@ -172,47 +134,13 @@ if err = view.Subscribe(&view.View{
 Subscribe begins collecting data for the view. Subscribed views' data will be
 exported via the registered exporters.
 
-[embedmd]:# (stats.go registerExporter)
-```go
-// Register an exporter to be able to retrieve
-// the data from the subscribed views.
-view.RegisterExporter(&exporter{})
-```
-
-An example logger exporter is below:
-
-[embedmd]:# (stats.go exporter)
-```go
-
-type exporter struct{}
-
-func (e *exporter) ExportView(vd *view.Data) {
-	log.Println(vd)
-}
-
-```
-
-Configure the default interval between reports of collected data.
-This is a system wide interval and impacts all views. The default
-interval duration is 10 seconds.
-
-[embedmd]:# (stats.go reportingPeriod)
-```go
-view.SetReportingPeriod(5 * time.Second)
-```
-
-
 ## Traces
-
-### Starting and ending a span
 
 [embedmd]:# (trace.go startend)
 ```go
 ctx, span := trace.StartSpan(ctx, "your choice of name")
 defer span.End()
 ```
-
-More tracing examples are coming soon...
 
 ## Profiles
 
@@ -238,7 +166,6 @@ tag.Do(ctx, func(ctx context.Context) {
 A screenshot of the CPU profile from the program above:
 
 ![CPU profile](https://i.imgur.com/jBKjlkw.png)
-
 
 [travis-image]: https://travis-ci.org/census-instrumentation/opencensus-go.svg?branch=master
 [travis-url]: https://travis-ci.org/census-instrumentation/opencensus-go

--- a/internal/readme/source.md
+++ b/internal/readme/source.md
@@ -34,19 +34,28 @@ Currently, OpenCensus supports:
 * [Jaeger][exporter-jaeger] for traces
 * [AWS X-Ray][exporter-xray] for traces
 
+
+## Overview
+
+![OpenCensus Overview](https://i.imgur.com/cf4ElHE.jpg)
+
+In a microservices environment, a user request may go through
+multiple services until there is a response. OpenCensus allows
+you to instrument your services and collect diagnostics data all
+through your services end-to-end.
+
+Start with instrumenting HTTP and gRPC clients and servers,
+then add additional custom instrumentation.
+
+* [HTTP guide](https://github.com/census-instrumentation/opencensus-go/tree/master/examples/http)
+* [gRPC guide](https://github.com/census-instrumentation/opencensus-go/tree/master/examples/grpc)
+
+
 ## Tags
 
 Tags represent propagated key-value pairs. They are propagated using context.Context
 in the same process or can be encoded to be transmitted on the wire and decoded back
 to a tag.Map at the destination.
-
-### Getting a key by a name
-
-A key is defined by its name. To use a key, a user needs to know its name and type.
-
-[embedmd]:# (tags.go stringKey)
-
-### Creating tags and propagating them
 
 Package tag provides a builder to create tag maps and put it
 into the current context.
@@ -56,31 +65,20 @@ If there is already a tag map in the current context, it will be replaced.
 
 [embedmd]:# (tags.go new)
 
-### Propagating a tag map in a context
-
-If you have access to a tag.Map, you can also
-propagate it in the current context:
-
-[embedmd]:# (tags.go newContext)
-
-In order to update existing tags from the current context,
-use New and pass the returned context.
-
-[embedmd]:# (tags.go replaceTagMap)
-
-
 ## Stats
 
-### Measures
+OpenCensus is a low-overhead framework even if instrumentation is always enabled.
+In order to be so, it is optimized to make recording of data points fast
+and separate from the data aggregation.
 
-Measures are used for recording data points with associated units.
-Creating a Measure:
+OpenCensus stats collection happens in two stages:
 
-[embedmd]:# (stats.go measure)
+* Definition of measures and recording of data points
+* Definition of views and aggregation of the recorded data
 
-### Recording Measurements
+### Recording
 
-Measurements are data points associated with Measures.
+Measurements are data points associated with a measure.
 Recording implicitly tags the set of Measurements with the tags from the
 provided context:
 
@@ -89,7 +87,7 @@ provided context:
 ### Views
 
 Views are how Measures are aggregated. You can think of them as queries over the
-set of recorded data points (Measurements).
+set of recorded data points (measurements).
 
 Views have two parts: the tags to group by and the aggregation type used.
 
@@ -101,35 +99,16 @@ Currently four types of aggregations are supported:
 
 [embedmd]:# (stats.go aggs)
 
-Here we create a view with the DistributionAggregation over our Measure.
-All Measurements will be aggregated together irrespective of their tags,
-i.e. no grouping by tag.
+Here we create a view with the DistributionAggregation over our measure.
 
 [embedmd]:# (stats.go view)
 
 Subscribe begins collecting data for the view. Subscribed views' data will be
 exported via the registered exporters.
 
-[embedmd]:# (stats.go registerExporter)
-
-An example logger exporter is below:
-
-[embedmd]:# (stats.go exporter)
-
-Configure the default interval between reports of collected data.
-This is a system wide interval and impacts all views. The default
-interval duration is 10 seconds.
-
-[embedmd]:# (stats.go reportingPeriod)
-
-
 ## Traces
 
-### Starting and ending a span
-
 [embedmd]:# (trace.go startend)
-
-More tracing examples are coming soon...
 
 ## Profiles
 
@@ -141,7 +120,6 @@ for users who are on Go 1.9 and above.
 A screenshot of the CPU profile from the program above:
 
 ![CPU profile](https://i.imgur.com/jBKjlkw.png)
-
 
 [travis-image]: https://travis-ci.org/census-instrumentation/opencensus-go.svg?branch=master
 [travis-url]: https://travis-ci.org/census-instrumentation/opencensus-go

--- a/internal/readme/stats.go
+++ b/internal/readme/stats.go
@@ -18,7 +18,6 @@ package readme
 import (
 	"context"
 	"log"
-	"time"
 
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
@@ -30,22 +29,15 @@ import (
 func statsExamples() {
 	ctx := context.Background()
 
-	// START measure
 	videoSize, err := stats.Int64("my.org/video_size", "processed video size", "MB")
 	if err != nil {
 		log.Fatal(err)
 	}
-	// END measure
-	_ = videoSize
 
-	// START findMeasure
 	m := stats.FindMeasure("my.org/video_size")
 	if m == nil {
 		log.Fatalln("measure not found")
 	}
-	// END findMeasure
-
-	_ = m
 
 	// START aggs
 	distAgg := view.DistributionAggregation{0, 1 << 32, 2 << 32, 3 << 32}
@@ -67,27 +59,7 @@ func statsExamples() {
 	}
 	// END view
 
-	// START reportingPeriod
-	view.SetReportingPeriod(5 * time.Second)
-	// END reportingPeriod
-
 	// START record
 	stats.Record(ctx, videoSize.M(102478))
 	// END record
-
-	// START registerExporter
-	// Register an exporter to be able to retrieve
-	// the data from the subscribed views.
-	view.RegisterExporter(&exporter{})
-	// END registerExporter
 }
-
-// START exporter
-
-type exporter struct{}
-
-func (e *exporter) ExportView(vd *view.Data) {
-	log.Println(vd)
-}
-
-// END exporter

--- a/internal/readme/tags.go
+++ b/internal/readme/tags.go
@@ -24,16 +24,6 @@ import (
 func tagsExamples() {
 	ctx := context.Background()
 
-	// START stringKey
-	// Get a key to represent user OS.
-	key, err := tag.NewKey("my.org/keys/user-os")
-	if err != nil {
-		log.Fatal(err)
-	}
-	// END stringKey
-	_ = key
-
-	// START new
 	osKey, err := tag.NewKey("my.org/keys/user-os")
 	if err != nil {
 		log.Fatal(err)
@@ -43,6 +33,7 @@ func tagsExamples() {
 		log.Fatal(err)
 	}
 
+	// START new
 	ctx, err = tag.New(ctx,
 		tag.Insert(osKey, "macOS-10.12.5"),
 		tag.Upsert(userIDKey, "cde36753ed"),
@@ -51,22 +42,6 @@ func tagsExamples() {
 		log.Fatal(err)
 	}
 	// END new
-
-	// START newContext
-	m := tag.FromContext(ctx)
-	// END newContext
-
-	_ = m
-
-	// START replaceTagMap
-	ctx, err = tag.New(ctx,
-		tag.Insert(osKey, "macOS-10.12.5"),
-		tag.Upsert(userIDKey, "fff0989878"),
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
-	// END replaceTagMap
 
 	// START profiler
 	ctx, err = tag.New(ctx,


### PR DESCRIPTION
Users are confused by the low-level API due to the significant
highlight on the README. Document the HTTP and gRPC guides as
the main entry points and reduce the number of low-level API
snippets.