### PR TITLE
Create a Go execution tracer task for each span

### DIFF
--- a/trace/trace_go11.go
+++ b/trace/trace_go11.go
@@ -1,0 +1,26 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build go1.11
+
+package trace
+
+import (
+	"context"
+	t "runtime/trace"
+)
+
+func startExecutionTracerSpan(ctx context.Context, name string) (context.Context, func()) {
+	return t.NewContext(ctx, name)
+}

--- a/trace/trace_nongo11.go
+++ b/trace/trace_nongo11.go
@@ -1,0 +1,25 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !go1.11
+
+package trace
+
+import (
+	"context"
+)
+
+func startExecutionTracerSpan(ctx context.Context, name string) (context.Context, func()) {
+	return ctx, func() {}
+}


### PR DESCRIPTION
This allows us to associate OpenCensus spans with execution
tracer tasks and allow users to have fine-grained details
about the runtime events happened in the lifetime of a
distributed tracing span.