### PR TITLE
trace: add buffer limit

### DIFF
--- a/trace/export.go
+++ b/trace/export.go
@@ -73,4 +73,11 @@ type SpanData struct {
 	Status
 	Links           []Link
 	HasRemoteParent bool
+
+	// The count of all span.bufferLimit overflows.
+	// See trace.WithBufferLimit for more info.
+	// TODO: This is not currently exported anywhere (e.g. tracez page).
+	DroppedAnnotations   int
+	DroppedMessageEvents int
+	DroppedLinks         int
 }


### PR DESCRIPTION
This applies to all span data entities that are slices: Annotations,
Links, and Message Events.

At the limit, it pops the oldest sample off prior to appending the new
sample. This should not cause an additional allocation.

Each entity shares the same WithBufferLimit option following the YAGNI
principle.

Each test ensures 4 entities are added in total -- the first 2 are
dropped and the last 2 remain. This should prevent off by 1 bugs.