### PR TITLE
Fix race in RetrieveData

### DIFF
--- a/stats/view/collector.go
+++ b/stats/view/collector.go
@@ -40,11 +40,12 @@ func (c *collector) addSample(s string, v float64) {
 	aggregator.addSample(v)
 }
 
+// collectRows returns a snapshot of the collected Row values.
 func (c *collector) collectedRows(keys []tag.Key) []*Row {
-	var rows []*Row
+	rows := make([]*Row, 0, len(c.signatures))
 	for sig, aggregator := range c.signatures {
 		tags := decodeTags([]byte(sig), keys)
-		row := &Row{tags, aggregator}
+		row := &Row{Tags: tags, Data: aggregator.clone()}
 		rows = append(rows, row)
 	}
 	return rows

--- a/stats/view/worker.go
+++ b/stats/view/worker.go
@@ -204,9 +204,6 @@ func (w *worker) reportUsage(now time.Time) {
 		if !ok {
 			w.startTimes[v] = now
 		}
-		// Make sure collector is never going
-		// to mutate the exported data.
-		rows = deepCopyRowData(rows)
 		viewData := &Data{
 			View:  v.view,
 			Start: w.startTimes[v],
@@ -219,15 +216,4 @@ func (w *worker) reportUsage(now time.Time) {
 		}
 		exportersMu.Unlock()
 	}
-}
-
-func deepCopyRowData(rows []*Row) []*Row {
-	newRows := make([]*Row, 0, len(rows))
-	for _, r := range rows {
-		newRows = append(newRows, &Row{
-			Data: r.Data.clone(),
-			Tags: r.Tags,
-		})
-	}
-	return newRows
 }


### PR DESCRIPTION
RetrieveData previously would return pointers to internal
aggregators that might subsequently be mutated based on future
view updates.

Instead, have collectedRows always return an immutable snapshot
of the collected aggregators (by calling clone on each one).

Since we do this, we can also avoid a defensive copy on the normal
export path.