### PR TITLE
Keep pointer receiver name consistency

### DIFF
--- a/stats/measure_float64.go
+++ b/stats/measure_float64.go
@@ -20,21 +20,21 @@ type Float64Measure struct {
 	measure
 }
 
-func (f *Float64Measure) subscribe() {
-	f.measure.subscribe()
+func (m *Float64Measure) subscribe() {
+	m.measure.subscribe()
 }
 
-func (f *Float64Measure) subscribed() bool {
-	return f.measure.subscribed()
+func (m *Float64Measure) subscribed() bool {
+	return m.measure.subscribed()
 }
 
 // M creates a new float64 measurement.
 // Use Record to record measurements.
-func (f *Float64Measure) M(v float64) Measurement {
-	if !f.subscribed() {
+func (m *Float64Measure) M(v float64) Measurement {
+	if !m.subscribed() {
 		return Measurement{}
 	}
-	return Measurement{m: f, v: v}
+	return Measurement{m: m, v: v}
 }
 
 // Float64 creates a new measure of type Float64Measure. It returns

--- a/stats/measure_int64.go
+++ b/stats/measure_int64.go
@@ -20,21 +20,21 @@ type Int64Measure struct {
 	measure
 }
 
-func (i *Int64Measure) subscribe() {
-	i.measure.subscribe()
+func (m *Int64Measure) subscribe() {
+	m.measure.subscribe()
 }
 
-func (i *Int64Measure) subscribed() bool {
-	return i.measure.subscribed()
+func (m *Int64Measure) subscribed() bool {
+	return m.measure.subscribed()
 }
 
 // M creates a new int64 measurement.
 // Use Record to record measurements.
-func (i *Int64Measure) M(v int64) Measurement {
-	if !i.subscribed() {
+func (m *Int64Measure) M(v int64) Measurement {
+	if !m.subscribed() {
 		return Measurement{}
 	}
-	return Measurement{m: i, v: float64(v)}
+	return Measurement{m: m, v: float64(v)}
 }
 
 // Int64 creates a new measure of type Int64Measure. It returns an


### PR DESCRIPTION
The names embedded via measure has m as the
receiver name.