### PR TITLE
Note that only binaries should register exporters

### DIFF
--- a/stats/view/example_test.go
+++ b/stats/view/example_test.go
@@ -35,5 +35,5 @@ func Example() {
 		log.Fatal(err)
 	}
 
-	// Use stats.RegisterExporter to export collected data.
+	// Use view.RegisterExporter to export collected data.
 }

--- a/stats/view/export.go
+++ b/stats/view/export.go
@@ -37,6 +37,8 @@ type Exporter interface {
 // registered exporters. Once you no longer
 // want data to be exported, invoke UnregisterExporter
 // with the previously registered exporter.
+//
+// Binaries can register exporters, libraries shouldn't register exporters.
 func RegisterExporter(e Exporter) {
 	exportersMu.Lock()
 	defer exportersMu.Unlock()

--- a/trace/export.go
+++ b/trace/export.go
@@ -37,6 +37,8 @@ var (
 
 // RegisterExporter adds to the list of Exporters that will receive sampled
 // trace spans.
+//
+// Binaries can register exporters, libraries shouldn't register exporters.
 func RegisterExporter(e Exporter) {
 	exportersMu.Lock()
 	if exporters == nil {


### PR DESCRIPTION
Given user feedback, it seems like we are not vendor agnostic
for libraries. But it is due to the confusion that libraries should
not register any vendor specific exporters.

Improve the confusion by documenting libraries shouldn't
register vendor-specific exporters.