### PR TITLE
Improve trace godoc

### DIFF
--- a/trace/doc.go
+++ b/trace/doc.go
@@ -13,19 +13,18 @@
 // limitations under the License.
 
 /*
-Package trace contains types for representing trace information, and
-functions for global configuration of tracing.
+Package trace contains support for OpenCensus distributed tracing.
 
 The following assumes a basic familiarity with OpenCensus concepts.
 See http://opencensus.io
 
 
-Enabling Tracing for a Program
+Exporting Traces
 
-To use OpenCensus tracing, register at least one Exporter. You can use
+To export collected tracing data, register at least one exporter. You can use
 one of the provided exporters or write your own.
 
-    trace.RegisterExporter(anExporter)
+    trace.RegisterExporter(exporter)
 
 By default, traces will be sampled relatively rarely. To change the sampling
 frequency for your entire program, call ApplyConfig. Use a ProbabilitySampler
@@ -43,13 +42,10 @@ It is common to want to capture all the activity of a function call in a span. F
 this to work, the function must take a context.Context as a parameter. Add these two
 lines to the top of the function:
 
-    ctx, span := trace.StartSpan(ctx, "your choice of name")
+    ctx, span := trace.StartSpan(ctx, "my.org/Run")
     defer span.End()
 
 StartSpan will create a new top-level span if the context
 doesn't contain another span, otherwise it will create a child span.
-
-As a suggestion, use the fully-qualified function name as the span name, e.g.
-"github.com/me/mypackage.Run".
 */
 package trace // import "go.opencensus.io/trace"


### PR DESCRIPTION
Tweak a few inaccurate lines and stop suggesting fully qualified
function name as a span name. Span names should be picked to make
statistical sense in each situation. Don't be opinionated.