### PR TITLE
Don't end execution tracer task if none exists

### DIFF
--- a/trace/trace_go11.go
+++ b/trace/trace_go11.go
@@ -21,6 +21,6 @@ import (
 	t "runtime/trace"
 )
 
-func startExecutionTracerSpan(ctx context.Context, name string) (context.Context, func()) {
+func startExecutionTracerTask(ctx context.Context, name string) (context.Context, func()) {
 	return t.NewContext(ctx, name)
 }

--- a/trace/trace_nongo11.go
+++ b/trace/trace_nongo11.go
@@ -20,6 +20,6 @@ import (
 	"context"
 )
 
-func startExecutionTracerSpan(ctx context.Context, name string) (context.Context, func()) {
+func startExecutionTracerTask(ctx context.Context, name string) (context.Context, func()) {
 	return ctx, func() {}
 }


### PR DESCRIPTION
For spans created with NewSpanXXX, we cannot
create execution tracer tasks. Don't try to end
if none is created.

Fixes #717.