### PR TITLE
Span names shouldn't be prefixed with Sent and Recv

### DIFF
--- a/exporter/jaeger/jaeger.go
+++ b/exporter/jaeger/jaeger.go
@@ -158,7 +158,7 @@ func (e *Exporter) ExportSpan(data *trace.SpanData) {
 		TraceIdLow:    bytesToInt64(data.TraceID[8:16]),
 		SpanId:        bytesToInt64(data.SpanID[:]),
 		ParentSpanId:  bytesToInt64(data.ParentSpanID[:]),
-		OperationName: data.Name,
+		OperationName: name(data),
 		Flags:         int32(data.TraceOptions),
 		StartTime:     data.StartTime.UnixNano() / 1000,
 		Duration:      data.EndTime.Sub(data.StartTime).Nanoseconds() / 1000,
@@ -168,6 +168,17 @@ func (e *Exporter) ExportSpan(data *trace.SpanData) {
 	}
 	e.bundler.Add(span, 1)
 	// TODO(jbd): Handle oversized bundlers.
+}
+
+func name(sd *trace.SpanData) string {
+	n := sd.Name
+	switch sd.SpanKind {
+	case trace.SpanKindClient:
+		n = "Sent." + n
+	case trace.SpanKindServer:
+		n = "Recv." + n
+	}
+	return n
 }
 
 func attributeToTag(key string, a interface{}) *gen.Tag {

--- a/exporter/stackdriver/trace_proto.go
+++ b/exporter/stackdriver/trace_proto.go
@@ -52,10 +52,18 @@ func protoFromSpanData(s *trace.SpanData, projectID string) *tracepb.Span {
 	traceIDString := s.SpanContext.TraceID.String()
 	spanIDString := s.SpanContext.SpanID.String()
 
+	name := s.Name
+	switch s.SpanKind {
+	case trace.SpanKindClient:
+		name = "Sent." + name
+	case trace.SpanKindServer:
+		name = "Recv." + name
+	}
+
 	sp := &tracepb.Span{
 		Name:                    "projects/" + projectID + "/traces/" + traceIDString + "/spans/" + spanIDString,
 		SpanId:                  spanIDString,
-		DisplayName:             trunc(s.Name, 128),
+		DisplayName:             trunc(name, 128),
 		StartTime:               timestampProto(s.StartTime),
 		EndTime:                 timestampProto(s.EndTime),
 		SameProcessAsParentSpan: &wrapperspb.BoolValue{Value: !s.HasRemoteParent},

--- a/exporter/zipkin/zipkin.go
+++ b/exporter/zipkin/zipkin.go
@@ -18,7 +18,6 @@ package zipkin // import "go.opencensus.io/exporter/zipkin"
 import (
 	"encoding/binary"
 	"strconv"
-	"strings"
 
 	"github.com/openzipkin/zipkin-go/model"
 	"github.com/openzipkin/zipkin-go/reporter"
@@ -102,22 +101,11 @@ func convertSpanID(s trace.SpanID) model.ID {
 }
 
 func spanKind(s *trace.SpanData) model.Kind {
-	if s.HasRemoteParent {
-		return model.Server
-	}
-	if strings.HasPrefix(s.Name, "Sent.") {
+	switch s.SpanKind {
+	case trace.SpanKindClient:
 		return model.Client
-	}
-	if strings.HasPrefix(s.Name, "Recv.") {
+	case trace.SpanKindServer:
 		return model.Server
-	}
-	if len(s.MessageEvents) > 0 {
-		switch s.MessageEvents[0].EventType {
-		case trace.MessageEventTypeSent:
-			return model.Client
-		case trace.MessageEventTypeRecv:
-			return model.Server
-		}
 	}
 	return model.Undetermined
 }

--- a/exporter/zipkin/zipkin_test.go
+++ b/exporter/zipkin/zipkin_test.go
@@ -50,6 +50,7 @@ func TestExport(t *testing.T) {
 					TraceOptions: 1,
 				},
 				Name:      "name",
+				SpanKind:  trace.SpanKindClient,
 				StartTime: now,
 				EndTime:   now.Add(24 * time.Hour),
 				Attributes: map[string]interface{}{

--- a/plugin/ocgrpc/trace_common.go
+++ b/plugin/ocgrpc/trace_common.go
@@ -34,7 +34,8 @@ const traceContextKey = "grpc-trace-bin"
 // It returns ctx with the new trace span added and a serialization of the
 // SpanContext added to the outgoing gRPC metadata.
 func (c *ClientHandler) traceTagRPC(ctx context.Context, rti *stats.RPCTagInfo) context.Context {
-	name := "Sent" + strings.Replace(rti.FullMethodName, "/", ".", -1)
+	name := strings.TrimPrefix(rti.FullMethodName, "/")
+	name = strings.Replace(name, "/", ".", -1)
 	span := trace.NewSpan(name, trace.FromContext(ctx), trace.StartOptions{
 		Sampler:  c.StartOptions.Sampler,
 		SpanKind: trace.SpanKindClient,
@@ -57,7 +58,8 @@ func (s *ServerHandler) traceTagRPC(ctx context.Context, rti *stats.RPCTagInfo) 
 	}
 
 	md, _ := metadata.FromIncomingContext(ctx)
-	name := "Recv" + strings.Replace(rti.FullMethodName, "/", ".", -1)
+	name := strings.TrimPrefix(rti.FullMethodName, "/")
+	name = strings.Replace(name, "/", ".", -1)
 	traceContext := md[traceContextKey]
 	var (
 		parent     trace.SpanContext

--- a/plugin/ochttp/server.go
+++ b/plugin/ochttp/server.go
@@ -79,7 +79,7 @@ func (h *Handler) startTrace(w http.ResponseWriter, r *http.Request) (*http.Requ
 		SpanKind: trace.SpanKindServer,
 	}
 
-	name := spanNameFromURL("Recv", r.URL)
+	name := spanNameFromURL(r.URL)
 	ctx := r.Context()
 	var span *trace.Span
 	sc, ok := h.extractSpanContext(r)

--- a/plugin/ochttp/trace.go
+++ b/plugin/ochttp/trace.go
@@ -50,7 +50,7 @@ type traceTransport struct {
 // The created span can follow a parent span, if a parent is presented in
 // the request's context.
 func (t *traceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	name := spanNameFromURL("Sent", req.URL)
+	name := spanNameFromURL(req.URL)
 	// TODO(jbd): Discuss whether we want to prefix
 	// outgoing requests with Sent.
 	parent := trace.FromContext(req.Context())
@@ -126,13 +126,8 @@ func (t *traceTransport) CancelRequest(req *http.Request) {
 	}
 }
 
-func spanNameFromURL(prefix string, u *url.URL) string {
-	host := u.Hostname()
-	port := ":" + u.Port()
-	if port == ":" || port == ":80" || port == ":443" {
-		port = ""
-	}
-	return prefix + "." + host + port + u.Path
+func spanNameFromURL(u *url.URL) string {
+	return u.Path
 }
 
 func requestAttrs(r *http.Request) []trace.Attribute {


### PR DESCRIPTION
Instead set them for some exporters that cannot
differentiate client spans from server spans in their model.

Fixes #607.