### PR TITLE
Introduce an internal-only ID generator

### DIFF
--- a/trace/basetypes.go
+++ b/trace/basetypes.go
@@ -22,6 +22,7 @@ import (
 type (
 	// TraceID is a 16-byte identifier for a set of spans.
 	TraceID [16]byte
+
 	// SpanID is an 8-byte identifier for a single span.
 	SpanID [8]byte
 )

--- a/trace/config.go
+++ b/trace/config.go
@@ -14,25 +14,27 @@
 
 package trace
 
-func init() {
-	config.DefaultSampler = ProbabilitySampler(defaultSamplingProbability)
-}
+import "go.opencensus.io/trace/internal"
 
 // Config represents the global tracing configuration.
 type Config struct {
 	// DefaultSampler is the default sampler used when creating new spans.
 	DefaultSampler Sampler
+
+	// IDGenerator is for internal use only.
+	IDGenerator internal.IDGenerator
 }
 
 // ApplyConfig applies changes to the global tracing configuration.
 //
 // Fields not provided in the given config are going to be preserved.
 func ApplyConfig(cfg Config) {
-	mu.Lock()
-	if cfg.DefaultSampler == nil {
-		cfg.DefaultSampler = config.DefaultSampler
+	c := config.Load().(*Config)
+	if cfg.DefaultSampler != nil {
+		c.DefaultSampler = cfg.DefaultSampler
 	}
-	// TODO(jbd): Reduce the global contention on config.
-	config = cfg
-	mu.Unlock()
+	if cfg.IDGenerator != nil {
+		c.IDGenerator = cfg.IDGenerator
+	}
+	config.Store(c)
 }

--- a/trace/internal/internal.go
+++ b/trace/internal/internal.go
@@ -12,22 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package trace
+// Package internal provides trace internals.
+package internal
 
-import (
-	"reflect"
-	"testing"
-)
-
-func TestApplyZeroConfig(t *testing.T) {
-	cfg := config.Load().(*Config)
-	ApplyConfig(Config{})
-	currentCfg := config.Load().(*Config)
-
-	if got, want := reflect.ValueOf(currentCfg.DefaultSampler).Pointer(), reflect.ValueOf(cfg.DefaultSampler).Pointer(); got != want {
-		t.Fatalf("config.DefaultSampler = %#v; want %#v", got, want)
-	}
-	if got, want := currentCfg.IDGenerator, cfg.IDGenerator; got != want {
-		t.Fatalf("config.IDGenerator = %#v; want %#v", got, want)
-	}
+type IDGenerator interface {
+	NewTraceID() [16]byte
+	NewSpanID() [8]byte
 }

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math/rand"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.opencensus.io/internal"
@@ -157,14 +158,14 @@ func NewSpanWithRemoteParent(name string, parent SpanContext, o StartOptions) *S
 func startSpanInternal(name string, hasParent bool, parent SpanContext, remoteParent bool, o StartOptions) *Span {
 	span := &Span{}
 	span.spanContext = parent
-	mu.Lock()
-	// TODO(jbd): Reduce the contention.
+
+	cfg := config.Load().(*Config)
+
 	if !hasParent {
-		span.spanContext.TraceID = newTraceIDLocked()
+		span.spanContext.TraceID = cfg.IDGenerator.NewTraceID()
 	}
-	span.spanContext.SpanID = newSpanIDLocked()
-	sampler := config.DefaultSampler
-	mu.Unlock()
+	span.spanContext.SpanID = cfg.IDGenerator.NewSpanID()
+	sampler := cfg.DefaultSampler
 
 	if !hasParent || remoteParent || o.Sampler != nil {
 		// If this span is the child of a local span and no Sampler is set in the
@@ -405,47 +406,58 @@ func (s *Span) String() string {
 	return str
 }
 
-var (
-	mu          sync.Mutex // protects the variables below
+var config atomic.Value // access atomically
+
+func init() {
+	gen := &defaultIDGenerator{}
+	// initialize traceID and spanID generators.
+	var rngSeed int64
+	for _, p := range []interface{}{
+		&rngSeed, &gen.traceIDAdd, &gen.nextSpanID, &gen.spanIDInc,
+	} {
+		binary.Read(crand.Reader, binary.LittleEndian, p)
+	}
+	gen.traceIDRand = rand.New(rand.NewSource(rngSeed))
+	gen.spanIDInc |= 1
+
+	config.Store(&Config{
+		DefaultSampler: ProbabilitySampler(defaultSamplingProbability),
+		IDGenerator:    gen,
+	})
+}
+
+type defaultIDGenerator struct {
+	sync.Mutex
 	traceIDRand *rand.Rand
 	traceIDAdd  [2]uint64
 	nextSpanID  uint64
 	spanIDInc   uint64
-	config      Config
-)
-
-func init() {
-	// initialize traceID and spanID generators.
-	var rngSeed int64
-	for _, p := range []interface{}{
-		&rngSeed, &traceIDAdd, &nextSpanID, &spanIDInc,
-	} {
-		binary.Read(crand.Reader, binary.LittleEndian, p)
-	}
-	traceIDRand = rand.New(rand.NewSource(rngSeed))
-	spanIDInc |= 1
 }
 
-// newSpanIDLocked returns a non-zero SpanID from a randomly-chosen sequence.
+// NewSpanID returns a non-zero span ID from a randomly-chosen sequence.
 // mu should be held while this function is called.
-func newSpanIDLocked() SpanID {
-	id := nextSpanID
-	nextSpanID += spanIDInc
-	if nextSpanID == 0 {
-		nextSpanID += spanIDInc
+func (gen *defaultIDGenerator) NewSpanID() [8]byte {
+	gen.Lock()
+	id := gen.nextSpanID
+	gen.nextSpanID += gen.spanIDInc
+	if gen.nextSpanID == 0 {
+		gen.nextSpanID += gen.spanIDInc
 	}
-	var sid SpanID
+	gen.Unlock()
+	var sid [8]byte
 	binary.LittleEndian.PutUint64(sid[:], id)
 	return sid
 }
 
-// newTraceIDLocked returns a non-zero TraceID from a randomly-chosen sequence.
+// NewTraceID returns a non-zero trace ID from a randomly-chosen sequence.
 // mu should be held while this function is called.
-func newTraceIDLocked() TraceID {
-	var tid TraceID
+func (gen *defaultIDGenerator) NewTraceID() [16]byte {
+	var tid [16]byte
 	// Construct the trace ID from two outputs of traceIDRand, with a constant
 	// added to each half for additional entropy.
-	binary.LittleEndian.PutUint64(tid[0:8], traceIDRand.Uint64()+traceIDAdd[0])
-	binary.LittleEndian.PutUint64(tid[8:16], traceIDRand.Uint64()+traceIDAdd[1])
+	gen.Lock()
+	binary.LittleEndian.PutUint64(tid[0:8], gen.traceIDRand.Uint64()+gen.traceIDAdd[0])
+	binary.LittleEndian.PutUint64(tid[8:16], gen.traceIDRand.Uint64()+gen.traceIDAdd[1])
+	gen.Unlock()
 	return tid
 }


### PR DESCRIPTION
We introduce this experimental generator to support AWS X-Ray.
Regular users should not depend on this API, it is preserved
to be used by the exporters.