### PR TITLE
*ResponseStatusCode* measures and views to use Distribution aggregations

### DIFF
--- a/plugin/ochttp/client_stats.go
+++ b/plugin/ochttp/client_stats.go
@@ -95,6 +95,7 @@ func (t *tracker) end() {
 		m := []stats.Measurement{
 			ClientLatency.M(float64(time.Since(t.start)) / float64(time.Millisecond)),
 			ClientResponseBytes.M(t.respSize),
+			ClientResponseStatusCode.M(int64(t.statusCode)),
 		}
 		if t.reqSize >= 0 {
 			m = append(m, ClientRequestBytes.M(t.reqSize))

--- a/plugin/ochttp/server.go
+++ b/plugin/ochttp/server.go
@@ -149,6 +149,7 @@ func (t *trackingResponseWriter) end() {
 		m := []stats.Measurement{
 			ServerLatency.M(float64(time.Since(t.start)) / float64(time.Millisecond)),
 			ServerResponseBytes.M(t.respSize),
+			ServerResponseStatusCode.M(int64(t.statusCode)),
 		}
 		if t.reqSize >= 0 {
 			m = append(m, ServerRequestBytes.M(t.reqSize))

--- a/plugin/ochttp/stats.go
+++ b/plugin/ochttp/stats.go
@@ -22,18 +22,20 @@ import (
 
 // The following client HTTP measures are supported for use in custom views.
 var (
-	ClientRequestCount  = stats.Int64("opencensus.io/http/client/request_count", "Number of HTTP requests started", stats.UnitNone)
-	ClientRequestBytes  = stats.Int64("opencensus.io/http/client/request_bytes", "HTTP request body size if set as ContentLength (uncompressed)", stats.UnitBytes)
-	ClientResponseBytes = stats.Int64("opencensus.io/http/client/response_bytes", "HTTP response body size (uncompressed)", stats.UnitBytes)
-	ClientLatency       = stats.Float64("opencensus.io/http/client/latency", "End-to-end latency", stats.UnitMilliseconds)
+	ClientRequestCount       = stats.Int64("opencensus.io/http/client/request_count", "Number of HTTP requests started", stats.UnitNone)
+	ClientRequestBytes       = stats.Int64("opencensus.io/http/client/request_bytes", "HTTP request body size if set as ContentLength (uncompressed)", stats.UnitBytes)
+	ClientResponseBytes      = stats.Int64("opencensus.io/http/client/response_bytes", "HTTP response body size (uncompressed)", stats.UnitBytes)
+	ClientLatency            = stats.Float64("opencensus.io/http/client/latency", "End-to-end latency", stats.UnitMilliseconds)
+	ClientResponseStatusCode = stats.Int64("opencensus.io/http/client_response_status_code", "Number of HTTP response status codes for the client", stats.UnitNone)
 )
 
 // The following server HTTP measures are supported for use in custom views:
 var (
-	ServerRequestCount  = stats.Int64("opencensus.io/http/server/request_count", "Number of HTTP requests started", stats.UnitNone)
-	ServerRequestBytes  = stats.Int64("opencensus.io/http/server/request_bytes", "HTTP request body size if set as ContentLength (uncompressed)", stats.UnitBytes)
-	ServerResponseBytes = stats.Int64("opencensus.io/http/server/response_bytes", "HTTP response body size (uncompressed)", stats.UnitBytes)
-	ServerLatency       = stats.Float64("opencensus.io/http/server/latency", "End-to-end latency", stats.UnitMilliseconds)
+	ServerRequestCount       = stats.Int64("opencensus.io/http/server/request_count", "Number of HTTP requests started", stats.UnitNone)
+	ServerRequestBytes       = stats.Int64("opencensus.io/http/server/request_bytes", "HTTP request body size if set as ContentLength (uncompressed)", stats.UnitBytes)
+	ServerResponseBytes      = stats.Int64("opencensus.io/http/server/response_bytes", "HTTP response body size (uncompressed)", stats.UnitBytes)
+	ServerLatency            = stats.Float64("opencensus.io/http/server/latency", "End-to-end latency", stats.UnitMilliseconds)
+	ServerResponseStatusCode = stats.Int64("opencensus.io/http/server_response_status_code", "Number of HTTP response status codes for the server", stats.UnitNone)
 )
 
 // The following tags are applied to stats recorded by this package. Host, Path
@@ -58,6 +60,9 @@ var (
 var (
 	DefaultSizeDistribution    = view.Distribution(0, 1024, 2048, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864, 268435456, 1073741824, 4294967296)
 	DefaultLatencyDistribution = view.Distribution(0, 1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 25, 30, 40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400, 500, 650, 800, 1000, 2000, 5000, 10000, 20000, 50000, 100000)
+
+	// Representing status code buckets:		 [0,  1XX, 2XX, 3XX, 4XX, 5XX, 6XX]
+	DefaultStatusCodeDistribution = view.Distribution(99, 199, 299, 399, 499, 599, 699)
 )
 
 // Package ochttp provides some convenience views.
@@ -102,9 +107,8 @@ var (
 	ClientResponseCountByStatusCode = &view.View{
 		Name:        "opencensus.io/http/client/response_count_by_status_code",
 		Description: "Client response count by status code",
-		TagKeys:     []tag.Key{StatusCode},
-		Measure:     ClientLatency,
-		Aggregation: view.Count(),
+		Measure:     ClientResponseStatusCode,
+		Aggregation: DefaultStatusCodeDistribution,
 	}
 
 	ServerRequestCountView = &view.View{
@@ -146,9 +150,8 @@ var (
 	ServerResponseCountByStatusCode = &view.View{
 		Name:        "opencensus.io/http/server/response_count_by_status_code",
 		Description: "Server response count by status code",
-		TagKeys:     []tag.Key{StatusCode},
-		Measure:     ServerLatency,
-		Aggregation: view.Count(),
+		Measure:     ServerResponseStatusCode,
+		Aggregation: DefaultStatusCodeDistribution,
 	}
 )
 

--- a/plugin/ochttp/stats_test.go
+++ b/plugin/ochttp/stats_test.go
@@ -1,0 +1,46 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ochttp_test
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+
+	"go.opencensus.io/plugin/ochttp"
+	"go.opencensus.io/stats/view"
+)
+
+// This code serves to assert some sanity checks about
+// the attributes of views such as the Aggregation.
+
+func TestSanityCheckViewAggregations(t *testing.T) {
+	mustHaveAggregation(t, ochttp.ClientResponseCountByStatusCode, view.AggTypeDistribution)
+	mustHaveAggregation(t, ochttp.ServerResponseCountByStatusCode, view.AggTypeDistribution)
+	mustHaveAggregation(t, ochttp.ClientRequestCountByMethod, view.AggTypeCount)
+	mustHaveAggregation(t, ochttp.ServerRequestCountByMethod, view.AggTypeCount)
+}
+
+func caller2() string {
+	pc, _, line, _ := runtime.Caller(2)
+	fn := runtime.FuncForPC(pc)
+	return fmt.Sprintf("%s::%d", fn.Name(), line)
+}
+
+func mustHaveAggregation(t *testing.T, v *view.View, aggType view.AggType) {
+	if g, w := v.Aggregation.Type, aggType; g != w {
+		t.Errorf("Location %q:\n\tnon-matching aggregation got = %v want = %v", caller2(), g, w)
+	}
+}


### PR DESCRIPTION
Fixes #659

* ClientResponseStatusCode and ServerResponseStatusCode measures can
now record within the respective track* wrappers for client and server
respectively.
* ClientResponseCountByStatusCode and ServerResponseCountByStatusCode
no longer use ClientLatency and ServerLatency measures and are no longer
based on Count aggregations, but now on Distribution aggregations. Also
introduced buckets for status codes:
  [99, 199, 299, 399, 499, 599, 699]
to account for status code buckets:
  [0, 1XX, 2XX, 3XX, 4XX, 5XX, 6XX]

Using *Latency measures doesn't make sense to try to correlate response
count by status code, which arguably are just the view groupings so that
request and response counts can be tagged by StatusCode, but it just
felt so off with that combination.