### PR TITLE
Fix plugin/ochttp statusCode mistype and unconditional set

### DIFF
--- a/plugin/ochttp/trace.go
+++ b/plugin/ochttp/trace.go
@@ -152,7 +152,7 @@ func responseAttrs(resp *http.Response) []trace.Attribute {
 
 func status(statusCode int) trace.Status {
 	var code int32
-	if code < 200 || code >= 400 {
+	if statusCode < 200 || statusCode >= 400 {
 		code = codeUnknown
 	}
 	switch statusCode {

--- a/plugin/ochttp/trace_test.go
+++ b/plugin/ochttp/trace_test.go
@@ -447,3 +447,27 @@ func TestResponseAttributes(t *testing.T) {
 		})
 	}
 }
+
+func TestStatusUnitTest(t *testing.T) {
+	tests := []struct {
+		in   int
+		want trace.Status
+	}{
+		{200, trace.Status{Code: 0, Message: `"OK"`}},
+		{100, trace.Status{Code: 2, Message: `"UNKNOWN"`}},
+		{500, trace.Status{Code: 2, Message: `"UNKNOWN"`}},
+		{404, trace.Status{Code: 5, Message: `"NOT_FOUND"`}},
+		{600, trace.Status{Code: 2, Message: `"UNKNOWN"`}},
+		{401, trace.Status{Code: 16, Message: `"UNAUTHENTICATED"`}},
+		{403, trace.Status{Code: 7, Message: `"PERMISSION_DENIED"`}},
+		{301, trace.Status{Code: 0, Message: `"OK"`}},
+		{501, trace.Status{Code: 12, Message: `"UNIMPLEMENTED"`}},
+	}
+
+	for _, tt := range tests {
+		got, want := status(tt.in), tt.want
+		if got != want {
+			t.Errorf("status(%d) got = (%#v) want = (%#v)", tt.in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #619

The mistyped source code unconditionally set variable code
to codeUnknown since
```go
var code int32
if code < 200 || code >= 400 {
   code = codeUnknown
}
```
always would set it to codeUnknown as the zero value
of int32 is 0 so always code = codeUnknown.

However if it didn't get matched in the next switch
case, e.g. a 200, we'd get an Unknown status.

Also add unit tests for status so that we never accidentally
regress.

This was discovered by demo app inspections on Stackdriver.


#### Before
<img width="478" alt="screen shot 2018-03-20 at 11 42 29 pm" src="https://user-images.githubusercontent.com/4898263/37697836-5be8347a-2c9c-11e8-8b0f-32e2c99c533a.png">

#### After
<img width="463" alt="screen shot 2018-03-20 at 11 44 26 pm" src="https://user-images.githubusercontent.com/4898263/37697821-4502a1a0-2c9c-11e8-864e-72c1f0d2980d.png">