### PR TITLE
Export a variable with the current version, for use by exporters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,4 @@ script:
   - go vet ./...
   - go test -v -race $PKGS            # Run all the tests with the race detector enabled
   - 'if [[ $TRAVIS_GO_VERSION = 1.8* ]]; then ! golint ./... | grep -vE "(_mock|_string|\.pb)\.go:"; fi'
+  - go run internal/check/version.go

--- a/exporterutil/version.go
+++ b/exporterutil/version.go
@@ -1,0 +1,20 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package exporterutil contains common utilities for exporter implementations.
+package exporterutil
+
+// Version is the current release version of OpenCensus in use. It is made
+// available for exporters to include in User-Agent-like metadata.
+var Version = "0.12.0"

--- a/internal/check/version.go
+++ b/internal/check/version.go
@@ -1,0 +1,88 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command version checks that the version string matches the latest Git tag.
+// This is expected to pass only on the master branch.
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+
+	"go.opencensus.io/exporterutil"
+)
+
+func main() {
+	cmd := exec.Command("git", "tag")
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	err := cmd.Run()
+	if err != nil {
+		log.Fatal(err)
+	}
+	var versions []version
+	for _, vStr := range strings.Split(buf.String(), "\n") {
+		if len(vStr) == 0 {
+			continue
+		}
+		versions = append(versions, parseVersion(vStr))
+	}
+	sort.Slice(versions, func(i, j int) bool {
+		return versionLess(versions[i], versions[j])
+	})
+	latest := versions[len(versions)-1]
+	codeVersion := parseVersion("v" + exporterutil.Version)
+	if !versionLess(latest, codeVersion) {
+		fmt.Printf("exporterutil.Version is out of date with Git tags. Got %s; want %s\n", latest, exporterutil.Version)
+		os.Exit(1)
+	}
+	fmt.Printf("exporterutil.Version is up-to-date: %s\n", exporterutil.Version)
+}
+
+type version [3]int
+
+func versionLess(v1, v2 version) bool {
+	for c := 0; c < 3; c++ {
+		if diff := v1[c] - v2[c]; diff != 0 {
+			return diff < 0
+		}
+	}
+	return false
+}
+
+func parseVersion(vStr string) version {
+	split := strings.Split(vStr[1:], ".")
+	var (
+		v   version
+		err error
+	)
+	for i := 0; i < 3; i++ {
+		v[i], err = strconv.Atoi(split[i])
+		if err != nil {
+			fmt.Printf("Unrecognized version tag %q: %s\n", vStr, err)
+			os.Exit(2)
+		}
+	}
+	return v
+}
+
+func (v version) String() string {
+	return fmt.Sprintf("%d.%d.%d", v[0], v[1], v[2])
+}

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -14,11 +14,16 @@
 
 package internal // import "go.opencensus.io/internal"
 
-import "time"
+import (
+	"fmt"
+	"time"
+
+	"go.opencensus.io/exporterutil"
+)
 
 // UserAgent is the user agent to be added to the outgoing
 // requests from the exporters.
-const UserAgent = "opencensus-go [0.12.0]"
+var UserAgent = fmt.Sprintf("opencensus-go [%s]", exporterutil.Version)
 
 // MonotonicEndTime returns the end time at present
 // but offset from start, monotonically.


### PR DESCRIPTION
See: census-ecosystem/opencensus-go-exporter-stackdriver#7