### PR TITLE
Fix links to zpages in http example.

### DIFF
--- a/examples/http/README.md
+++ b/examples/http/README.md
@@ -27,5 +27,5 @@ You will see traces and stats exported on the stdout. You can use one of the
 to upload collected data to the backend of your choice.
 
 You can also see the z-pages provided from the server:
-* Traces: http://localhost:8081/tracez
-* RPCs: http://localhost:8081/rpcz
+* Traces: http://localhost:8081/debug/tracez
+* RPCs: http://localhost:8081/debug/rpcz


### PR DESCRIPTION
Added prefix 'debug' to fix the zpages link. 