### PR TITLE
Fix go get command

### DIFF
--- a/examples/grpc/README.md
+++ b/examples/grpc/README.md
@@ -7,7 +7,7 @@ This example uses:
 * Debugging exporters to print stats and traces to stdout.
 
 ```
-$ go get go.opencensus.io/examples/grpc
+$ go get go.opencensus.io/examples/grpc/...
 ```
 
 First, run the server:


### PR DESCRIPTION
Right now `go get` returns error:
`can't load package: package go.opencensus.io/examples/grpc: no Go files in /home/heliko/go/src/go.opencensus.io/examples/grpc`