### PR TITLE
Span naming flexibility

### DIFF
--- a/plugin/ochttp/client.go
+++ b/plugin/ochttp/client.go
@@ -46,7 +46,7 @@ type Transport struct {
 	// NameFromRequest holds the function to use for generating the span name
 	// from the information found in the outgoing HTTP Request. By default the
 	// name equals the URL Path.
-	NameFromRequest func(*http.Request) string
+	FormatSpanName func(*http.Request) string
 
 	// TODO: Implement tag propagation for HTTP.
 }
@@ -59,9 +59,9 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if format == nil {
 		format = defaultFormat
 	}
-	nameFromRequest := t.NameFromRequest
-	if nameFromRequest == nil {
-		nameFromRequest = spanNameFromURL
+	spanNameFormatter := t.FormatSpanName
+	if spanNameFormatter == nil {
+		spanNameFormatter = spanNameFromURL
 	}
 	rt = &traceTransport{
 		base:   rt,
@@ -70,7 +70,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 			Sampler:  t.StartOptions.Sampler,
 			SpanKind: trace.SpanKindClient,
 		},
-		nameFromRequest: nameFromRequest,
+		formatSpanName: spanNameFormatter,
 	}
 	rt = statsTransport{base: rt}
 	return rt.RoundTrip(req)

