### PR TITLE
Export LastValueData as Gauge for Prometheus exporter.

### DIFF
--- a/exporter/prometheus/prometheus.go
+++ b/exporter/prometheus/prometheus.go
@@ -257,7 +257,7 @@ func (c *collector) toMetric(desc *prometheus.Desc, v *view.View, row *view.Row)
 		return prometheus.NewConstMetric(desc, prometheus.UntypedValue, data.Value, tagValues(row.Tags)...)
 
 	case *view.LastValueData:
-		return prometheus.NewConstMetric(desc, prometheus.UntypedValue, data.Value, tagValues(row.Tags)...)
+		return prometheus.NewConstMetric(desc, prometheus.GaugeValue, data.Value, tagValues(row.Tags)...)
 
 	default:
 		return nil, fmt.Errorf("aggregation %T is not yet supported", v.Aggregation)

--- a/exporter/prometheus/prometheus_test.go
+++ b/exporter/prometheus/prometheus_test.go
@@ -45,6 +45,7 @@ func newView(measureName string, agg *view.Aggregation) *view.View {
 func TestOnlyCumulativeWindowSupported(t *testing.T) {
 	// See Issue https://github.com/census-instrumentation/opencensus-go/issues/214.
 	count1 := &view.CountData{Value: 1}
+	lastValue1 := &view.LastValueData{Value: 56.7}
 	tests := []struct {
 		vds  *view.Data
 		want int
@@ -60,6 +61,15 @@ func TestOnlyCumulativeWindowSupported(t *testing.T) {
 				View: newView("TestOnlyCumulativeWindowSupported/m2", view.Count()),
 				Rows: []*view.Row{
 					{Data: count1},
+				},
+			},
+			want: 1,
+		},
+		2: {
+			vds: &view.Data{
+				View: newView("TestOnlyCumulativeWindowSupported/m3", view.LastValue()),
+				Rows: []*view.Row{
+					{Data: lastValue1},
 				},
 			},
 			want: 1,


### PR DESCRIPTION
To be consistent with [specs](https://github.com/census-instrumentation/opencensus-specs/blob/master/stats/Export.md#aggregation-to-metric).