### PR TITLE
Fix go get command in example readme.

### DIFF
--- a/examples/http/README.md
+++ b/examples/http/README.md
@@ -7,7 +7,7 @@ This example uses:
 * Debugging exporters to print stats and traces to stdout.
 
 ```
-$ go get go.opencensus.io/examples/http
+$ go get go.opencensus.io/examples/http/...
 ```
 
 First, run the server:


### PR DESCRIPTION
Right now `go get` exits with error:
`can't load package: package go.opencensus.io/examples/http: no Go files in /home/username/go/src/go.opencensus.io/examples/http`

This change should fix it.