### PR TITLE
Omit nil check before executing command

### DIFF
--- a/stats/view/worker.go
+++ b/stats/view/worker.go
@@ -143,9 +143,7 @@ func (w *worker) start() {
 	for {
 		select {
 		case cmd := <-w.c:
-			if cmd != nil {
-				cmd.handleCommand(w)
-			}
+			cmd.handleCommand(w)
 		case <-w.timer.C:
 			w.reportUsage(time.Now())
 		case <-w.quit:


### PR DESCRIPTION
The if condition makes it appear as if a nil command is legitimate
to send, but nothing ever sends a nil command, and when the
channel is closed the goroutine returns immediately, so we will never
receive a nil value for that reason either.