### PR TITLE
Don't enable execution tracer tasks if tracer is not enabled

### DIFF
--- a/trace/trace_go11.go
+++ b/trace/trace_go11.go
@@ -22,5 +22,10 @@ import (
 )
 
 func startExecutionTracerTask(ctx context.Context, name string) (context.Context, func()) {
+	if !t.IsEnabled() {
+		// Avoid additional overhead if
+		// runtime/trace is not enabled.
+		return ctx, func() {}
+	}
 	return t.NewContext(ctx, name)
 }


### PR DESCRIPTION
Fixes #722.

Before:
BenchmarkStartEndSpan/AlwaysSample-8         	 2000000	       761 ns/op	     664 B/op	       8 allocs/op
BenchmarkStartEndSpan/NeverSample-8          	 5000000	       370 ns/op	     216 B/op	       6 allocs/op
BenchmarkSpanWithAnnotations_3/AlwaysSample-8         	 1000000	      1428 ns/op	    1360 B/op	      14 allocs/op
BenchmarkSpanWithAnnotations_3/NeverSample-8          	 3000000	       426 ns/op	     240 B/op	       8 allocs/op
BenchmarkSpanWithAnnotations_6/AlwaysSample-8         	 1000000	      1722 ns/op	    1384 B/op	      16 allocs/op
BenchmarkSpanWithAnnotations_6/NeverSample-8          	 3000000	       482 ns/op	     264 B/op	      10 allocs/op
BenchmarkSpanID_DotString/AlwaysSample-8              	10000000	       224 ns/op	      56 B/op	       3 allocs/op
BenchmarkSpanID_DotString/NeverSample-8               	10000000	       222 ns/op	      56 B/op	       3 allocs/op

After:
BenchmarkStartEndSpan/AlwaysSample-8         	 2000000	       634 ns/op	     592 B/op	       5 allocs/op
BenchmarkStartEndSpan/NeverSample-8          	 5000000	       257 ns/op	     144 B/op	       3 allocs/op
BenchmarkSpanWithAnnotations_3/AlwaysSample-8         	 1000000	      1301 ns/op	    1288 B/op	      11 allocs/op
BenchmarkSpanWithAnnotations_3/NeverSample-8          	 5000000	       308 ns/op	     168 B/op	       5 allocs/op
BenchmarkSpanWithAnnotations_6/AlwaysSample-8         	 1000000	      1637 ns/op	    1312 B/op	      13 allocs/op
BenchmarkSpanWithAnnotations_6/NeverSample-8          	 5000000	       373 ns/op	     192 B/op	       7 allocs/op
BenchmarkSpanID_DotString/AlwaysSample-8              	10000000	       222 ns/op	      56 B/op	       3 allocs/op
BenchmarkSpanID_DotString/NeverSample-8               	10000000	       223 ns/op	      56 B/op	       3 allocs/op