### PR TITLE
Update internal UserAgent version to 0.4.0 to match latest release

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -18,7 +18,7 @@ import "time"
 
 // UserAgent is the user agent to be added to the outgoing
 // requests from the exporters.
-const UserAgent = "opencensus-go-v0.1.0"
+const UserAgent = "opencensus-go-v0.4.0"
 
 // MonotonicEndTime returns the end time at present
 // but offset from start, monotonically.


### PR DESCRIPTION
Noticed while examining some Stackdriver traces that we are
on release 0.4.0 but the useragent field shows `opencensus-go-v0.1.0`

<img width="438" alt="screen shot 2018-03-13 at 4 12 50 pm" src="https://user-images.githubusercontent.com/4898263/37374666-663ad5b8-26d9-11e8-8ab1-fdc217e69c8c.png">
