### PR TITLE
Avoid mention of NewMap in the documentation

### DIFF
--- a/stats/view/view_test.go
+++ b/stats/view/view_test.go
@@ -171,7 +171,7 @@ func Test_View_MeasureFloat64_AggregationDistribution(t *testing.T) {
 			}
 			ctx, err := tag.New(context.Background(), mods...)
 			if err != nil {
-				t.Errorf("%v: NewMap = %v", tc.label, err)
+				t.Errorf("%v: New = %v", tc.label, err)
 			}
 			view.addSample(tag.FromContext(ctx), r.f)
 		}

--- a/tag/map.go
+++ b/tag/map.go
@@ -28,13 +28,13 @@ type Tag struct {
 	Value string
 }
 
-// Map is a map of tags. Use NewMap to build tag maps.
+// Map is a map of tags. Use New to create a context containing
+// a new Map.
 type Map struct {
 	m map[Key]string
 }
 
-// Value returns the value for the key if a value
-// for the key exists.
+// Value returns the value for the key if a value for the key exists.
 func (m *Map) Value(k Key) (string, bool) {
 	if m == nil {
 		return "", false
@@ -47,7 +47,7 @@ func (m *Map) String() string {
 	if m == nil {
 		return "nil"
 	}
-	var keys []Key
+	keys := make([]Key, 0, len(m.m))
 	for k := range m.m {
 		keys = append(keys, k)
 	}
@@ -83,8 +83,8 @@ func (m *Map) delete(k Key) {
 	delete(m.m, k)
 }
 
-func newMap(sizeHint int) *Map {
-	return &Map{m: make(map[Key]string, sizeHint)}
+func newMap() *Map {
+	return &Map{m: make(map[Key]string)}
 }
 
 // Mutator modifies a tag map.
@@ -153,7 +153,7 @@ func Delete(k Key) Mutator {
 // originated from the incoming context and modified
 // with the provided mutators.
 func New(ctx context.Context, mutator ...Mutator) (context.Context, error) {
-	m := newMap(0)
+	m := newMap()
 	orig := FromContext(ctx)
 	if orig != nil {
 		for k, v := range orig.m {

--- a/tag/map_codec.go
+++ b/tag/map_codec.go
@@ -176,7 +176,7 @@ func Encode(m *Map) []byte {
 
 // Decode decodes the given []byte into a tag map.
 func Decode(bytes []byte) (*Map, error) {
-	ts := newMap(0)
+	ts := newMap()
 
 	eg := &encoderGRPC{
 		buf: bytes,

--- a/tag/map_codec_test.go
+++ b/tag/map_codec_test.go
@@ -80,7 +80,7 @@ func TestEncodeDecode(t *testing.T) {
 		}
 		ctx, err := New(context.Background(), mods...)
 		if err != nil {
-			t.Errorf("%v: NewMap = %v", tc.label, err)
+			t.Errorf("%v: New = %v", tc.label, err)
 		}
 
 		encoded := Encode(FromContext(ctx))

--- a/tag/map_test.go
+++ b/tag/map_test.go
@@ -33,7 +33,7 @@ func TestContext(t *testing.T) {
 		Insert(k2, "v2"),
 	)
 	got := FromContext(ctx)
-	want := newMap(2)
+	want := newMap()
 	want.insert(k1, "v1")
 	want.insert(k2, "v2")
 
@@ -51,7 +51,7 @@ func TestDo(t *testing.T) {
 		Insert(k2, "v2"),
 	)
 	got := FromContext(ctx)
-	want := newMap(2)
+	want := newMap()
 	want.insert(k1, "v1")
 	want.insert(k2, "v2")
 	Do(ctx, func(ctx context.Context) {
@@ -168,7 +168,7 @@ func TestNewMap(t *testing.T) {
 	}
 }
 
-func TestNewMapValidation(t *testing.T) {
+func TestNewValidation(t *testing.T) {
 	tests := []struct {
 		err  string
 		seed *Map
@@ -213,7 +213,7 @@ func TestNewMapValidation(t *testing.T) {
 }
 
 func makeTestTagMap(ids ...int) *Map {
-	m := newMap(len(ids))
+	m := newMap()
 	for _, v := range ids {
 		k, _ := NewKey(fmt.Sprintf("k%d", v))
 		m.m[k] = fmt.Sprintf("v%d", v)


### PR DESCRIPTION
The NewMap function does not exist - New seems to be the
only way to create a new map.

Also lose the map size hint in newMap - it's currently always
zero and can easily be reinstated later as an optimization if needed.

Also include trivial optimization to slice allocation in Map.String.