### PR TITLE
Do not enforce singleton property of Prometheus exporter

### DIFF
--- a/exporter/prometheus/example_test.go
+++ b/exporter/prometheus/example_test.go
@@ -29,7 +29,7 @@ func Example() {
 	}
 	view.RegisterExporter(exporter)
 
-	// Serve the scrap endpoint at localhost:9999.
+	// Serve the scrape endpoint on port 9999.
 	http.Handle("/metrics", exporter)
 	log.Fatal(http.ListenAndServe(":9999", nil))
 }

--- a/exporter/prometheus/prometheus.go
+++ b/exporter/prometheus/prometheus.go
@@ -12,14 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package prometheus contains a Prometheus exporter.
-//
-// Please note that this exporter is currently work in progress and not complete.
+// Package prometheus contains a Prometheus exporter that supports exporting
+// OpenCensus views as Prometheus metrics.
 package prometheus // import "go.opencensus.io/exporter/prometheus"
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -51,23 +49,8 @@ type Options struct {
 	OnError   func(err error)
 }
 
-var (
-	newExporterOnce      sync.Once
-	errSingletonExporter = errors.New("expecting only one exporter per instance")
-)
-
 // NewExporter returns an exporter that exports stats to Prometheus.
-// Only one exporter should exist per instance
 func NewExporter(o Options) (*Exporter, error) {
-	var err = errSingletonExporter
-	var exporter *Exporter
-	newExporterOnce.Do(func() {
-		exporter, err = newExporter(o)
-	})
-	return exporter, err
-}
-
-func newExporter(o Options) (*Exporter, error) {
 	if o.Registry == nil {
 		o.Registry = prometheus.NewRegistry()
 	}

--- a/exporter/prometheus/prometheus_test.go
+++ b/exporter/prometheus/prometheus_test.go
@@ -91,29 +91,10 @@ func TestOnlyCumulativeWindowSupported(t *testing.T) {
 	}
 }
 
-func TestSingletonExporter(t *testing.T) {
-	exp, err := NewExporter(Options{})
-	if err != nil {
-		t.Fatalf("NewExporter() = %v", err)
-	}
-	if exp == nil {
-		t.Fatal("Nil exporter")
-	}
-
-	// Should all now fail
-	exp, err = NewExporter(Options{})
-	if err == nil {
-		t.Fatal("NewExporter() = nil")
-	}
-	if exp != nil {
-		t.Fatal("Non-nil exporter")
-	}
-}
-
 func TestCollectNonRacy(t *testing.T) {
 	// Despite enforcing the singleton, for this case we
 	// need an exporter hence won't be using NewExporter.
-	exp, err := newExporter(Options{})
+	exp, err := NewExporter(Options{})
 	if err != nil {
 		t.Fatalf("NewExporter: %v", err)
 	}
@@ -202,7 +183,7 @@ func (vc *vCreator) createAndAppend(name, description string, keys []tag.Key, me
 }
 
 func TestMetricsEndpointOutput(t *testing.T) {
-	exporter, err := newExporter(Options{})
+	exporter, err := NewExporter(Options{})
 	if err != nil {
 		t.Fatalf("failed to create prometheus exporter: %v", err)
 	}
@@ -276,7 +257,7 @@ func TestMetricsEndpointOutput(t *testing.T) {
 }
 
 func TestCumulativenessFromHistograms(t *testing.T) {
-	exporter, err := newExporter(Options{})
+	exporter, err := NewExporter(Options{})
 	if err != nil {
 		t.Fatalf("failed to create prometheus exporter: %v", err)
 	}


### PR DESCRIPTION
It is unnecessarily defensive to enforce that only a single
instance of the Prometheus exporter is created.

Doing this gets in the way of using the exporter in systems where
exporters are created dynamically at runtime based on configuration,
such as Istio.