--- a/plugin/ochttp/server.go
+++ b/plugin/ochttp/server.go
@@ -60,6 +60,11 @@ type Handler struct {
 	// be added as a linked trace instead of being added as a parent of the
 	// current trace.
 	IsPublicEndpoint bool
+
+	// NameFromRequest holds the function to use for generating the span name
+	// from the information found in the incoming HTTP Request. By default the
+	// name equals the URL Path.
+	NameFromRequest func(*http.Request) string
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -76,7 +81,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) startTrace(w http.ResponseWriter, r *http.Request) (*http.Request, func()) {
-	name := spanNameFromURL(r.URL)
+	var name string
+	if h.NameFromRequest == nil {
+		name = spanNameFromURL(r)
+	} else {
+		name = h.NameFromRequest(r)
+	}
 	ctx := r.Context()
 	var span *trace.Span
 	sc, ok := h.extractSpanContext(r)

--- a/plugin/ochttp/server.go
+++ b/plugin/ochttp/server.go
@@ -61,10 +61,10 @@ type Handler struct {
 	// current trace.
 	IsPublicEndpoint bool
 
-	// NameFromRequest holds the function to use for generating the span name
+	// FormatSpanName holds the function to use for generating the span name
 	// from the information found in the incoming HTTP Request. By default the
 	// name equals the URL Path.
-	NameFromRequest func(*http.Request) string
+	FormatSpanName func(*http.Request) string
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -82,10 +82,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) startTrace(w http.ResponseWriter, r *http.Request) (*http.Request, func()) {
 	var name string
-	if h.NameFromRequest == nil {
+	if h.FormatSpanName == nil {
 		name = spanNameFromURL(r)
 	} else {
-		name = h.NameFromRequest(r)
+		name = h.FormatSpanName(r)
 	}
 	ctx := r.Context()
 	var span *trace.Span

--- a/plugin/ochttp/server_test.go
+++ b/plugin/ochttp/server_test.go
@@ -309,7 +309,7 @@ func TestEnsureTrackingResponseWriterSetsStatusCode(t *testing.T) {
 			}()
 			inRes := tt.res
 			inRes.Body = prc
-			tr := &traceTransport{base: &testResponseTransport{res: inRes}, nameFromRequest: spanNameFromURL}
+			tr := &traceTransport{base: &testResponseTransport{res: inRes}, formatSpanName: spanNameFromURL}
 			req, err := http.NewRequest("POST", "https://example.org", bytes.NewReader([]byte("testing")))
 			if err != nil {
 				t.Fatalf("NewRequest error: %v", err)

--- a/plugin/ochttp/server_test.go
+++ b/plugin/ochttp/server_test.go
@@ -309,7 +309,7 @@ func TestEnsureTrackingResponseWriterSetsStatusCode(t *testing.T) {
 			}()
 			inRes := tt.res
 			inRes.Body = prc
-			tr := &traceTransport{base: &testResponseTransport{res: inRes}}
+			tr := &traceTransport{base: &testResponseTransport{res: inRes}, nameFromRequest: spanNameFromURL}
 			req, err := http.NewRequest("POST", "https://example.org", bytes.NewReader([]byte("testing")))
 			if err != nil {
 				t.Fatalf("NewRequest error: %v", err)

--- a/plugin/ochttp/trace.go
+++ b/plugin/ochttp/trace.go
@@ -17,7 +17,6 @@ package ochttp
 import (
 	"io"
 	"net/http"
-	"net/url"
 
 	"go.opencensus.io/plugin/ochttp/propagation/b3"
 	"go.opencensus.io/trace"
@@ -39,9 +38,10 @@ const (
 )
 
 type traceTransport struct {
-	base         http.RoundTripper
-	startOptions trace.StartOptions
-	format       propagation.HTTPFormat
+	base            http.RoundTripper
+	startOptions    trace.StartOptions
+	format          propagation.HTTPFormat
+	nameFromRequest func(*http.Request) string
 }
 
 // TODO(jbd): Add message events for request and response size.
@@ -50,7 +50,7 @@ type traceTransport struct {
 // The created span can follow a parent span, if a parent is presented in
 // the request's context.
 func (t *traceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	name := spanNameFromURL(req.URL)
+	name := t.nameFromRequest(req)
 	// TODO(jbd): Discuss whether we want to prefix
 	// outgoing requests with Sent.
 	_, span := trace.StartSpan(req.Context(), name,
@@ -127,8 +127,8 @@ func (t *traceTransport) CancelRequest(req *http.Request) {
 	}
 }
 
-func spanNameFromURL(u *url.URL) string {
-	return u.Path
+func spanNameFromURL(req *http.Request) string {
+	return req.URL.Path
 }
 
 func requestAttrs(r *http.Request) []trace.Attribute {

--- a/plugin/ochttp/trace.go
+++ b/plugin/ochttp/trace.go
@@ -38,10 +38,10 @@ const (
 )
 
 type traceTransport struct {
-	base            http.RoundTripper
-	startOptions    trace.StartOptions
-	format          propagation.HTTPFormat
-	nameFromRequest func(*http.Request) string
+	base           http.RoundTripper
+	startOptions   trace.StartOptions
+	format         propagation.HTTPFormat
+	formatSpanName func(*http.Request) string
 }
 
 // TODO(jbd): Add message events for request and response size.
@@ -50,7 +50,7 @@ type traceTransport struct {
 // The created span can follow a parent span, if a parent is presented in
 // the request's context.
 func (t *traceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	name := t.nameFromRequest(req)
+	name := t.formatSpanName(req)
 	// TODO(jbd): Discuss whether we want to prefix
 	// outgoing requests with Sent.
 	_, span := trace.StartSpan(req.Context(), name,

--- a/plugin/ochttp/trace_test.go
+++ b/plugin/ochttp/trace_test.go
@@ -375,8 +375,8 @@ func TestSpanNameFromURL(t *testing.T) {
 	}
 }
 
-func TestSpanNameFromRequest(t *testing.T) {
-	spanNameFromURLAndMethod := func(r *http.Request) string {
+func TestFormatSpanName(t *testing.T) {
+	formatSpanName := func(r *http.Request) string {
 		return r.Method + " " + r.URL.Path
 	}
 
@@ -384,14 +384,14 @@ func TestSpanNameFromRequest(t *testing.T) {
 		Handler: http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 			resp.Write([]byte("Hello, world!"))
 		}),
-		NameFromRequest: spanNameFromURLAndMethod,
+		FormatSpanName: formatSpanName,
 	}
 
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
 	client := &http.Client{
-		Transport: &Transport{NameFromRequest: spanNameFromURLAndMethod},
+		Transport: &Transport{FormatSpanName: formatSpanName},
 	}
 
 	tests := []struct {

--- a/plugin/ochttp/trace_test.go
+++ b/plugin/ochttp/trace_test.go
@@ -25,7 +25,6 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"reflect"
 	"strings"
 	"testing"
@@ -357,11 +356,11 @@ func TestSpanNameFromURL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.u, func(t *testing.T) {
-			u, err := url.Parse(tt.u)
+			req, err := http.NewRequest("GET", tt.u, nil)
 			if err != nil {
-				t.Errorf("url.Parse() = %v", err)
+				t.Errorf("url issue = %v", err)
 			}
-			if got := spanNameFromURL(u); got != tt.want {
+			if got := spanNameFromURL(req); got != tt.want {
 				t.Errorf("spanNameFromURL() = %v, want %v", got, tt.want)
 			}
 		})

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -310,6 +310,16 @@ func (s *Span) SpanContext() SpanContext {
 	return s.spanContext
 }
 
+// SetName sets the name of the span, if it is recording events.
+func (s *Span) SetName(name string) {
+	if !s.IsRecordingEvents() {
+		return
+	}
+	s.mu.Lock()
+	s.data.Name = name
+	s.mu.Unlock()
+}
+
 // SetStatus sets the status of the span, if it is recording events.
 func (s *Span) SetStatus(status Status) {
 	if !s.IsRecordingEvents() {

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -446,6 +446,30 @@ func TestMessageEvents(t *testing.T) {
 	}
 }
 
+func TestSetSpanName(t *testing.T) {
+	span := startSpan(StartOptions{})
+	span.SetName("NewName")
+	got, err := endSpan(span)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &SpanData{
+		SpanContext: SpanContext{
+			TraceID:      tid,
+			SpanID:       SpanID{},
+			TraceOptions: 0x1,
+		},
+		ParentSpanID:    sid,
+		Name:            "NewName",
+		Status:          Status{},
+		HasRemoteParent: true,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("exporting span: got %#v want %#v", got, want)
+	}
+}
+
 func TestSetSpanStatus(t *testing.T) {
 	span := startSpan(StartOptions{})
 	span.SetStatus(Status{Code: int32(1), Message: "request failed"})


### PR DESCRIPTION
This PR enables more flexibility in span naming for various use cases.

span.SetName() allows one to update the span name after creation time. This allows routing middlewares to update the span name to the matched route providing lower cardinality then path names (think REST services).

ochttp client and server handlers now allow for the span name to be generated from pluggable functions defaulting to the already existing spanNameFromURL.  This can be used if span naming conventions in a brown field deployment are different from OpenCensus defaults or if using URL constructors for REST services that can also report route templates instead of expanded URL path.