### PR TITLE
Support reading the values from a tag.Map

### DIFF
--- a/tag/map.go
+++ b/tag/map.go
@@ -33,6 +33,18 @@ type Map struct {
 	m map[Key]string
 }
 
+// GetTags reads the tags contained in the map. It shouldn't usually be
+// necessary to read the tags directly (normally views are used to aggregate
+// measures by tags), but this can be useful for debugging or transmitting tags
+// to a separate metrics system.
+func (m *Map) GetTags() map[string]string {
+	tags := make(map[string]string)
+	for k, v := range m.m {
+		tags[k.name] = v
+	}
+	return tags
+}
+
 // Value returns the value for the key if a value
 // for the key exists.
 func (m *Map) Value(k Key) (string, bool) {

--- a/tag/map_codec_test.go
+++ b/tag/map_codec_test.go
@@ -152,3 +152,14 @@ func TestDecode(t *testing.T) {
 		})
 	}
 }
+
+func TestGetTags(t *testing.T) {
+	m, err := Decode([]byte{0, 0, 2, 107, 49, 2, 118, 49})
+	if err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+	tags := m.GetTags()
+	if got, want := tags["k1"], "v1"; got != want {
+		t.Errorf("tags[k1] = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
This is needed so that we can use tag.Decode from Istio to
populate attributes based on the tag header.