### PR TITLE
Fix the broken Apache Thrift import path

### DIFF
--- a/exporter/jaeger/internal/gen-go/jaeger/agent.go
+++ b/exporter/jaeger/internal/gen-go/jaeger/agent.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"fmt"
 
-	"git.apache.org/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 )
 
 // (needed to ensure safety because of naive import list construction.)

--- a/exporter/jaeger/internal/gen-go/jaeger/collector-remote/collector-remote.go
+++ b/exporter/jaeger/internal/gen-go/jaeger/collector-remote/collector-remote.go
@@ -14,7 +14,7 @@ import (
 	"strconv"
 	"strings"
 
-	"git.apache.org/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 	"go.opencensus.io/exporter/jaeger/internal/gen-go/jaeger"
 )
 

--- a/exporter/jaeger/internal/gen-go/jaeger/jaeger.go
+++ b/exporter/jaeger/internal/gen-go/jaeger/jaeger.go
@@ -11,7 +11,8 @@ import (
 	"fmt"
 	"reflect"
 
-	"git.apache.org/thrift.git/lib/go/thrift"
+	// TODO(jbd): Switch back to the vanity URL for Thrift.
+	"github.com/apache/thrift/lib/go/thrift"
 )
 
 // (needed to ensure safety because of naive import list construction.)


### PR DESCRIPTION
Thrift's import path is broken. Use the GitHub import
path instead. We don't export any APIs depending on Thrift
symbols, so this change is safe.