### PR TITLE
Set the report period shorter that the exported data could be printed

### DIFF
--- a/examples/helloworld/main.go
+++ b/examples/helloworld/main.go
@@ -54,6 +54,7 @@ func main() {
 		log.Fatal(err)
 	}
 	videoSize = stats.Int64("my.org/measure/video_size", "size of processed videos", stats.UnitBytes)
+	view.SetReportingPeriod(2 * time.Second)
 
 	// Create view to see the processed video size
 	// distribution broken down by frontend.


### PR DESCRIPTION
I set the reporting period as 2 seconds instead of the default value. In this way, the collected data could be exported by displaying on the console.