### PR TITLE
[trace] Add default span attributes

### DIFF
--- a/trace/export.go
+++ b/trace/export.go
@@ -32,19 +32,20 @@ type Exporter interface {
 
 var (
 	exportersMu sync.Mutex
-	exporters   map[Exporter]struct{}
+	exporters   map[Exporter][]Attribute
 )
 
 // RegisterExporter adds to the list of Exporters that will receive sampled
-// trace spans.
+// trace spans. Passed attributes will be appended to every span that is
+// exported by this exporter.
 //
 // Binaries can register exporters, libraries shouldn't register exporters.
-func RegisterExporter(e Exporter) {
+func RegisterExporter(e Exporter, a ...Attribute) {
 	exportersMu.Lock()
 	if exporters == nil {
-		exporters = make(map[Exporter]struct{})
+		exporters = make(map[Exporter][]Attribute)
 	}
-	exporters[e] = struct{}{}
+	exporters[e] = a
 	exportersMu.Unlock()
 }
 

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -278,7 +278,13 @@ func (s *Span) End() {
 		if s.spanContext.IsSampled() {
 			// TODO: consider holding exportersMu for less time.
 			exportersMu.Lock()
-			for e := range exporters {
+			for e, defaultAttrs := range exporters {
+				if len(defaultAttrs) > 0 && sd.Attributes == nil {
+					sd.Attributes = make(map[string]interface{})
+				}
+				for _, attr := range defaultAttrs {
+					sd.Attributes[attr.key] = attr.value
+				}
 				e.ExportSpan(sd)
 			}
 			exportersMu.Unlock()


### PR DESCRIPTION
This adds default span attributes that can be submitted when registering
the exporter. All submitted attributes are set on every span when it's
being exported.

refs #707 