### PR TITLE
unregister should properly delete View

### DIFF
--- a/stats/view/view_test.go
+++ b/stats/view/view_test.go
@@ -371,3 +371,31 @@ func containsRow(rows []*Row, r *Row) bool {
 	}
 	return false
 }
+
+func TestRegisterUnregisterParity(t *testing.T) {
+	measures := []stats.Measure{
+		stats.Int64("ifoo", "iFOO", "iBar"),
+		stats.Float64("ffoo", "fFOO", "fBar"),
+	}
+	aggregations := []*Aggregation{
+		Count(),
+		Sum(),
+		Distribution(1, 2.0, 4.0, 8.0, 16.0),
+	}
+
+	for i := 0; i < 10; i++ {
+		for _, m := range measures {
+			for _, agg := range aggregations {
+				v := &View{
+					Aggregation: agg,
+					Name:        "Lookup here",
+					Measure:     m,
+				}
+				if err := Register(v); err != nil {
+					t.Errorf("Iteration #%d:\nMeasure: (%#v)\nAggregation (%#v)\nError: %v", i, m, agg, err)
+				}
+				Unregister(v)
+			}
+		}
+	}
+}

--- a/stats/view/worker.go
+++ b/stats/view/worker.go
@@ -86,7 +86,7 @@ func Unregister(views ...*View) {
 	for i := range views {
 		names[i] = views[i].Name
 	}
-	req := &unsubscribeFromViewReq{
+	req := &unregisterFromViewReq{
 		views: names,
 		done:  make(chan struct{}),
 	}

--- a/stats/view/worker_commands.go
+++ b/stats/view/worker_commands.go
@@ -73,15 +73,15 @@ func (cmd *registerViewReq) handleCommand(w *worker) {
 	}
 }
 
-// unsubscribeFromViewReq is the command to unsubscribe to a view. Has no
+// unregisterFromViewReq is the command to unsubscribe to a view. Has no
 // impact on the data collection for client that are pulling data from the
 // library.
-type unsubscribeFromViewReq struct {
+type unregisterFromViewReq struct {
 	views []string
 	done  chan struct{}
 }
 
-func (cmd *unsubscribeFromViewReq) handleCommand(w *worker) {
+func (cmd *unregisterFromViewReq) handleCommand(w *worker) {
 	for _, name := range cmd.views {
 		vi, ok := w.views[name]
 		if !ok {
@@ -94,6 +94,7 @@ func (cmd *unsubscribeFromViewReq) handleCommand(w *worker) {
 			// The collected data can be cleared.
 			vi.clearRows()
 		}
+		delete(w.views, name)
 	}
 	cmd.done <- struct{}{}
 }


### PR DESCRIPTION
Fixes #706
Fixes #710

Confusion that came from having two APIs:
a) Unregister
b) Unsubscribe

that initially had different purposes:
a) To completely remove the view from the underlying worker
b) To keep a reference to it but not completely remove it

However the difference between the two manifested in a bug
because we mistakenly assumed the subtle difference between
them never existed, hence on agreeing to deprecate Unsubscribe
for Unregister, the logic for Unsubscribe was kept but that
for Unregister was already lost in previous API changes in
PR https://github.com/census-instrumentation/opencensus-go/pull/492.

PR https://github.com/census-instrumentation/opencensus-go/pull/615
then naively folded Unsubscribe into Unregister and the bug then
fully manifested and could be tested by creating the same view with
a distribution aggregation in a loop and error-ing if Register fails.

With this change, I've also added a test that registers views of
different types, unregisters them in a loop and checks that we
don't error -- which is the original reproducer.
Also while here, just remove the vestiges of unsubscribeViewReq
to solidify the intent and name to unregisterViewReq.