### PR TITLE
Add tag.DecodeEach to decode a serialized tag map

### DIFF
--- a/tag/map_codec.go
+++ b/tag/map_codec.go
@@ -177,45 +177,58 @@ func Encode(m *Map) []byte {
 // Decode decodes the given []byte into a tag map.
 func Decode(bytes []byte) (*Map, error) {
 	ts := newMap()
+	err := DecodeEach(bytes, ts.upsert)
+	if err != nil {
+		// no partial failures
+		return nil, err
+	}
+	return ts, nil
+}
 
+// DecodeEach decodes the given serialized tag map, calling handler for each
+// tag key and value decoded.
+func DecodeEach(bytes []byte, fn func(key Key, val string)) error {
 	eg := &encoderGRPC{
 		buf: bytes,
 	}
 	if len(eg.buf) == 0 {
-		return ts, nil
+		return nil
 	}
 
 	version := eg.readByte()
 	if version > tagsVersionID {
-		return nil, fmt.Errorf("cannot decode: unsupported version: %q; supports only up to: %q", version, tagsVersionID)
+		return fmt.Errorf("cannot decode: unsupported version: %q; supports only up to: %q", version, tagsVersionID)
 	}
 
 	for !eg.readEnded() {
 		typ := keyType(eg.readByte())
 
 		if typ != keyTypeString {
-			return nil, fmt.Errorf("cannot decode: invalid key type: %q", typ)
+			return fmt.Errorf("cannot decode: invalid key type: %q", typ)
 		}
 
 		k, err := eg.readBytesWithVarintLen()
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		v, err := eg.readBytesWithVarintLen()
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		key, err := NewKey(string(k))
 		if err != nil {
-			return nil, err // no partial failures
+			return err
 		}
 		val := string(v)
 		if !checkValue(val) {
-			return nil, errInvalidValue // no partial failures
+			return errInvalidValue
 		}
-		ts.upsert(key, val)
+		fn(key, val)
+		if err != nil {
+			return err
+		}
 	}
-	return ts, nil
+	return nil
 }


### PR DESCRIPTION
This can be used to parse the tags in header into a datastructure
other than tag.Map: it's useful for applications that want to read
the tags header but don't use the stats package.