### PR TITLE
Allow setting the Zipkin LocalEndpoint per-span

### DIFF
--- a/exporter/zipkin/zipkin.go
+++ b/exporter/zipkin/zipkin.go
@@ -68,13 +68,13 @@ func (e *Exporter) ExportSpan(s *trace.SpanData) {
 }
 
 func (e *Exporter) spanLocalEndpoint(s *trace.SpanData) *model.Endpoint {
-	hostPoint, ok := s.Attributes[serviceEndpointKey].(string)
-	if !ok {
-		return e.localEndpoint
-	}
 	serviceName, ok := s.Attributes[serviceNameKey].(string)
 	if !ok {
 		return e.localEndpoint
+	}
+	hostPoint, ok := s.Attributes[serviceEndpointKey].(string)
+	if !ok {
+		hostPoint = defaultHostPort
 	}
 	ep, err := zipkin.NewEndpoint(serviceName, hostPoint)
 	if err != nil {
@@ -89,6 +89,8 @@ const (
 	statusDescriptionTagKey = "opencensus.status_description"
 	serviceNameKey          = "opencensus.service_name"
 	serviceEndpointKey      = "opencensus.service_endpoint"
+
+	defaultHostPort = "0.0.0.0:0"
 )
 
 var (

--- a/exporter/zipkin/zipkin.go
+++ b/exporter/zipkin/zipkin.go
@@ -19,6 +19,10 @@ import (
 	"encoding/binary"
 	"strconv"
 
+	"log"
+	"os"
+
+	"github.com/openzipkin/zipkin-go"
 	"github.com/openzipkin/zipkin-go/model"
 	"github.com/openzipkin/zipkin-go/reporter"
 	"go.opencensus.io/trace"
@@ -29,6 +33,11 @@ import (
 type Exporter struct {
 	reporter      reporter.Reporter
 	localEndpoint *model.Endpoint
+
+	// Logger will be used to report errors from this exporter.
+	Logger interface {
+		Printf(string, ...interface{})
+	}
 }
 
 // NewExporter returns an implementation of trace.Exporter that uploads spans
@@ -38,25 +47,48 @@ type Exporter struct {
 // can be created with the openzipkin library, using one of the packages under
 // github.com/openzipkin/zipkin-go/reporter.
 //
-// localEndpoint sets the local endpoint of exported spans.  It can be
+// localEndpoint sets the default local endpoint of exported spans.  It can be
 // constructed with github.com/openzipkin/zipkin-go.NewEndpoint, e.g.:
 // 	localEndpoint, err := NewEndpoint("my server", listener.Addr().String())
 // localEndpoint can be nil.
+//
+// localEndpoint can be overridden on a per-span basis by setting Span attributes
+// "zipkin.local_endpoint.service_name" and "zipkin.local_endpoint.host_port".
 func NewExporter(reporter reporter.Reporter, localEndpoint *model.Endpoint) *Exporter {
 	return &Exporter{
 		reporter:      reporter,
 		localEndpoint: localEndpoint,
+		Logger:        log.New(os.Stderr, "zipkin", log.LstdFlags),
 	}
 }
 
 // ExportSpan exports a span to a Zipkin server.
 func (e *Exporter) ExportSpan(s *trace.SpanData) {
-	e.reporter.Send(zipkinSpan(s, e.localEndpoint))
+	e.reporter.Send(e.zipkinSpan(s))
+}
+
+func (e *Exporter) spanLocalEndpoint(s *trace.SpanData) *model.Endpoint {
+	hostPoint, ok := s.Attributes[serviceEndpointKey].(string)
+	if !ok {
+		return e.localEndpoint
+	}
+	serviceName, ok := s.Attributes[serviceNameKey].(string)
+	if !ok {
+		return e.localEndpoint
+	}
+	ep, err := zipkin.NewEndpoint(serviceName, hostPoint)
+	if err != nil {
+		e.Logger.Printf("Invalid values %s=%q, %s=%q: %s", serviceEndpointKey, hostPoint, serviceNameKey, serviceName, err)
+		return e.localEndpoint
+	}
+	return ep
 }
 
 const (
 	statusCodeTagKey        = "error"
 	statusDescriptionTagKey = "opencensus.status_description"
+	serviceNameKey          = "opencensus.service_name"
+	serviceEndpointKey      = "opencensus.service_endpoint"
 )
 
 var (
@@ -110,7 +142,13 @@ func spanKind(s *trace.SpanData) model.Kind {
 	return model.Undetermined
 }
 
-func zipkinSpan(s *trace.SpanData, localEndpoint *model.Endpoint) model.SpanModel {
+var ignoredAttributeKeys = map[string]struct{}{
+	serviceEndpointKey: {},
+	serviceNameKey:     {},
+}
+
+func (e *Exporter) zipkinSpan(s *trace.SpanData) model.SpanModel {
+	localEndpoint := e.spanLocalEndpoint(s)
 	sc := s.SpanContext
 	z := model.SpanModel{
 		SpanContext: model.SpanContext{
@@ -138,6 +176,9 @@ func zipkinSpan(s *trace.SpanData, localEndpoint *model.Endpoint) model.SpanMode
 	if len(s.Attributes) != 0 {
 		m := make(map[string]string, len(s.Attributes)+2)
 		for key, value := range s.Attributes {
+			if _, ok := ignoredAttributeKeys[key]; ok {
+				continue
+			}
 			switch v := value.(type) {
 			case string:
 				m[key] = v

--- a/exporter/zipkin/zipkin_integration_test.go
+++ b/exporter/zipkin/zipkin_integration_test.go
@@ -1,0 +1,31 @@
+package zipkin_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	zgo "github.com/openzipkin/zipkin-go"
+	zhttp "github.com/openzipkin/zipkin-go/reporter/http"
+	oczipkin "go.opencensus.io/exporter/zipkin"
+	"go.opencensus.io/trace"
+)
+
+func TestEndToEnd(t *testing.T) {
+	url := os.Getenv("ZIPKIN_URL")
+	if url == "" {
+		t.Skip("No ZIPKIN_URL set")
+	}
+	r := zhttp.NewReporter(url, zhttp.BatchSize(1))
+	endpoint, _ := zgo.NewEndpoint("default", ":0")
+	exporter := oczipkin.NewExporter(r, endpoint)
+	trace.RegisterExporter(exporter)
+
+	ctx := context.Background()
+	ctx, span := trace.StartSpan(ctx, "/a/b/c", trace.WithSampler(trace.AlwaysSample()), trace.WithSpanKind(trace.SpanKindServer))
+	time.Sleep(150 * time.Millisecond)
+	span.End()
+
+	r.Close()
+}

--- a/exporter/zipkin/zipkin_test.go
+++ b/exporter/zipkin/zipkin_test.go
@@ -238,6 +238,90 @@ func TestExport(t *testing.T) {
 			},
 		},
 		{
+			name: "no endpoint",
+			span: &trace.SpanData{
+				SpanContext: trace.SpanContext{
+					TraceID:      trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+					SpanID:       trace.SpanID{17, 18, 19, 20, 21, 22, 23, 24},
+					TraceOptions: 1,
+				},
+				Name:      "name",
+				SpanKind:  trace.SpanKindClient,
+				StartTime: now,
+				EndTime:   now.Add(24 * time.Hour),
+				Attributes: map[string]interface{}{
+					"stringkey":               "value",
+					"intkey":                  int64(42),
+					"boolkey1":                true,
+					"boolkey2":                false,
+					"opencensus.service_name": "myservice",
+				},
+				MessageEvents: []trace.MessageEvent{
+					{
+						Time:                 now,
+						EventType:            trace.MessageEventTypeSent,
+						MessageID:            12,
+						UncompressedByteSize: 99,
+						CompressedByteSize:   98,
+					},
+				},
+				Annotations: []trace.Annotation{
+					{
+						Time:    now,
+						Message: "Annotation",
+						Attributes: map[string]interface{}{
+							"stringkey": "value",
+							"intkey":    int64(42),
+							"boolkey1":  true,
+							"boolkey2":  false,
+						},
+					},
+				},
+				Status: trace.Status{
+					Code:    3,
+					Message: "error",
+				},
+			},
+			want: model.SpanModel{
+				LocalEndpoint: &model.Endpoint{
+					ServiceName: "myservice",
+					IPv4:        net.ParseIP("0.0.0.0"),
+					Port:        0,
+				},
+				SpanContext: model.SpanContext{
+					TraceID: model.TraceID{
+						High: 0x0102030405060708,
+						Low:  0x090a0b0c0d0e0f10,
+					},
+					ID:      0x1112131415161718,
+					Sampled: &sampledTrue,
+				},
+				Name:      "name",
+				Kind:      model.Client,
+				Timestamp: now,
+				Duration:  24 * time.Hour,
+				Shared:    false,
+				Annotations: []model.Annotation{
+					{
+						Timestamp: now,
+						Value:     "Annotation",
+					},
+					{
+						Timestamp: now,
+						Value:     "SENT",
+					},
+				},
+				Tags: map[string]string{
+					"stringkey": "value",
+					"intkey":    "42",
+					"boolkey1":  "true",
+					"boolkey2":  "false",
+					"error":     "INVALID_ARGUMENT",
+					"opencensus.status_description": "error",
+				},
+			},
+		},
+		{
 			name: "zero endpoint",
 			span: &trace.SpanData{
 				SpanContext: trace.SpanContext{

--- a/trace/basetypes.go
+++ b/trace/basetypes.go
@@ -50,16 +50,19 @@ type Attribute struct {
 }
 
 // BoolAttribute returns a bool-valued attribute.
+// Attribute keys starting with "opencensus" are reserved for internal use.
 func BoolAttribute(key string, value bool) Attribute {
 	return Attribute{key: key, value: value}
 }
 
 // Int64Attribute returns an int64-valued attribute.
+// Attribute keys starting with "opencensus" are reserved for internal use.
 func Int64Attribute(key string, value int64) Attribute {
 	return Attribute{key: key, value: value}
 }
 
 // StringAttribute returns a string-valued attribute.
+// Attribute keys starting with "opencensus" are reserved for internal use.
 func StringAttribute(key string, value string) Attribute {
 	return Attribute{key: key, value: value}
 }

--- a/trace/sampling.go
+++ b/trace/sampling.go
@@ -20,10 +20,6 @@ import (
 
 const defaultSamplingProbability = 1e-4
 
-func newDefaultSampler() Sampler {
-	return ProbabilitySampler(defaultSamplingProbability)
-}
-
 // Sampler decides whether a trace should be sampled and exported.
 type Sampler func(SamplingParameters) SamplingDecision
 
@@ -52,13 +48,13 @@ func ProbabilitySampler(fraction float64) Sampler {
 	}
 
 	traceIDUpperBound := uint64(fraction * (1 << 63))
-	return Sampler(func(p SamplingParameters) SamplingDecision {
+	return func(p SamplingParameters) SamplingDecision {
 		if p.ParentContext.IsSampled() {
 			return SamplingDecision{Sample: true}
 		}
 		x := binary.BigEndian.Uint64(p.TraceID[0:8]) >> 1
 		return SamplingDecision{Sample: x < traceIDUpperBound}
-	})
+	}
 }
 
 // AlwaysSample returns a Sampler that samples every trace.


### PR DESCRIPTION
This is needed for rare cases when the logical endpoint differs from
the process submitting the span, for example Istio.