### PR TITLE
Update cloud.google.com to v0.22.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -226,8 +226,6 @@
     "metadata",
     "naming",
     "peer",
-    "reflection",
-    "reflection/grpc_reflection_v1alpha",
     "resolver",
     "resolver/dns",
     "resolver/passthrough",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -9,8 +9,8 @@
     "monitoring/apiv3",
     "trace/apiv2"
   ]
-  revision = "29f476ffa9c4cd4fd14336b6043090ac1ad76733"
-  version = "v0.21.0"
+  revision = "056a55f54a6cc77b440b31a56a5e7c3982d32811"
+  version = "v0.22.0"
 
 [[projects]]
   branch = "master"
@@ -242,6 +242,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "1be7e5255452682d433fe616bb0987e00cb73c1172fe797b9b7a6fd2c1f53d37"
+  inputs-digest = "099e791acf9531cbb058b668139ef993c2eb6846b708caf44802e35f59bc2cee"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,6 +1,6 @@
 [[constraint]]
   name = "cloud.google.com/go"
-  version = "0.21.0"
+  version = "0.22.0"
 
 [[constraint]]
   branch = "master"


### PR DESCRIPTION
`0.x.y` constraints in Gopkg.toml are equivalent to `>= 0.x.y, < 0.(x+1).0`.  To keep in sync with [cloud.google.com/go](https://github.com/GoogleCloudPlatform/google-cloud-go), we have to bump its version in the `dep` manifest.

I'm also hoping to (re)boot a discussion in #703 by @johanbrandhorst regarding dependencies and when they should be updated.

From what I gather, [cloud.google.com/go](https://github.com/GoogleCloudPlatform/google-cloud-go) has a minor version bump roughly once a month. The other two dependencies `< 1.0.0` are [github.com/openzipkin/zipkin-go](https://github.com/openzipkin/zipkin-go) and [github.com/prometheus/client_golang](https://github.com/prometheus/client_golang).