### PR TITLE
Ensure rpcData fields are aligned properly on 32-bit architectures

### DIFF
--- a/plugin/ocgrpc/stats_common.go
+++ b/plugin/ocgrpc/stats_common.go
@@ -31,12 +31,15 @@ type grpcInstrumentationKey string
 // and end of an call. It holds the info that this package needs to keep track
 // of between the various GRPC events.
 type rpcData struct {
+	// reqCount and respCount has to be the first words
+	// in order to be 64-aligned on 32-bit architectures.
+	reqCount, respCount int64 // access atomically
+
 	// startTime represents the time at which TagRPC was invoked at the
 	// beginning of an RPC. It is an appoximation of the time when the
 	// application code invoked GRPC code.
-	startTime           time.Time
-	reqCount, respCount int64 // access atomically
-	method              string
+	startTime time.Time
+	method    string
 }
 
 // The following variables define the default hard-coded auxiliary data used by


### PR DESCRIPTION
On 32-bit architectures, it is the caller's responsibility
to arrange for 64-bit alignment for atomic access.

Fixes #587.