### PR TITLE
Remove unnecessary defer in Span.End, shaving significant time

### DIFF
--- a/trace/trace.go
+++ b/trace/trace.go
@@ -213,10 +213,10 @@ func (s *Span) End() {
 		if s.spanContext.IsSampled() {
 			// TODO: consider holding exportersMu for less time.
 			exportersMu.Lock()
-			defer exportersMu.Unlock()
 			for e := range exporters {
 				e.ExportSpan(sd)
 			}
+			exportersMu.Unlock()
 		}
 	})
 }


### PR DESCRIPTION
Updates #590

Defer is quite expensive and in this context, we are using it for
code that's very short. Microbenchmarks of defer show a significant
time improvement such as
https://gist.github.com/odeke-em/f8fb3a8695b33dd06a700fc3473f3e62

With this change, after running the benchmarks 10 times, we
get an ~10% time shave from AlwaysSample and a 4% time shave for
NeverSample i.e. on average 65 nanoseconds for always sampling.

```shell
$ benchstat old.txt new.txt
name                         old time/op    new time/op    delta
StartEndSpan/AlwaysSample-4     679ns ±17%     614ns ± 9%  -9.65%
(p=0.001 n=9+9)
StartEndSpan/NeverSample-4      192ns ± 5%     184ns ± 1%  -4.11%
(p=0.000 n=10+8)

name                         old alloc/op   new alloc/op   delta
StartEndSpan/AlwaysSample-4      576B ± 0%      576B ± 0%    ~     (all
samples are equal)
StartEndSpan/NeverSample-4       128B ± 0%      128B ± 0%    ~     (all
samples are equal)

name                         old allocs/op  new allocs/op  delta
StartEndSpan/AlwaysSample-4      4.00 ± 0%      4.00 ± 0%    ~     (all
samples are equal)
StartEndSpan/NeverSample-4       2.00 ± 0%      2.00 ± 0%    ~     (all
samples are equal)
```

If our sampling probability is 1 in 10000, and used on a system
processing 1BN (1e9 requests) an hour, that's 0.0065 seconds shaved an
hour.