### PR TITLE
Remove ending dot in documentation URL

### DIFF
--- a/trace/doc.go
+++ b/trace/doc.go
@@ -17,7 +17,7 @@ Package trace contains types for representing trace information, and
 functions for global configuration of tracing.
 
 The following assumes a basic familiarity with OpenCensus concepts.
-See http://opencensus.io.
+See http://opencensus.io
 
 
 Enabling Tracing for a Program


### PR DESCRIPTION
The dot is causing SSL common name issues, as GitHub and Godoc linking to the domain name with an extra dot.