### PR TITLE
Rename view.Subscribe to view.Register for language consistency

### DIFF
--- a/examples/grpc/helloworld_client/main.go
+++ b/examples/grpc/helloworld_client/main.go
@@ -37,8 +37,8 @@ func main() {
 	// the collected data.
 	view.RegisterExporter(&exporter.PrintExporter{})
 
-	// Subscribe to collect client request count.
-	if err := ocgrpc.ClientErrorCountView.Subscribe(); err != nil {
+	// Register the view to collect client request count.
+	if err := view.Register(ocgrpc.ClientErrorCountView); err != nil {
 		log.Fatal(err)
 	}
 

--- a/examples/grpc/helloworld_server/main.go
+++ b/examples/grpc/helloworld_server/main.go
@@ -56,8 +56,8 @@ func main() {
 	// the collected data.
 	view.RegisterExporter(&exporter.PrintExporter{})
 
-	// Subscribe to collect server request count.
-	if err := view.Subscribe(ocgrpc.DefaultServerViews...); err != nil {
+	// Register the views to collect server request count.
+	if err := view.Register(ocgrpc.DefaultServerViews...); err != nil {
 		log.Fatal(err)
 	}
 

--- a/examples/helloworld/main.go
+++ b/examples/helloworld/main.go
@@ -57,8 +57,8 @@ func main() {
 
 	// Create view to see the processed video size
 	// distribution broken down by frontend.
-	// Subscribe will allow view data to be exported.
-	if err := view.Subscribe(&view.View{
+	// Register will allow view data to be exported.
+	if err := view.Register(&view.View{
 		Name:        "my.org/views/video_size",
 		Description: "processed video size over time",
 		TagKeys:     []tag.Key{frontendKey},

--- a/stats/view/benchmark_test.go
+++ b/stats/view/benchmark_test.go
@@ -46,9 +46,9 @@ var (
 func BenchmarkRecordReqCommand(b *testing.B) {
 	w := newWorker()
 
-	subscribe := &subscribeToViewReq{views: []*View{view}, err: make(chan error, 1)}
-	subscribe.handleCommand(w)
-	if err := <-subscribe.err; err != nil {
+	register := &registerViewReq{views: []*View{view}, err: make(chan error, 1)}
+	register.handleCommand(w)
+	if err := <-register.err; err != nil {
 		b.Fatal(err)
 	}
 

--- a/stats/view/example_test.go
+++ b/stats/view/example_test.go
@@ -26,7 +26,7 @@ func Example() {
 	m := stats.Int64("my.org/measure/openconns", "open connections", stats.UnitNone)
 
 	// Views are usually subscribed in your application main function.
-	if err := view.Subscribe(&view.View{
+	if err := view.Register(&view.View{
 		Name:        "my.org/views/openconns",
 		Description: "open connections",
 		Measure:     m,

--- a/stats/view/view_test.go
+++ b/stats/view/view_test.go
@@ -339,7 +339,7 @@ func TestViewSortedKeys(t *testing.T) {
 	ks := []tag.Key{k1, k3, k2}
 
 	m := stats.Int64("TestViewSortedKeys/m1", "", stats.UnitNone)
-	Subscribe(&View{
+	Register(&View{
 		Name:        "sort_keys",
 		Description: "desc sort_keys",
 		TagKeys:     ks,

--- a/stats/view/worker.go
+++ b/stats/view/worker.go
@@ -73,7 +73,7 @@ func Unsubscribe(v ...*View) error {
 }
 
 // Deprecated: Use the Register function.
-func (v *View) Register() error {
+func (v *View) Subscribe() error {
 	return Register(v)
 }
 
@@ -111,7 +111,7 @@ func Unregister(views ...*View) {
 }
 
 // Deprecated: Use the Unregister function instead.
-func (v *View) Unregister() error {
+func (v *View) Unsubscribe() error {
 	if v == nil {
 		return nil
 	}

--- a/stats/view/worker.go
+++ b/stats/view/worker.go
@@ -61,30 +61,31 @@ func Find(name string) (v *View) {
 	return resp.v
 }
 
-// Deprecated: Registering is a no-op. Use the Subscribe function.
-func Register(_ *View) error {
+// Deprecated: Use the Register function
+func Subscribe(v ...*View) error {
+	return Register(v...)
+}
+
+// Deprecated: Use the Unregister function
+func Unsubscribe(v ...*View) error {
+	Unregister(v...)
 	return nil
 }
 
-// Deprecated: Unregistering is a no-op, see: Unsubscribe.
-func Unregister(_ *View) error {
-	return nil
+// Deprecated: Use the Register function.
+func (v *View) Register() error {
+	return Register(v)
 }
 
-// Deprecated: Use the Subscribe function.
-func (v *View) Subscribe() error {
-	return Subscribe(v)
-}
-
-// Subscribe begins collecting data for the given views.
+// Register begins collecting data for the given views.
 // Once a view is subscribed, it reports data to the registered exporters.
-func Subscribe(views ...*View) error {
+func Register(views ...*View) error {
 	for _, v := range views {
 		if err := v.canonicalize(); err != nil {
 			return err
 		}
 	}
-	req := &subscribeToViewReq{
+	req := &registerViewReq{
 		views: views,
 		err:   make(chan error),
 	}
@@ -92,11 +93,11 @@ func Subscribe(views ...*View) error {
 	return <-req.err
 }
 
-// Unsubscribe the given views. Data will not longer be exported for these views
-// after Unsubscribe returns.
-// It is not necessary to unsubscribe from views you expect to collect for the
+// Unregister the given views. Data will not longer be exported for these views
+// after Unregister returns.
+// It is not necessary to unregister from views you expect to collect for the
 // duration of your program execution.
-func Unsubscribe(views ...*View) {
+func Unregister(views ...*View) {
 	names := make([]string, len(views))
 	for i := range views {
 		names[i] = views[i].Name
@@ -109,12 +110,12 @@ func Unsubscribe(views ...*View) {
 	<-req.done
 }
 
-// Deprecated: Use the Unsubscribe function instead.
-func (v *View) Unsubscribe() error {
+// Deprecated: Use the Unregister function instead.
+func (v *View) Unregister() error {
 	if v == nil {
 		return nil
 	}
-	Unsubscribe(v)
+	Unregister(v)
 	return nil
 }
 

--- a/stats/view/worker_commands.go
+++ b/stats/view/worker_commands.go
@@ -44,13 +44,13 @@ func (cmd *getViewByNameReq) handleCommand(w *worker) {
 	cmd.c <- &getViewByNameResp{w.views[cmd.name].view}
 }
 
-// subscribeToViewReq is the command to subscribe to a view.
-type subscribeToViewReq struct {
+// registerViewReq is the command to register a view.
+type registerViewReq struct {
 	views []*View
 	err   chan error
 }
 
-func (cmd *subscribeToViewReq) handleCommand(w *worker) {
+func (cmd *registerViewReq) handleCommand(w *worker) {
 	var errstr []string
 	for _, view := range cmd.views {
 		vi, err := w.tryRegisterView(view)

--- a/stats/view/worker_test.go
+++ b/stats/view/worker_test.go
@@ -233,7 +233,7 @@ func Test_Worker_RecordFloat64(t *testing.T) {
 
 		// cleaning up
 		for _, v := range tc.registrations {
-			if err := v.Unregister(); err != nil {
+			if err := v.Unsubscribe(); err != nil {
 				t.Fatalf("%v: Unregistering from view %v errored with %v; want no error", tc.label, v.Name, err)
 			}
 		}
@@ -323,7 +323,7 @@ func TestWorkerStarttime(t *testing.T) {
 	v, _ := New("testview", "", nil, m, Count())
 
 	SetReportingPeriod(25 * time.Millisecond)
-	if err := v.Register(); err != nil {
+	if err := Register(v); err != nil {
 		t.Fatalf("cannot register to %v: %v", v.Name, err)
 	}
 

--- a/zpages/rpcz.go
+++ b/zpages/rpcz.go
@@ -61,7 +61,7 @@ func init() {
 	for v := range viewType {
 		views = append(views, v)
 	}
-	if err := view.Subscribe(views...); err != nil {
+	if err := view.Register(views...); err != nil {
 		log.Printf("error subscribing to views: %v", err)
 	}
 	view.RegisterExporter(snapExporter{})


### PR DESCRIPTION
Fixes #612

* Replace Subscribe with Register in examples
* Deprecate instead of radically removing {"", "Un"}Subscribe

Since Subscribe has been used in many API samples and has
been the function of choice, deprecate it but still underlyingly
use Register. The same for Unsubscribe.

Gradually users should see the deprecation notice and switch over
to using Register and Unregister.