### PR TITLE
Don't record measurements with no subscription

### DIFF
--- a/stats/internal/record.go
+++ b/stats/internal/record.go
@@ -18,7 +18,8 @@ import (
 	"go.opencensus.io/tag"
 )
 
-type Recorder func(*tag.Map, interface{})
-
 // DefaultRecorder will be called for each Record call.
-var DefaultRecorder Recorder = nil
+var DefaultRecorder func(*tag.Map, interface{})
+
+// SubscriptionReporter reports when a view subscribed with a measure.
+var SubscriptionReporter func(measure string)

--- a/stats/measure_float64.go
+++ b/stats/measure_float64.go
@@ -20,10 +20,21 @@ type Float64Measure struct {
 	measure
 }
 
+func (f *Float64Measure) subscribe() {
+	f.measure.subscribe()
+}
+
+func (f *Float64Measure) subscribed() bool {
+	return f.measure.subscribed()
+}
+
 // M creates a new float64 measurement.
 // Use Record to record measurements.
-func (m *Float64Measure) M(v float64) Measurement {
-	return Measurement{m: m, v: v}
+func (f *Float64Measure) M(v float64) Measurement {
+	if !f.subscribed() {
+		return Measurement{}
+	}
+	return Measurement{m: f, v: v}
 }
 
 // Float64 creates a new measure of type Float64Measure. It returns

--- a/stats/measure_int64.go
+++ b/stats/measure_int64.go
@@ -20,10 +20,21 @@ type Int64Measure struct {
 	measure
 }
 
+func (i *Int64Measure) subscribe() {
+	i.measure.subscribe()
+}
+
+func (i *Int64Measure) subscribed() bool {
+	return i.measure.subscribed()
+}
+
 // M creates a new int64 measurement.
 // Use Record to record measurements.
-func (m *Int64Measure) M(v int64) Measurement {
-	return Measurement{m: m, v: float64(v)}
+func (i *Int64Measure) M(v int64) Measurement {
+	if !i.subscribed() {
+		return Measurement{}
+	}
+	return Measurement{m: i, v: float64(v)}
 }
 
 // Int64 creates a new measure of type Int64Measure. It returns an

--- a/stats/record.go
+++ b/stats/record.go
@@ -22,10 +22,28 @@ import (
 	"go.opencensus.io/tag"
 )
 
+func init() {
+	internal.SubscriptionReporter = func(measure string) {
+		mu.Lock()
+		measures[measure].subscribe()
+		mu.Unlock()
+	}
+}
+
 // Record records one or multiple measurements with the same tags at once.
 // If there are any tags in the context, measurements will be tagged with them.
 func Record(ctx context.Context, ms ...Measurement) {
 	if len(ms) == 0 {
+		return
+	}
+	var record bool
+	for _, m := range ms {
+		if (m != Measurement{}) {
+			record = true
+			break
+		}
+	}
+	if !record {
 		return
 	}
 	if internal.DefaultRecorder != nil {


### PR DESCRIPTION
Suggested by Ramon, immediately dropping the measurements from
the measures with no subscription rather than doing it at a later time
significantly improves the performance on the critical path.

Before:
BenchmarkRecord0-8            	500000000	         3.09 ns/op
BenchmarkRecord1-8            	 5000000	       366 ns/op
BenchmarkRecord8-8            	 3000000	       412 ns/op
BenchmarkRecord8_Parallel-8   	 2000000	       804 ns/op
BenchmarkRecord8_8Tags-8      	 3000000	       415 ns/op

After:
BenchmarkRecord0-8            	500000000	         3.75 ns/op
BenchmarkRecord1-8            	30000000	        39.7 ns/op
BenchmarkRecord8-8            	20000000	       101 ns/op
BenchmarkRecord8_Parallel-8   	30000000	        40.1 ns/op
BenchmarkRecord8_8Tags-8      	20000000	       102 ns/op