### PR TITLE
Make plugin/ochttp/server set its span status on ending

### DIFF
--- a/plugin/ochttp/server.go
+++ b/plugin/ochttp/server.go
@@ -159,6 +159,10 @@ func (t *trackingResponseWriter) end() {
 		if t.statusCode == 0 {
 			t.statusCode = 200
 		}
+
+		span := trace.FromContext(t.ctx)
+		span.SetStatus(status(t.statusCode))
+
 		m := []stats.Measurement{
 			ServerLatency.M(float64(time.Since(t.start)) / float64(time.Millisecond)),
 			ServerResponseBytes.M(t.respSize),

--- a/plugin/ochttp/trace.go
+++ b/plugin/ochttp/trace.go
@@ -169,6 +169,8 @@ func status(statusCode int) trace.Status {
 		code = codeUnimplemented
 	case http.StatusServiceUnavailable:
 		code = codeUnavailable
+	case http.StatusOK:
+		code = codeOK
 	}
 	return trace.Status{Code: code, Message: codeToStr[code]}
 }


### PR DESCRIPTION
Fixes #700

The server plugin should set the status on end, after roundtripping.
Also while here ensure that helper function status converts
http.StatusOK i.e. 200 to codeOK i.e. 0