### PR TITLE
Be more permissive with 0.x.y dependencies

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,6 +1,10 @@
+# For v0.x.y dependencies, prefer adding a constraints of the form: version=">= 0.x.y"
+# to avoid locking to a particular minor version which can cause dep to not be
+# able to find a satisfying dependency graph.
+
 [[constraint]]
   name = "cloud.google.com/go"
-  version = "0.21.0"
+  version = ">=0.21.0"
 
 [[constraint]]
   branch = "master"
@@ -13,11 +17,11 @@
 
 [[constraint]]
   name = "github.com/openzipkin/zipkin-go"
-  version = "0.1.0"
+  version = ">=0.1.0"
 
 [[constraint]]
   name = "github.com/prometheus/client_golang"
-  version = "0.8.0"
+  version = ">=0.8.0"
 
 [[constraint]]
   branch = "master"


### PR DESCRIPTION
By default, dep won't permit updates to minor versions for default
version spec of versions less than 1.0.0. This causes headaches when
combining OpenCensus with other <1.0.0 dependencies, like the GCP SDK.

Since the Gopkg.toml exists primarily to permit ease of use of this
library for dep users, it seems like a better tradeoff to be more
permissive here, rather than force lock-step upgrades all the time.

See also: https://github.com/census-ecosystem/opencensus-go-exporter-stackdriver/pull/4