### PR TITLE
Deprecate NewSpanXXX in the favor of StartSpan

### DIFF
--- a/exporter/stackdriver/stackdriver_test.go
+++ b/exporter/stackdriver/stackdriver_test.go
@@ -53,14 +53,13 @@ func TestExport(t *testing.T) {
 
 	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 
-	span := trace.NewSpan("custom-span", nil, trace.StartOptions{})
+	_, span := trace.StartSpan(context.Background(), "custom-span")
 	time.Sleep(10 * time.Millisecond)
 	span.End()
 
 	// Test HTTP spans
 
 	handler := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-
 		_, backgroundSpan := trace.StartSpan(context.Background(), "BackgroundWork")
 		spanContext := backgroundSpan.SpanContext()
 		time.Sleep(10 * time.Millisecond)

--- a/exporter/stackdriver/stats.go
+++ b/exporter/stackdriver/stats.go
@@ -155,12 +155,11 @@ func (e *statsExporter) Flush() {
 }
 
 func (e *statsExporter) uploadStats(vds []*view.Data) error {
-	span := trace.NewSpan(
+	ctx, span := trace.StartSpan(
+		context.Background(),
 		"go.opencensus.io/exporter/stackdriver.uploadStats",
-		nil,
-		trace.StartOptions{Sampler: trace.NeverSample()},
+		trace.WithSampler(trace.NeverSample()),
 	)
-	ctx := trace.WithSpan(context.Background(), span)
 	defer span.End()
 
 	for _, vd := range vds {

--- a/exporter/stackdriver/trace_proto_test.go
+++ b/exporter/stackdriver/trace_proto_test.go
@@ -57,19 +57,21 @@ func (t *testExporter) ExportSpan(s *trace.SpanData) {
 }
 
 func TestExportTrace(t *testing.T) {
+	ctx := context.Background()
+
 	var te testExporter
 	trace.RegisterExporter(&te)
 	defer trace.UnregisterExporter(&te)
 
-	span0 := trace.NewSpanWithRemoteParent(
+	ctx, span0 := trace.StartSpan(
+		ctx,
 		"span0",
-		trace.SpanContext{
+		trace.WithRemoteParent(trace.SpanContext{
 			TraceID:      traceID,
 			SpanID:       spanID,
 			TraceOptions: 1,
-		},
-		trace.StartOptions{})
-	ctx := trace.WithSpan(context.Background(), span0)
+		}),
+	)
 	{
 		ctx1, span1 := trace.StartSpan(ctx, "span1")
 		{

--- a/exporter/stackdriver/trace_proto_test.go
+++ b/exporter/stackdriver/trace_proto_test.go
@@ -63,14 +63,14 @@ func TestExportTrace(t *testing.T) {
 	trace.RegisterExporter(&te)
 	defer trace.UnregisterExporter(&te)
 
-	ctx, span0 := trace.StartSpan(
+	ctx, span0 := trace.StartSpanWithRemoteParent(
 		ctx,
 		"span0",
-		trace.WithRemoteParent(trace.SpanContext{
+		trace.SpanContext{
 			TraceID:      traceID,
 			SpanID:       spanID,
 			TraceOptions: 1,
-		}),
+		},
 	)
 	{
 		ctx1, span1 := trace.StartSpan(ctx, "span1")

--- a/exporter/stackdriver/trace_test.go
+++ b/exporter/stackdriver/trace_test.go
@@ -35,9 +35,8 @@ func TestBundling(t *testing.T) {
 	}
 	trace.RegisterExporter(exporter)
 
-	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 	for i := 0; i < 35; i++ {
-		_, span := trace.StartSpan(context.Background(), "span")
+		_, span := trace.StartSpan(context.Background(), "span", trace.WithSampler(trace.AlwaysSample()))
 		span.End()
 	}
 

--- a/plugin/ocgrpc/grpc_test.go
+++ b/plugin/ocgrpc/grpc_test.go
@@ -35,10 +35,7 @@ func TestClientHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	span := trace.NewSpan("/foo", nil, trace.StartOptions{
-		Sampler: trace.AlwaysSample(),
-	})
-	ctx = trace.WithSpan(ctx, span)
+	ctx, _ = trace.StartSpan(ctx, "/foo", trace.WithSampler(trace.AlwaysSample()))
 
 	var handler ClientHandler
 	ctx = handler.TagRPC(ctx, &stats.RPCTagInfo{

--- a/plugin/ocgrpc/trace_common.go
+++ b/plugin/ocgrpc/trace_common.go
@@ -65,8 +65,7 @@ func (s *ServerHandler) traceTagRPC(ctx context.Context, rti *stats.RPCTagInfo) 
 		traceContextBinary := []byte(traceContext[0])
 		parent, haveParent = propagation.FromBinary(traceContextBinary)
 		if haveParent && !s.IsPublicEndpoint {
-			ctx, _ := trace.StartSpan(ctx, name,
-				trace.WithRemoteParent(parent),
+			ctx, _ := trace.StartSpanWithRemoteParent(ctx, name, parent,
 				trace.WithSpanKind(trace.SpanKindServer),
 				trace.WithSampler(s.StartOptions.Sampler),
 			)

--- a/plugin/ocgrpc/trace_common.go
+++ b/plugin/ocgrpc/trace_common.go
@@ -36,11 +36,9 @@ const traceContextKey = "grpc-trace-bin"
 func (c *ClientHandler) traceTagRPC(ctx context.Context, rti *stats.RPCTagInfo) context.Context {
 	name := strings.TrimPrefix(rti.FullMethodName, "/")
 	name = strings.Replace(name, "/", ".", -1)
-	span := trace.NewSpan(name, trace.FromContext(ctx), trace.StartOptions{
-		Sampler:  c.StartOptions.Sampler,
-		SpanKind: trace.SpanKindClient,
-	}) // span is ended by traceHandleRPC
-	ctx = trace.WithSpan(ctx, span)
+	ctx, span := trace.StartSpan(ctx, name,
+		trace.WithSampler(c.StartOptions.Sampler),
+		trace.WithSpanKind(trace.SpanKindClient)) // span is ended by traceHandleRPC
 	traceContextBinary := propagation.Binary(span.SpanContext())
 	return metadata.AppendToOutgoingContext(ctx, traceContextKey, string(traceContextBinary))
 }
@@ -52,11 +50,6 @@ func (c *ClientHandler) traceTagRPC(ctx context.Context, rti *stats.RPCTagInfo) 
 //
 // It returns ctx, with the new trace span added.
 func (s *ServerHandler) traceTagRPC(ctx context.Context, rti *stats.RPCTagInfo) context.Context {
-	opts := trace.StartOptions{
-		Sampler:  s.StartOptions.Sampler,
-		SpanKind: trace.SpanKindServer,
-	}
-
 	md, _ := metadata.FromIncomingContext(ctx)
 	name := strings.TrimPrefix(rti.FullMethodName, "/")
 	name = strings.Replace(name, "/", ".", -1)
@@ -72,15 +65,21 @@ func (s *ServerHandler) traceTagRPC(ctx context.Context, rti *stats.RPCTagInfo) 
 		traceContextBinary := []byte(traceContext[0])
 		parent, haveParent = propagation.FromBinary(traceContextBinary)
 		if haveParent && !s.IsPublicEndpoint {
-			span := trace.NewSpanWithRemoteParent(name, parent, opts)
-			return trace.WithSpan(ctx, span)
+			ctx, _ := trace.StartSpan(ctx, name,
+				trace.WithRemoteParent(parent),
+				trace.WithSpanKind(trace.SpanKindServer),
+				trace.WithSampler(s.StartOptions.Sampler),
+			)
+			return ctx
 		}
 	}
-	span := trace.NewSpan(name, nil, opts)
+	ctx, span := trace.StartSpan(ctx, name,
+		trace.WithSpanKind(trace.SpanKindServer),
+		trace.WithSampler(s.StartOptions.Sampler))
 	if haveParent {
 		span.AddLink(trace.Link{TraceID: parent.TraceID, SpanID: parent.SpanID, Type: trace.LinkTypeChild})
 	}
-	return trace.WithSpan(ctx, span)
+	return ctx
 }
 
 func traceHandleRPC(ctx context.Context, rs stats.RPCStats) {

--- a/plugin/ochttp/server.go
+++ b/plugin/ochttp/server.go
@@ -81,8 +81,7 @@ func (h *Handler) startTrace(w http.ResponseWriter, r *http.Request) (*http.Requ
 	var span *trace.Span
 	sc, ok := h.extractSpanContext(r)
 	if ok && !h.IsPublicEndpoint {
-		ctx, span = trace.StartSpan(ctx, name,
-			trace.WithRemoteParent(sc),
+		ctx, span = trace.StartSpanWithRemoteParent(ctx, name, sc,
 			trace.WithSampler(h.StartOptions.Sampler),
 			trace.WithSpanKind(trace.SpanKindServer))
 	} else {

--- a/plugin/ochttp/trace.go
+++ b/plugin/ochttp/trace.go
@@ -53,10 +53,11 @@ func (t *traceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	name := spanNameFromURL(req.URL)
 	// TODO(jbd): Discuss whether we want to prefix
 	// outgoing requests with Sent.
-	parent := trace.FromContext(req.Context())
-	span := trace.NewSpan(name, parent, t.startOptions)
-	req = req.WithContext(trace.WithSpan(req.Context(), span))
+	_, span := trace.StartSpan(req.Context(), name,
+		trace.WithSampler(t.startOptions.Sampler),
+		trace.WithSpanKind(trace.SpanKindClient))
 
+	req = req.WithContext(trace.WithSpan(req.Context(), span))
 	if t.format != nil {
 		t.format.SpanContextToRequest(span.SpanContext(), req)
 	}

--- a/plugin/ochttp/trace_test.go
+++ b/plugin/ochttp/trace_test.go
@@ -73,7 +73,8 @@ func (t testPropagator) SpanContextToRequest(sc trace.SpanContext, req *http.Req
 }
 
 func TestTransport_RoundTrip(t *testing.T) {
-	parent := trace.NewSpan("parent", nil, trace.StartOptions{})
+	ctx := context.Background()
+	ctx, parent := trace.StartSpan(ctx, "parent")
 	tests := []struct {
 		name   string
 		parent *trace.Span
@@ -221,12 +222,9 @@ func TestEndToEnd(t *testing.T) {
 			url := serveHTTP(tt.handler, serverDone, serverReturn)
 
 			// Start a root Span in the client.
-			root := trace.NewSpan(
-				"top-level",
-				nil,
-				trace.StartOptions{})
-			ctx := trace.WithSpan(context.Background(), root)
-
+			ctx, root := trace.StartSpan(
+				context.Background(),
+				"top-level")
 			// Make the request.
 			req, err := http.NewRequest(
 				http.MethodPost,
@@ -278,7 +276,7 @@ func TestEndToEnd(t *testing.T) {
 						t.Errorf("Span name: %q; want %q", got, want)
 					}
 				default:
-					t.Fatalf("server or client span missing")
+					t.Fatalf("server or client span missing; kind = %v", sp.SpanKind)
 				}
 			}
 

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -97,7 +97,14 @@ func FromContext(ctx context.Context) *Span {
 }
 
 // WithSpan returns a new context with the given Span attached.
+//
+// Deprecated: Use NewContext.
 func WithSpan(parent context.Context, s *Span) context.Context {
+	return NewContext(parent, s)
+}
+
+// NewContext returns a new context with the given Span attached.
+func NewContext(parent context.Context, s *Span) context.Context {
 	return context.WithValue(parent, contextKey{}, s)
 }
 
@@ -146,6 +153,12 @@ func WithSampler(sampler Sampler) StartOption {
 }
 
 // WithRemoteParent makes new spans to be the child of the given part.
+//
+// WithRemoteParent is used to set a parent that has been
+// propagated in an incoming request or RPC.
+//
+// If there is already a parent in the incoming context.Context,
+// this option replaces it with the given parent.
 func WithRemoteParent(parent SpanContext) StartOption {
 	return func(o *StartOptions) {
 		o.remoteParent = parent

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -109,22 +109,16 @@ func TestSampling(t *testing.T) {
 				SpanID:       sid,
 				TraceOptions: test.parentTraceOptions,
 			}
-			ctx, _ = startSpanWithRemoteParent(context.Background(), "foo", sc, StartOptions{
-				Sampler: test.sampler,
-			})
+			ctx, _ = StartSpan(context.Background(), "foo", WithRemoteParent(sc), WithSampler(test.sampler))
 		} else if test.localParent {
 			sampler := NeverSample()
 			if test.parentTraceOptions == 1 {
 				sampler = AlwaysSample()
 			}
-			ctx2, _ := startSpanWithOptions(context.Background(), "foo", StartOptions{Sampler: sampler})
-			ctx, _ = startSpanWithOptions(ctx2, "foo", StartOptions{
-				Sampler: test.sampler,
-			})
+			ctx2, _ := StartSpan(context.Background(), "foo", WithSampler(sampler))
+			ctx, _ = StartSpan(ctx2, "foo", WithSampler(test.sampler))
 		} else {
-			ctx, _ = startSpanWithOptions(context.Background(), "foo", StartOptions{
-				Sampler: test.sampler,
-			})
+			ctx, _ = StartSpan(context.Background(), "foo", WithSampler(test.sampler))
 		}
 		sc := FromContext(ctx).SpanContext()
 		if (sc == SpanContext{}) {
@@ -159,7 +153,7 @@ func TestSampling(t *testing.T) {
 			if test.parentTraceOptions == 1 {
 				sampler = AlwaysSample()
 			}
-			ctx2, _ := startSpanWithOptions(context.Background(), "foo", StartOptions{Sampler: sampler})
+			ctx2, _ := StartSpan(context.Background(), "foo", WithSampler(sampler))
 			ctx, _ := StartSpan(ctx2, "foo")
 			sc := FromContext(ctx).SpanContext()
 			if (sc == SpanContext{}) {
@@ -180,9 +174,7 @@ func TestSampling(t *testing.T) {
 func TestProbabilitySampler(t *testing.T) {
 	exported := 0
 	for i := 0; i < 1000; i++ {
-		_, span := startSpanWithOptions(context.Background(), "foo", StartOptions{
-			Sampler: ProbabilitySampler(0.3),
-		})
+		_, span := StartSpan(context.Background(), "foo", WithSampler(ProbabilitySampler(0.3)))
 		if span.SpanContext().IsSampled() {
 			exported++
 		}
@@ -192,23 +184,18 @@ func TestProbabilitySampler(t *testing.T) {
 	}
 }
 
-func startSpanWithRemoteParent(ctx context.Context, name string, parent SpanContext, o StartOptions) (context.Context, *Span) {
-	span := NewSpanWithRemoteParent(name, parent, o)
-	return WithSpan(ctx, span), span
-}
-
 func TestStartSpanWithRemoteParent(t *testing.T) {
 	sc := SpanContext{
 		TraceID:      tid,
 		SpanID:       sid,
 		TraceOptions: 0x0,
 	}
-	ctx, _ := startSpanWithRemoteParent(context.Background(), "startSpanWithRemoteParent", sc, StartOptions{})
+	ctx, _ := StartSpan(context.Background(), "startSpanWithRemoteParent", WithRemoteParent(sc))
 	if err := checkChild(sc, FromContext(ctx)); err != nil {
 		t.Error(err)
 	}
 
-	ctx, _ = startSpanWithRemoteParent(context.Background(), "startSpanWithRemoteParent", sc, StartOptions{})
+	ctx, _ = StartSpan(context.Background(), "startSpanWithRemoteParent", WithRemoteParent(sc))
 	if err := checkChild(sc, FromContext(ctx)); err != nil {
 		t.Error(err)
 	}
@@ -218,12 +205,12 @@ func TestStartSpanWithRemoteParent(t *testing.T) {
 		SpanID:       sid,
 		TraceOptions: 0x1,
 	}
-	ctx, _ = startSpanWithRemoteParent(context.Background(), "startSpanWithRemoteParent", sc, StartOptions{})
+	ctx, _ = StartSpan(context.Background(), "startSpanWithRemoteParent", WithRemoteParent(sc))
 	if err := checkChild(sc, FromContext(ctx)); err != nil {
 		t.Error(err)
 	}
 
-	ctx, _ = startSpanWithRemoteParent(context.Background(), "startSpanWithRemoteParent", sc, StartOptions{})
+	ctx, _ = StartSpan(context.Background(), "startSpanWithRemoteParent", WithRemoteParent(sc))
 	if err := checkChild(sc, FromContext(ctx)); err != nil {
 		t.Error(err)
 	}
@@ -237,14 +224,18 @@ func TestStartSpanWithRemoteParent(t *testing.T) {
 
 // startSpan returns a context with a new Span that is recording events and will be exported.
 func startSpan(o StartOptions) *Span {
-	return NewSpanWithRemoteParent("span0",
-		SpanContext{
-			TraceID:      tid,
-			SpanID:       sid,
-			TraceOptions: 1,
-		},
-		o,
+	_, span := StartSpan(context.Background(), "span0",
+		WithSampler(o.Sampler),
+		WithSpanKind(o.SpanKind),
+		WithRemoteParent(
+			SpanContext{
+				TraceID:      tid,
+				SpanID:       sid,
+				TraceOptions: 1,
+			},
+		),
 	)
+	return span
 }
 
 type testExporter struct {
@@ -585,18 +576,12 @@ func (e exporter) ExportSpan(s *SpanData) {
 	e[s.Name] = s
 }
 
-func startSpanWithOptions(ctx context.Context, name string, o StartOptions) (context.Context, *Span) {
-	parentSpan, _ := ctx.Value(contextKey{}).(*Span)
-	span := NewSpan(name, parentSpan, o)
-	return WithSpan(ctx, span), span
-}
-
 func Test_Issue328_EndSpanTwice(t *testing.T) {
 	spans := make(exporter)
 	RegisterExporter(&spans)
 	defer UnregisterExporter(&spans)
 	ctx := context.Background()
-	ctx, span := startSpanWithOptions(ctx, "span-1", StartOptions{Sampler: AlwaysSample()})
+	ctx, span := StartSpan(ctx, "span-1", WithSampler(AlwaysSample()))
 	span.End()
 	span.End()
 	UnregisterExporter(&spans)
@@ -609,12 +594,12 @@ func TestStartSpanAfterEnd(t *testing.T) {
 	spans := make(exporter)
 	RegisterExporter(&spans)
 	defer UnregisterExporter(&spans)
-	ctx, span0 := startSpanWithOptions(context.Background(), "parent", StartOptions{Sampler: AlwaysSample()})
-	ctx1, span1 := startSpanWithOptions(ctx, "span-1", StartOptions{Sampler: AlwaysSample()})
+	ctx, span0 := StartSpan(context.Background(), "parent", WithSampler(AlwaysSample()))
+	ctx1, span1 := StartSpan(ctx, "span-1", WithSampler(AlwaysSample()))
 	span1.End()
 	// Start a new span with the context containing span-1
 	// even though span-1 is ended, we still add this as a new child of span-1
-	_, span2 := startSpanWithOptions(ctx1, "span-2", StartOptions{Sampler: AlwaysSample()})
+	_, span2 := StartSpan(ctx1, "span-2", WithSampler(AlwaysSample()))
 	span2.End()
 	span0.End()
 	UnregisterExporter(&spans)

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -109,7 +109,7 @@ func TestSampling(t *testing.T) {
 				SpanID:       sid,
 				TraceOptions: test.parentTraceOptions,
 			}
-			ctx, _ = StartSpan(context.Background(), "foo", WithRemoteParent(sc), WithSampler(test.sampler))
+			ctx, _ = StartSpanWithRemoteParent(context.Background(), "foo", sc, WithSampler(test.sampler))
 		} else if test.localParent {
 			sampler := NeverSample()
 			if test.parentTraceOptions == 1 {
@@ -190,12 +190,12 @@ func TestStartSpanWithRemoteParent(t *testing.T) {
 		SpanID:       sid,
 		TraceOptions: 0x0,
 	}
-	ctx, _ := StartSpan(context.Background(), "startSpanWithRemoteParent", WithRemoteParent(sc))
+	ctx, _ := StartSpanWithRemoteParent(context.Background(), "startSpanWithRemoteParent", sc)
 	if err := checkChild(sc, FromContext(ctx)); err != nil {
 		t.Error(err)
 	}
 
-	ctx, _ = StartSpan(context.Background(), "startSpanWithRemoteParent", WithRemoteParent(sc))
+	ctx, _ = StartSpanWithRemoteParent(context.Background(), "startSpanWithRemoteParent", sc)
 	if err := checkChild(sc, FromContext(ctx)); err != nil {
 		t.Error(err)
 	}
@@ -205,12 +205,12 @@ func TestStartSpanWithRemoteParent(t *testing.T) {
 		SpanID:       sid,
 		TraceOptions: 0x1,
 	}
-	ctx, _ = StartSpan(context.Background(), "startSpanWithRemoteParent", WithRemoteParent(sc))
+	ctx, _ = StartSpanWithRemoteParent(context.Background(), "startSpanWithRemoteParent", sc)
 	if err := checkChild(sc, FromContext(ctx)); err != nil {
 		t.Error(err)
 	}
 
-	ctx, _ = StartSpan(context.Background(), "startSpanWithRemoteParent", WithRemoteParent(sc))
+	ctx, _ = StartSpanWithRemoteParent(context.Background(), "startSpanWithRemoteParent", sc)
 	if err := checkChild(sc, FromContext(ctx)); err != nil {
 		t.Error(err)
 	}
@@ -224,16 +224,14 @@ func TestStartSpanWithRemoteParent(t *testing.T) {
 
 // startSpan returns a context with a new Span that is recording events and will be exported.
 func startSpan(o StartOptions) *Span {
-	_, span := StartSpan(context.Background(), "span0",
+	_, span := StartSpanWithRemoteParent(context.Background(), "span0",
+		SpanContext{
+			TraceID:      tid,
+			SpanID:       sid,
+			TraceOptions: 1,
+		},
 		WithSampler(o.Sampler),
 		WithSpanKind(o.SpanKind),
-		WithRemoteParent(
-			SpanContext{
-				TraceID:      tid,
-				SpanID:       sid,
-				TraceOptions: 1,
-			},
-		),
 	)
 	return span
 }


### PR DESCRIPTION
Required to support the Go execution tracer spans.

Fixes #694.