### PR TITLE
Fix example. Do not overwrite new request.

### DIFF
--- a/examples/http/helloworld_server/main.go
+++ b/examples/http/helloworld_server/main.go
@@ -50,7 +50,7 @@ func main() {
 		r, _ := http.NewRequest("GET", "https://example.com", nil)
 
 		// Propagate the trace header info in the outgoing requests.
-		r.WithContext(req.Context())
+		r = r.WithContext(req.Context())
 		resp, err := client.Do(r)
 		if err != nil {
 			log.Println(err)

--- a/examples/http/helloworld_server/main.go
+++ b/examples/http/helloworld_server/main.go
@@ -50,7 +50,7 @@ func main() {
 		r, _ := http.NewRequest("GET", "https://example.com", nil)
 
 		// Propagate the trace header info in the outgoing requests.
-		r = req.WithContext(req.Context())
+		r.WithContext(req.Context())
 		resp, err := client.Do(r)
 		if err != nil {
 			log.Println(err)


### PR DESCRIPTION
Instead of overwriting new request, use only context from original request.