### PR TITLE
Add a mechanism to filter spans at export time

### DIFF
--- a/trace/traceutil/doc.go
+++ b/trace/traceutil/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package traceutil contains utilities to support OpenCensus tracing.
+package traceutil

--- a/trace/traceutil/examples_test.go
+++ b/trace/traceutil/examples_test.go
@@ -1,0 +1,58 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package traceutil_test
+
+import (
+	"fmt"
+
+	"go.opencensus.io/trace"
+	"go.opencensus.io/trace/traceutil"
+	"golang.org/x/net/context"
+)
+
+type testExporter struct {
+	buf string
+}
+
+func (e *testExporter) ExportSpan(spanData *trace.SpanData) {
+	e.buf += spanData.Name + "\n"
+}
+
+func (e *testExporter) Flush() {
+	fmt.Print(e.buf)
+}
+
+func ExampleNewExcludeSpansExporter() {
+	ctx := context.Background()
+	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
+
+	filtered := traceutil.NewExcludeSpansExporter(
+		new(testExporter),
+		[]traceutil.SpanMatcher{
+			{NamePrefix: "io.opencensus.Excluded/", SpanKind: trace.SpanKindClient},
+		})
+	trace.RegisterExporter(filtered)
+
+	// Sampled and exported span:
+	_, span := trace.StartSpan(ctx, "io.opencensus.Included/SomeMethod", trace.WithSpanKind(trace.SpanKindClient))
+	span.End()
+
+	// Sampled, but not exported span:
+	_, span2 := trace.StartSpan(ctx, "io.opencensus.Excluded/SomeMethod", trace.WithSpanKind(trace.SpanKindClient))
+	span2.End()
+
+	filtered.Flush()
+	// Output: io.opencensus.Included/SomeMethod
+}

--- a/trace/traceutil/exclude_spans.go
+++ b/trace/traceutil/exclude_spans.go
@@ -1,0 +1,69 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package traceutil
+
+import (
+	"strings"
+
+	"go.opencensus.io/trace"
+)
+
+// ExcludeSpansExporter is an exporter that allows excluding specified spans by
+// name and span kind.
+type ExcludeSpansExporter struct {
+	e       trace.Exporter
+	exclude []SpanMatcher
+}
+
+// NewExcludeSpansExporter creates a new exporter that drops all spans that match
+// any of the given SpanMatchers.
+func NewExcludeSpansExporter(exporter trace.Exporter, excludeMatching []SpanMatcher) *ExcludeSpansExporter {
+	return &ExcludeSpansExporter{exporter, excludeMatching}
+}
+
+var _ ExportFlusher = (*ExcludeSpansExporter)(nil)
+
+// ExportSpan exports the given span data provided that it doesn't match any of
+// the excluded matchers.
+func (e *ExcludeSpansExporter) ExportSpan(spanData *trace.SpanData) {
+	exclude := true
+	for _, matcher := range e.exclude {
+		if !matcher.matches(spanData) {
+			exclude = false
+			break
+		}
+	}
+	if !exclude {
+		e.e.ExportSpan(spanData)
+	}
+}
+
+// Flush will flush the underlying exporter if this is supported.
+func (e *ExcludeSpansExporter) Flush() {
+	if fl, ok := e.e.(ExportFlusher); ok {
+		fl.Flush()
+	}
+}
+
+// SpanMatcher selects spans by name and kind. Both name and kind must match in
+// order for the SpanMatcher to match.
+type SpanMatcher struct {
+	NamePrefix string // NamePrefix is a prefix of all matching span names.
+	SpanKind   int    // SpanKind is the span kind of all matching spans.
+}
+
+func (sm SpanMatcher) matches(spanData *trace.SpanData) bool {
+	return spanData.SpanKind == sm.SpanKind && strings.HasPrefix(spanData.Name, sm.NamePrefix)
+}

--- a/trace/traceutil/exclude_spans_test.go
+++ b/trace/traceutil/exclude_spans_test.go
@@ -1,0 +1,74 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package traceutil
+
+import (
+	"testing"
+
+	"go.opencensus.io/trace"
+)
+
+type testExporter struct {
+	exported []*trace.SpanData
+	flushed  bool
+}
+
+func (e *testExporter) ExportSpan(spanData *trace.SpanData) {
+	e.exported = append(e.exported, spanData)
+}
+
+func (e *testExporter) Flush() {
+	e.flushed = true
+}
+
+func TestExcludeSpans_AllExcluded(t *testing.T) {
+	te := &testExporter{}
+	e := NewExcludeSpansExporter(te, nil)
+	e.ExportSpan(&trace.SpanData{})
+	if got, want := len(te.exported), 0; got != want {
+		t.Fatalf("len(te.exported) = %d; want %d", got, want)
+	}
+}
+
+func TestExcludeSpans(t *testing.T) {
+	te := &testExporter{}
+	e := NewExcludeSpansExporter(te, []SpanMatcher{
+		{NamePrefix: "/com.example.HelloWorld", SpanKind: trace.SpanKindClient},
+	})
+
+	e.ExportSpan(&trace.SpanData{
+		Name:     "/com.example.HelloWorld.SayHello",
+		SpanKind: trace.SpanKindClient,
+	})
+	if got, want := len(te.exported), 0; got != want {
+		t.Fatalf("len(te.exported) = %d; want %d", got, want)
+	}
+
+	e.ExportSpan(&trace.SpanData{
+		Name:     "/com.example.NoMatch.SayHello",
+		SpanKind: trace.SpanKindClient,
+	})
+	if got, want := len(te.exported), 1; got != want {
+		t.Fatalf("len(te.exported) = %d; want %d", got, want)
+	}
+
+	e.ExportSpan(&trace.SpanData{
+		Name:     "/com.example.HelloWorld.SayHello",
+		SpanKind: trace.SpanKindServer,
+	})
+	if got, want := len(te.exported), 2; got != want {
+		t.Fatalf("len(te.exported) = %d; want %d", got, want)
+	}
+}

--- a/trace/traceutil/export_flusher.go
+++ b/trace/traceutil/export_flusher.go
@@ -1,0 +1,25 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package traceutil
+
+import "go.opencensus.io/trace"
+
+// ExportFlusher extends Exporter to support synchronous flushing of any
+// internal buffered spans. As with most aspects of exporting, it is
+// best-effort only.
+type ExportFlusher interface {
+	trace.Exporter
+	Flush() // Flush synchronously sends any internally buffered spans.
+}


### PR DESCRIPTION
This change is designed to address:
GoogleCloudPlatform/google-cloud-go#1008