### PR TITLE
proposed commit for log package

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 OpenCensus Go is a Go implementation of OpenCensus, a toolkit for
 collecting application performance and behavior monitoring data.
-Currently it consists of three major components: tags, stats, and tracing.
+Currently it consists of three major components: tags, stats, tracing, and logging.
 
 ## Installation
 
@@ -190,6 +190,21 @@ methods for different protocols.
 * HTTP integrations uses Zipkin's [B3](https://github.com/openzipkin/b3-propagation)
   by default but can be configured to use a custom propagation method by setting another
   [propagation.HTTPFormat](https://godoc.org/go.opencensus.io/trace/propagation#HTTPFormat).
+  
+## Logs
+
+OpenCensus provides a structured logger that is both tag aware and trace aware.  `log` can be configured to 
+look for tags within the current `context.Context` and capture them as part of the log record.  In addition,
+if the log is associated with a `trace.Span`, the `TraceID` and `SpanID` will be captured as well.
+
+Structured fields can be associated with the message. For example:
+
+```go
+log.Info(ctx, "message",
+	log.String("userID", "abc"),
+	log.Int("count", 123),
+)
+```
 
 ## Execution Tracer
 

--- a/log/README.md
+++ b/log/README.md
@@ -1,0 +1,36 @@
+log
+--------
+
+`log` package supports structured logging that is both tag and trace aware.
+
+
+#### QuickStart
+
+The simplest way to get started is to register a logger and get started.
+
+```go
+var exporter log.Exporter = ...
+log.RegisterExporter(exporter)
+log.Info(ctx, "hello world", log.String("userID", "abc"), log.Int("count", 123))
+```
+
+#### Customizing
+
+The behavior of the `log` package can be customized via `ApplyConfig`.
+
+```go
+var exporter log.Exporter = ...
+userID, _ := tag.NewKey("userID")
+log.RegisterExporter(exporter)
+
+// customize behavior of log package here
+log.ApplyConfig(log.Config{
+	LogLevel: log.DebugLevel,                          // change log level to debug
+	TimeFunc: func() time.Time { return time.Now() },  // customize how now is generated
+	Fields: []log.Field{log.String("global", "field")} // global fields to be added to all logs
+	Tags: []tag.Key{userID},                           // extract tags from context when present
+})
+
+log.Info(ctx, "hello world")
+
+```

--- a/log/config.go
+++ b/log/config.go
@@ -1,0 +1,36 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"time"
+
+	"go.opencensus.io/tag"
+)
+
+// Config represents the global log configuration.
+type Config struct {
+	LogLevel Level            // LogLevel; defaults to InfoLevel
+	TimeFunc func() time.Time // TimeFunc provides optional time generator
+	Fields   []Field          // Fields that will be included in all log messages
+	Tags     []tag.Key        // Tags that will be added to the log
+}
+
+// ApplyConfig applies changes to the global tracing configuration.
+//
+// Fields not provided in the given config are going to be preserved.
+func ApplyConfig(cfg Config) {
+	defaultLogger.ApplyConfig(cfg)
+}

--- a/log/export.go
+++ b/log/export.go
@@ -1,0 +1,53 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"time"
+)
+
+// defaultLogger defines the global logger
+var defaultLogger = &Logger{}
+
+// Exporter is a type for functions that receive log data.
+//
+// The ExportLog method should be safe for concurrent use and should return
+// quickly; if an Exporter takes a significant amount of time to process a
+// Data, that work should be done on another goroutine.
+type Exporter interface {
+	ExportLog(d Data)
+}
+
+// Data contains a single log record
+type Data struct {
+	LogLevel  Level             // LogLevel is the level of the message; either InfoLevel or DebugLevel
+	Timestamp time.Time         // Timestamp when the log record was received
+	Message   string            // Message recorded
+	Tags      map[string]string // Tags contains the optional list of tags found in context
+	Fields    []Field           // Fields contains the log fields merged with the global fields (from ApplyConfig)
+}
+
+// RegisterExporter adds to the list of Exporters that will receive log data.
+//
+// Binaries can register exporters, libraries shouldn't register exporters.
+func RegisterExporter(e Exporter) {
+	defaultLogger.RegisterExporter(e)
+}
+
+// UnregisterExporter removes from the list of Exporters the Exporter that was
+// registered with the given name.
+func UnregisterExporter(e Exporter) {
+	defaultLogger.UnregisterExporter(e)
+}

--- a/log/export.go
+++ b/log/export.go
@@ -32,6 +32,8 @@ type Exporter interface {
 
 // Data contains a single log record
 type Data struct {
+	TraceID   string            // TraceID associated with current trace.Span (if present)
+	SpanID    string            // SpanID associated with current trace.Span (if present)
 	LogLevel  Level             // LogLevel is the level of the message; either InfoLevel or DebugLevel
 	Timestamp time.Time         // Timestamp when the log record was received
 	Message   string            // Message recorded

--- a/log/export_test.go
+++ b/log/export_test.go
@@ -1,0 +1,81 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"go.opencensus.io/log"
+)
+
+func TestGlobalApplyConfig(t *testing.T) {
+	ctx := context.Background()
+	e := &Capturer{}
+	global := log.String("global", "field")
+
+	log.RegisterExporter(e)
+	log.ApplyConfig(log.Config{
+		Fields: []log.Field{global},
+	})
+
+	log.Info(ctx, "message")
+
+	if got := len(e.Records); got != 1 {
+		t.Fatalf("got %v, want 1", got)
+	}
+
+	data := e.Records[0]
+	if want := []log.Field{global}; !reflect.DeepEqual(data.Fields, want) {
+		t.Errorf("got %v, want %v", data.Fields, want)
+	}
+}
+
+func TestGlobalInfo(t *testing.T) {
+	ctx := context.Background()
+	e := &Capturer{}
+	log.RegisterExporter(e)
+
+	log.Info(ctx, "message")
+
+	if got := len(e.Records); got != 1 {
+		t.Fatalf("got %v, want 1", got)
+	}
+}
+
+func TestGlobalDebug(t *testing.T) {
+	ctx := context.Background()
+	e := &Capturer{}
+	log.RegisterExporter(e)
+
+	log.Debug(ctx, "message")
+
+	if got := len(e.Records); got != 1 {
+		t.Fatalf("got %v, want 1", got)
+	}
+}
+
+func TestGlobalUnregister(t *testing.T) {
+	ctx := context.Background()
+	e := &Capturer{}
+	log.RegisterExporter(e)
+	log.UnregisterExporter(e)
+	log.Info(ctx, "ignored")
+
+	if got := len(e.Records); got != 0 {
+		t.Fatalf("got %v, want 0", got)
+	}
+}

--- a/log/export_test.go
+++ b/log/export_test.go
@@ -59,6 +59,9 @@ func TestGlobalInfo(t *testing.T) {
 func TestGlobalDebug(t *testing.T) {
 	ctx := context.Background()
 	e := &Capturer{}
+	log.ApplyConfig(log.Config{
+		LogLevel: log.DebugLevel,
+	})
 	log.RegisterExporter(e)
 
 	log.Debug(ctx, "message")

--- a/log/field.go
+++ b/log/field.go
@@ -1,0 +1,244 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"fmt"
+	"time"
+)
+
+// FieldType identifies the native type of the value represented by the Field union type.
+type FieldType uint8
+
+const (
+	// UnknownType defined for completeness
+	UnknownType  FieldType = iota
+	BoolType               // BoolType defines true as field.Int == 1; everything else is false
+	DurationType           // DurationType holds duration in field.Int
+	ErrorType              // ErrorType holds error in field.Interface
+	Float32Type            // Float32Type holds float32 as field.Float
+	Float64Type            // Float64Type holds float64 as field.Float
+	IntType                // IntType holds int as field.Int
+	Int8Type               // Int8Type holds int8 as field.Int
+	Int16Type              // Int16Type holds int16 as field.Int
+	Int32Type              // Int32Type holds int32 as field.Int
+	Int64Type              // Int64Type holds int64 as field.Int
+	NoOpType               // NoOpType is a virtual type and indicates the Field should be ignored
+	StringType             // StringType holds string as field.String
+	StringsType            // StringsType holds []string as field.Interface
+	StringerType           // StringerType holds fmt.Stringer as field.Interface
+	TimeType               // TimeType holds time.Time as field.Interface
+	UintType               // UintType holds uint as field.Int
+	Uint8Type              // Uint8Type holds uint8 as field.Int
+	Uint16Type             // Uint16Type holds uint16 as field.Int
+	Uint32Type             // Uint32Type holds uint32 as field.Int
+	Uint64Type             // Uint64Type holds uint64 as field.Int
+)
+
+// Field is a union type that defines a key value pair.  The key must be a string.  However,
+// the value can be any type.
+type Field struct {
+	Key       string      // Key name
+	Type      FieldType   // Type contained in this union
+	Int       int64       // Int holds all Int types (see Type above)
+	Float     float64     // Float holds all Float types (see Type above)
+	String    string      // String hold string type
+	Interface interface{} // Interface holds everything else
+}
+
+// Any attempts to encode the value provided.  If Any is unable to encode the value,
+// Any will return a Field of type NoOp
+func Any(key string, v interface{}) Field {
+	switch value := v.(type) {
+	case bool:
+		return Bool(key, value)
+	case time.Duration:
+		return Duration(key, value)
+	case error:
+		return Error(key, value)
+	case float32:
+		return Float32(key, value)
+	case float64:
+		return Float64(key, value)
+	case int:
+		return Int(key, value)
+	case int8:
+		return Int8(key, value)
+	case int16:
+		return Int16(key, value)
+	case int32:
+		return Int32(key, value)
+	case int64:
+		return Int64(key, value)
+	case string:
+		return String(key, value)
+	case []string:
+		return Strings(key, value)
+	case time.Time: // time.Time must be before fmt.Stringer
+		return Time(key, value)
+	case fmt.Stringer:
+		return Stringer(key, value)
+	case uint:
+		return Uint(key, value)
+	case uint8:
+		return Uint8(key, value)
+	case uint16:
+		return Uint16(key, value)
+	case uint32:
+		return Uint32(key, value)
+	case uint64:
+		return Uint64(key, value)
+	default:
+		return NoOp()
+	}
+}
+
+// Bool constructs a Field that holds a bool
+func Bool(key string, v bool) Field {
+	var value int64
+	if v {
+		value = 1
+	}
+	return Field{Key: key, Type: BoolType, Int: value}
+}
+
+// Duration constructs a Field that holds a time.Duration. Duration will be
+// recorded in millis
+func Duration(key string, v time.Duration) Field {
+	return Field{Key: key, Type: DurationType, Int: int64(v)}
+}
+
+// Error constructs a Field that holds a error
+func Error(key string, v error) Field {
+	if v == nil {
+		return Field{Type: NoOpType}
+	}
+	return Field{Key: key, Type: ErrorType, Interface: v}
+}
+
+// Float32 constructs a Field that holds a float32
+func Float32(key string, v float32) Field {
+	return Field{Key: key, Type: Float32Type, Float: float64(v)}
+}
+
+// Float64 constructs a Field that holds a float64
+func Float64(key string, v float64) Field {
+	return Field{Key: key, Type: Float64Type, Float: float64(v)}
+}
+
+// Int constructs a Field that holds a int
+func Int(key string, v int) Field {
+	return Field{Key: key, Type: IntType, Int: int64(v)}
+}
+
+// Int8 constructs a Field that holds a int8
+func Int8(key string, v int8) Field {
+	return Field{Key: key, Type: Int8Type, Int: int64(v)}
+}
+
+// Int16 constructs a Field that holds a int16
+func Int16(key string, v int16) Field {
+	return Field{Key: key, Type: Int16Type, Int: int64(v)}
+}
+
+// Int32 constructs a Field that holds a int32
+func Int32(key string, v int32) Field {
+	return Field{Key: key, Type: Int32Type, Int: int64(v)}
+}
+
+// Int64 constructs a Field that holds a int64
+func Int64(key string, v int64) Field {
+	return Field{Key: key, Type: Int64Type, Int: int64(v)}
+}
+
+// NoOp constructs a field that should be ignored.  Useful for cases where
+// a functional constructor may optionally return a Field
+func NoOp() Field {
+	return Field{Type: NoOpType}
+}
+
+// String constructs a Field that holds a string
+func String(key string, v string) Field {
+	return Field{Key: key, Type: StringType, String: v}
+}
+
+// Strings constructs a Field that holds a []string
+func Strings(key string, v []string) Field {
+	return Field{Key: key, Type: StringsType, Interface: v}
+}
+
+// Stringer constructs a Field that holds a fmt.String
+func Stringer(key string, v fmt.Stringer) Field {
+	return Field{Key: key, Type: StringerType, Interface: v}
+}
+
+// Time constructs a Field that holds a time.Time
+func Time(key string, v time.Time) Field {
+	return Field{Key: key, Type: TimeType, Interface: v}
+}
+
+// Uint constructs a Field that holds a uint
+func Uint(key string, v uint) Field {
+	return Field{Key: key, Type: UintType, Int: int64(v)}
+}
+
+// Uint8 constructs a Field that holds a uint8
+func Uint8(key string, v uint8) Field {
+	return Field{Key: key, Type: Uint8Type, Int: int64(v)}
+}
+
+// Uint16 constructs a Field that holds a uint16
+func Uint16(key string, v uint16) Field {
+	return Field{Key: key, Type: Uint16Type, Int: int64(v)}
+}
+
+// Uint32 constructs a Field that holds a uint32
+func Uint32(key string, v uint32) Field {
+	return Field{Key: key, Type: Uint32Type, Int: int64(v)}
+}
+
+// Uint64 constructs a Field that holds a uint64
+func Uint64(key string, v uint64) Field {
+	return Field{Key: key, Type: Uint64Type, Int: int64(v)}
+}
+
+func fieldsContainsKey(fields []Field, key string) bool {
+	for _, field := range fields {
+		if field.Key == key {
+			return true
+		}
+	}
+	return false
+}
+
+func mergeFields(a, b []Field) []Field {
+	fields := make([]Field, 0, len(a)+len(b))
+
+	for _, field := range a {
+		if fieldsContainsKey(fields, field.Key) {
+			continue
+		}
+		fields = append(fields, field)
+	}
+
+	for _, field := range b {
+		if fieldsContainsKey(fields, field.Key) {
+			continue
+		}
+		fields = append(fields, field)
+	}
+
+	return fields
+}

--- a/log/field_test.go
+++ b/log/field_test.go
@@ -1,0 +1,275 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"io"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestMerge(t *testing.T) {
+	a := String("a", "abc")
+	b := String("b", "def")
+
+	testCases := map[string]struct {
+		A    []Field
+		B    []Field
+		Want []Field
+	}{
+		"nil a": {
+			A:    nil,
+			B:    []Field{a},
+			Want: []Field{a},
+		},
+		"nil b": {
+			A:    []Field{a},
+			B:    nil,
+			Want: []Field{a},
+		},
+		"a before b": {
+			A:    []Field{a},
+			B:    []Field{b},
+			Want: []Field{a, b},
+		},
+		"remove dupe - 1": {
+			A:    []Field{a},
+			B:    []Field{a, b},
+			Want: []Field{a, b},
+		},
+		"remove dupe - 2": {
+			A:    []Field{a, a},
+			B:    nil,
+			Want: []Field{a},
+		},
+		"remove dupe - 3": {
+			A:    nil,
+			B:    []Field{a, a},
+			Want: []Field{a},
+		},
+	}
+
+	for label, tc := range testCases {
+		t.Run(label, func(t *testing.T) {
+			got := mergeFields(tc.A, tc.B)
+			if !reflect.DeepEqual(got, tc.Want) {
+				t.Errorf("%v: got %v, want %v", label, got, tc.Want)
+			}
+		})
+	}
+}
+
+var Result []Field
+
+func BenchmarkMerge(t *testing.B) {
+	a := []Field{
+		String("a1", "1"),
+		String("a2", "2"),
+		String("a3", "3"),
+	}
+	b := []Field{
+		String("b1", "1"),
+		String("b2", "2"),
+		String("b3", "3"),
+	}
+
+	for i := 0; i < t.N; i++ {
+		Result = mergeFields(a, b)
+	}
+
+	want := append(a, b...)
+	if !reflect.DeepEqual(Result, want) {
+		t.Errorf("want %#v, got %#v", Result, want)
+	}
+}
+
+func TestFactories(t *testing.T) {
+	testCases := map[string]struct {
+		Value interface{}
+		Want  Field
+	}{
+		"bool": {
+			Value: true,
+			Want: Field{
+				Type: BoolType,
+				Int:  1,
+			},
+		},
+		"false": {
+			Value: false,
+			Want: Field{
+				Type: BoolType,
+				Int:  0,
+			},
+		},
+		"duration": {
+			Value: time.Second,
+			Want: Field{
+				Type: DurationType,
+				Int:  int64(time.Second),
+			},
+		},
+		"error - present": {
+			Value: io.EOF,
+			Want: Field{
+				Type:      ErrorType,
+				Interface: io.EOF,
+			},
+		},
+		"error - nil": {
+			Value: error(nil),
+			Want: Field{
+				Type:      NoOpType,
+			},
+		},
+		"float32": {
+			Value: float32(1.23),
+			Want: Field{
+				Type:  Float32Type,
+				Float: float64(float32(1.23)),
+			},
+		},
+		"float64": {
+			Value: float64(1.23),
+			Want: Field{
+				Type:  Float64Type,
+				Float: 1.23,
+			},
+		},
+		"int": {
+			Value: 1,
+			Want: Field{
+				Type: IntType,
+				Int:  1,
+			},
+		},
+		"int8": {
+			Value: int8(1),
+			Want: Field{
+				Type: Int8Type,
+				Int:  1,
+			},
+		},
+		"int16": {
+			Value: int16(1),
+			Want: Field{
+				Type: Int16Type,
+				Int:  1,
+			},
+		},
+		"int32": {
+			Value: int32(1),
+			Want: Field{
+				Type: Int32Type,
+				Int:  1,
+			},
+		},
+		"int64": {
+			Value: int64(1),
+			Want: Field{
+				Type: Int64Type,
+				Int:  1,
+			},
+		},
+		"string": {
+			Value: "string",
+			Want: Field{
+				Type:   StringType,
+				String: "string",
+			},
+		},
+		"strings": {
+			Value: []string{"a", "b", "c"},
+			Want: Field{
+				Type:      StringsType,
+				Interface: []string{"a", "b", "c"},
+			},
+		},
+		"strings - nil": {
+			Value: []string(nil),
+			Want: Field{
+				Type:      StringsType,
+				Interface: []string(nil),
+			},
+		},
+		//"stringer": {
+		//	Value: Stringer{value: "value"},
+		//	Want: Field{
+		//		Type: BoolType,
+		//		Int:  1,
+		//	},
+		//},
+		"time": {
+			Value: time.Date(2018, time.July, 13, 5, 6, 7, 0, time.UTC),
+			Want: Field{
+				Type:      TimeType,
+				Interface: time.Date(2018, time.July, 13, 5, 6, 7, 0, time.UTC),
+			},
+		},
+		"time - zero": {
+			Value: time.Time{},
+			Want: Field{
+				Type:      TimeType,
+				Interface: time.Time{},
+			},
+		},
+		"uint": {
+			Value: uint(1),
+			Want: Field{
+				Type: UintType,
+				Int:  1,
+			},
+		},
+		"uint8": {
+			Value: uint8(1),
+			Want: Field{
+				Type: Uint8Type,
+				Int:  1,
+			},
+		},
+		"uint16": {
+			Value: uint16(1),
+			Want: Field{
+				Type: Uint16Type,
+				Int:  1,
+			},
+		},
+		"uint32": {
+			Value: uint32(1),
+			Want: Field{
+				Type: Uint32Type,
+				Int:  1,
+			},
+		},
+		"uint64": {
+			Value: uint64(1),
+			Want: Field{
+				Type: Uint64Type,
+				Int:  1,
+			},
+		},
+	}
+
+	for label, tc := range testCases {
+		t.Run(label, func(t *testing.T) {
+			got := Any("key", tc.Value)
+			tc.Want.Key = got.Key
+			if !reflect.DeepEqual(got, tc.Want) {
+				t.Errorf("%v: got %v, want %v", label, got, tc.Want)
+			}
+		})
+	}
+}

--- a/log/field_test.go
+++ b/log/field_test.go
@@ -132,7 +132,7 @@ func TestFactories(t *testing.T) {
 		"error - nil": {
 			Value: error(nil),
 			Want: Field{
-				Type:      NoOpType,
+				Type: NoOpType,
 			},
 		},
 		"float32": {
@@ -205,13 +205,6 @@ func TestFactories(t *testing.T) {
 				Interface: []string(nil),
 			},
 		},
-		//"stringer": {
-		//	Value: Stringer{value: "value"},
-		//	Want: Field{
-		//		Type: BoolType,
-		//		Int:  1,
-		//	},
-		//},
 		"time": {
 			Value: time.Date(2018, time.July, 13, 5, 6, 7, 0, time.UTC),
 			Want: Field{

--- a/log/level.go
+++ b/log/level.go
@@ -1,0 +1,37 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"context"
+)
+
+// Level defines the priority level of the log
+type Level int
+
+const (
+	DebugLevel Level = iota - 1 // DebugLevel provides detailed logging; should be disabled for production
+	InfoLevel                   // InfoLevel is the default priority level
+)
+
+// Debug message (requires DebugLevel or better)
+func Debug(ctx context.Context, message string, fields ...Field) {
+	defaultLogger.Debug(ctx, message, fields...)
+}
+
+// Info message.  General purpose messages to be logged.
+func Info(ctx context.Context, message string, fields ...Field) {
+	defaultLogger.Info(ctx, message, fields...)
+}

--- a/log/logcore/logjson/encode.go
+++ b/log/logcore/logjson/encode.go
@@ -1,0 +1,250 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logjson
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"go.opencensus.io/log"
+)
+
+var (
+	hex       = "0123456789abcdef"
+	jsonFalse = []byte(`false`)
+	jsonNull  = []byte(`null`)
+	jsonTrue  = []byte(`true`)
+)
+
+func Encode(buf *bytes.Buffer, fields []log.Field) error {
+	buf.WriteByte('{')
+	for index, field := range fields {
+		if field.Type == log.NoOpType {
+			continue
+		}
+
+		if index > 0 {
+			buf.WriteByte(',')
+		}
+
+		encodeString(buf, field.Key)
+		buf.WriteByte(':')
+
+		if err := encodeField(buf, field); err != nil {
+			return err
+		}
+	}
+	buf.WriteByte('}')
+	return nil
+}
+
+func encodeField(buf *bytes.Buffer, field log.Field) error {
+	switch field.Type {
+	case log.BoolType:
+		return encodeBool(buf, field.Int == 1)
+	case log.DurationType:
+		encodeInt64(buf, field.Int/int64(time.Millisecond))
+		return nil
+	case log.ErrorType:
+		encodeString(buf, field.Interface.(error).Error())
+		return nil
+	case log.Float32Type:
+		return encodeFloat64(buf, field.Float, 32)
+	case log.Float64Type:
+		return encodeFloat64(buf, field.Float, 64)
+	case log.IntType:
+		return encodeInt64(buf, field.Int)
+	case log.Int8Type:
+		return encodeInt64(buf, field.Int)
+	case log.Int16Type:
+		return encodeInt64(buf, field.Int)
+	case log.Int32Type:
+		return encodeInt64(buf, field.Int)
+	case log.Int64Type:
+		return encodeInt64(buf, field.Int)
+	case log.StringType:
+		encodeString(buf, field.String)
+		return nil
+	case log.StringsType:
+		if v, ok := field.Interface.([]string); ok && len(v) == 0 {
+			buf.Write(jsonNull)
+			return nil
+		} else {
+			encodeString(buf, strings.Join(field.Interface.([]string), ","))
+			return nil
+		}
+	case log.StringerType:
+		if field.Interface == nil {
+			buf.Write(jsonNull)
+			return nil
+		} else {
+			encodeString(buf, field.Interface.(fmt.Stringer).String())
+			return nil
+		}
+	case log.TimeType:
+		if t := field.Interface.(time.Time); t.IsZero() {
+			buf.Write(jsonNull)
+			return nil
+		} else {
+			encodeString(buf, t.In(time.UTC).Format(time.RFC3339))
+			return nil
+		}
+	case log.UintType:
+		return encodeInt64(buf, field.Int)
+	case log.Uint8Type:
+		return encodeInt64(buf, field.Int)
+	case log.Uint16Type:
+		return encodeInt64(buf, field.Int)
+	case log.Uint32Type:
+		return encodeInt64(buf, field.Int)
+	case log.Uint64Type:
+		return encodeInt64(buf, field.Int)
+	default:
+		panic(fmt.Errorf("unable to encode unexpected field type, %#v", field))
+	}
+}
+
+func encodeBool(buf *bytes.Buffer, v bool) error {
+	if v {
+		buf.Write(jsonTrue)
+	} else {
+		buf.Write(jsonFalse)
+	}
+	return nil
+}
+
+func encodeFloat64(buf *bytes.Buffer, f float64, bits int) error {
+	b := request()
+	defer release(b)
+
+	if math.IsInf(f, 0) || math.IsNaN(f) {
+		return fmt.Errorf("unsupported value, %v", f)
+	}
+
+	// Convert as if by ES6 number to string conversion.
+	// This matches most other JSON generators.
+	// See golang.org/issue/6384 and golang.org/issue/14135.
+	// Like fmt %g, but the exponent cutoffs are different
+	// and exponents themselves are not padded to two digits.
+	abs := math.Abs(f)
+	format := byte('f')
+	// Note: Must use float32 comparisons for underlying float32 value to get precise cutoffs right.
+	if abs != 0 {
+		if bits == 64 && (abs < 1e-6 || abs >= 1e21) || bits == 32 && (float32(abs) < 1e-6 || float32(abs) >= 1e21) {
+			format = 'e'
+		}
+	}
+	b = strconv.AppendFloat(b, f, format, -1, int(bits))
+	if format == 'e' {
+		// clean up e-09 to e-9
+		n := len(b)
+		if n >= 4 && b[n-4] == 'e' && b[n-3] == '-' && b[n-2] == '0' {
+			b[n-2] = b[n-1]
+			b = b[:n-1]
+		}
+	}
+
+	buf.Write(b)
+	return nil
+}
+
+func encodeInt64(buf *bytes.Buffer, v int64) error {
+	b := request()
+	defer release(b)
+	b = strconv.AppendInt(b, v, 10)
+
+	_, err := buf.Write(b)
+	return err
+}
+
+// encodeString was lifted from the go standard library encoding/json/encode.go
+func encodeString(buf *bytes.Buffer, v string) {
+	buf.WriteByte('"')
+	start := 0
+	for i := 0; i < len(v); {
+		if b := v[i]; b < utf8.RuneSelf {
+			if safeSet[b] {
+				i++
+				continue
+			}
+			if start < i {
+				buf.WriteString(v[start:i])
+			}
+			switch b {
+			case '\\', '"':
+				buf.WriteByte('\\')
+				buf.WriteByte(b)
+			case '\n':
+				buf.WriteByte('\\')
+				buf.WriteByte('n')
+			case '\r':
+				buf.WriteByte('\\')
+				buf.WriteByte('r')
+			case '\t':
+				buf.WriteByte('\\')
+				buf.WriteByte('t')
+			default:
+				// This encodes bytes < 0x20 except for \t, \n and \r.
+				// If escapeHTML is set, it also escapes <, >, and &
+				// because they can lead to security holes when
+				// user-controlled strings are rendered into JSON
+				// and served to some browsers.
+				buf.WriteString(`\u00`)
+				buf.WriteByte(hex[b>>4])
+				buf.WriteByte(hex[b&0xF])
+			}
+			i++
+			start = i
+			continue
+		}
+		c, size := utf8.DecodeRuneInString(v[i:])
+		if c == utf8.RuneError && size == 1 {
+			if start < i {
+				buf.WriteString(v[start:i])
+			}
+			buf.WriteString(`\ufffd`)
+			i += size
+			start = i
+			continue
+		}
+		// U+2028 is LINE SEPARATOR.
+		// U+2029 is PARAGRAPH SEPARATOR.
+		// They are both technically valid characters in JSON strings,
+		// but don't work in JSONP, which has to be evaluated as JavaScript,
+		// and can lead to security holes there. It is valid JSON to
+		// escape them, so we do so unconditionally.
+		// See http://timelessrepo.com/json-isnt-a-javascript-subset for discussion.
+		if c == '\u2028' || c == '\u2029' {
+			if start < i {
+				buf.WriteString(v[start:i])
+			}
+			buf.WriteString(`\u202`)
+			buf.WriteByte(hex[c&0xF])
+			i += size
+			start = i
+			continue
+		}
+		i += size
+	}
+	if start < len(v) {
+		buf.WriteString(v[start:])
+	}
+	buf.WriteByte('"')
+}

--- a/log/logcore/logjson/encode_test.go
+++ b/log/logcore/logjson/encode_test.go
@@ -31,6 +31,18 @@ func (s Stringer) String() string {
 	return s.value
 }
 
+func TestEncodeArray(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	err := Encode(buf, []log.Field{log.String("string", "abc"), log.Int("int", 123)})
+	if err != nil {
+		t.Fatalf("got %v, want nil", err)
+	}
+
+	if want := `{"string":"abc","int":123}`; buf.String() != want {
+		t.Errorf("got %v, want %v", buf.String(), want)
+	}
+}
+
 func TestEncode(t *testing.T) {
 	testCases := map[string]struct {
 		Value interface{}

--- a/log/logcore/logjson/encode_test.go
+++ b/log/logcore/logjson/encode_test.go
@@ -139,7 +139,7 @@ func TestEncode(t *testing.T) {
 				t.Fatalf("%v: got %v, want nil", label, err)
 			}
 
-			if got := buf.String(); got != tc.Want  {
+			if got := buf.String(); got != tc.Want {
 				t.Errorf("%v: got %v, want %v", label, got, tc.Want)
 			}
 		})

--- a/log/logcore/logjson/encode_test.go
+++ b/log/logcore/logjson/encode_test.go
@@ -1,0 +1,189 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logjson
+
+import (
+	"bytes"
+	"io"
+	"testing"
+	"time"
+
+	"go.opencensus.io/log"
+)
+
+type Stringer struct {
+	value string
+}
+
+func (s Stringer) String() string {
+	return s.value
+}
+
+func TestEncode(t *testing.T) {
+	testCases := map[string]struct {
+		Value interface{}
+		Want  string
+	}{
+		"bool": {
+			Value: true,
+			Want:  `{"key":true}`,
+		},
+		"false": {
+			Value: false,
+			Want:  `{"key":false}`,
+		},
+		"duration": {
+			Value: time.Second,
+			Want:  `{"key":1000}`,
+		},
+		"error - present": {
+			Value: io.EOF,
+			Want:  `{"key":"EOF"}`,
+		},
+		"error - nil": {
+			Value: error(nil),
+			Want:  `{}`,
+		},
+		"float32": {
+			Value: float32(1.23),
+			Want:  `{"key":1.23}`,
+		},
+		"float64": {
+			Value: float64(1.23),
+			Want:  `{"key":1.23}`,
+		},
+		"int": {
+			Value: 1,
+			Want:  `{"key":1}`,
+		},
+		"int8": {
+			Value: int8(1),
+			Want:  `{"key":1}`,
+		},
+		"int16": {
+			Value: int16(1),
+			Want:  `{"key":1}`,
+		},
+		"int32": {
+			Value: int32(1),
+			Want:  `{"key":1}`,
+		},
+		"int64": {
+			Value: int64(1),
+			Want:  `{"key":1}`,
+		},
+		"string": {
+			Value: "string",
+			Want:  `{"key":"string"}`,
+		},
+		"strings": {
+			Value: []string{"a", "b", "c"},
+			Want:  `{"key":"a,b,c"}`,
+		},
+		"strings - nil": {
+			Value: []string(nil),
+			Want:  `{"key":null}`,
+		},
+		"stringer": {
+			Value: Stringer{value: "value"},
+			Want:  `{"key":"value"}`,
+		},
+		"time": {
+			Value: time.Date(2018, time.July, 13, 5, 6, 7, 0, time.UTC),
+			Want:  `{"key":"2018-07-13T05:06:07Z"}`,
+		},
+		"time - zero": {
+			Value: time.Time{},
+			Want:  `{"key":null}`,
+		},
+		"uint": {
+			Value: uint(1),
+			Want:  `{"key":1}`,
+		},
+		"uint8": {
+			Value: uint8(1),
+			Want:  `{"key":1}`,
+		},
+		"uint16": {
+			Value: uint16(1),
+			Want:  `{"key":1}`,
+		},
+		"uint32": {
+			Value: uint32(1),
+			Want:  `{"key":1}`,
+		},
+		"uint64": {
+			Value: uint64(1),
+			Want:  `{"key":1}`,
+		},
+	}
+
+	for label, tc := range testCases {
+		t.Run(label, func(t *testing.T) {
+			field := log.Any("key", tc.Value)
+			buf := bytes.NewBuffer(nil)
+			err := Encode(buf, []log.Field{field})
+			if err != nil {
+				t.Fatalf("%v: got %v, want nil", label, err)
+			}
+
+			if got := buf.String(); got != tc.Want  {
+				t.Errorf("%v: got %v, want %v", label, got, tc.Want)
+			}
+		})
+	}
+}
+
+func TestEncodeString(t *testing.T) {
+	testCases := map[string]struct {
+		Input string
+		Want  string
+	}{
+		"newlines": {
+			Input: "\r\n",
+			Want:  `"\r\n"`,
+		},
+		"quote": {
+			Input: `"`,
+			Want:  `"\""`,
+		},
+		"tab": {
+			Input: "\t",
+			Want:  `"\t"`,
+		},
+		"low byte": {
+			Input: string([]byte{0x1}),
+			Want:  `"\u0001"`,
+		},
+		"hello": {
+			Input: `hello`,
+			Want:  `"hello"`,
+		},
+		"hello - quoted": {
+			Input: `"hello"`,
+			Want:  `"\"hello\""`,
+		},
+	}
+
+	for label, tc := range testCases {
+		t.Run(label, func(t *testing.T) {
+			buf := bytes.NewBuffer(nil)
+			encodeString(buf, tc.Input)
+			if got := buf.String(); got != tc.Want {
+				t.Errorf("%v: got %v, want %v", label, got, tc.Want)
+			}
+		})
+	}
+}

--- a/log/logcore/logjson/pool.go
+++ b/log/logcore/logjson/pool.go
@@ -1,0 +1,34 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logjson
+
+import "sync"
+
+var (
+	pool = &sync.Pool{
+		New: func() interface{} {
+			return make([]byte, 0, 256)
+		},
+	}
+)
+
+func request() []byte {
+	b := pool.Get().([]byte)
+	return b[:0]
+}
+
+func release(b []byte) {
+	pool.Put(b)
+}

--- a/log/logcore/logjson/tables.go
+++ b/log/logcore/logjson/tables.go
@@ -1,0 +1,124 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logjson
+
+import "unicode/utf8"
+
+// from encodings/json/tables.go
+//
+// safeSet holds the value true if the ASCII character with the given array
+// position can be represented inside a JSON string without any further
+// escaping.
+//
+// All values are true except for the ASCII control characters (0-31), the
+// double quote ("), and the backslash character ("\").
+var safeSet = [utf8.RuneSelf]bool{
+	' ':      true,
+	'!':      true,
+	'"':      false,
+	'#':      true,
+	'$':      true,
+	'%':      true,
+	'&':      true,
+	'\'':     true,
+	'(':      true,
+	')':      true,
+	'*':      true,
+	'+':      true,
+	',':      true,
+	'-':      true,
+	'.':      true,
+	'/':      true,
+	'0':      true,
+	'1':      true,
+	'2':      true,
+	'3':      true,
+	'4':      true,
+	'5':      true,
+	'6':      true,
+	'7':      true,
+	'8':      true,
+	'9':      true,
+	':':      true,
+	';':      true,
+	'<':      true,
+	'=':      true,
+	'>':      true,
+	'?':      true,
+	'@':      true,
+	'A':      true,
+	'B':      true,
+	'C':      true,
+	'D':      true,
+	'E':      true,
+	'F':      true,
+	'G':      true,
+	'H':      true,
+	'I':      true,
+	'J':      true,
+	'K':      true,
+	'L':      true,
+	'M':      true,
+	'N':      true,
+	'O':      true,
+	'P':      true,
+	'Q':      true,
+	'R':      true,
+	'S':      true,
+	'T':      true,
+	'U':      true,
+	'V':      true,
+	'W':      true,
+	'X':      true,
+	'Y':      true,
+	'Z':      true,
+	'[':      true,
+	'\\':     false,
+	']':      true,
+	'^':      true,
+	'_':      true,
+	'`':      true,
+	'a':      true,
+	'b':      true,
+	'c':      true,
+	'd':      true,
+	'e':      true,
+	'f':      true,
+	'g':      true,
+	'h':      true,
+	'i':      true,
+	'j':      true,
+	'k':      true,
+	'l':      true,
+	'm':      true,
+	'n':      true,
+	'o':      true,
+	'p':      true,
+	'q':      true,
+	'r':      true,
+	's':      true,
+	't':      true,
+	'u':      true,
+	'v':      true,
+	'w':      true,
+	'x':      true,
+	'y':      true,
+	'z':      true,
+	'{':      true,
+	'|':      true,
+	'}':      true,
+	'~':      true,
+	'\u007f': true,
+}

--- a/log/logger.go
+++ b/log/logger.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"go.opencensus.io/tag"
+	"go.opencensus.io/trace"
 )
 
 // Logger defines the standard opencensus logger.
@@ -124,6 +125,11 @@ func (l *Logger) log(ctx context.Context, level Level, message string, fields ..
 		Message:   message,
 		Tags:      tags,
 		Fields:    mergedFields,
+	}
+
+	if span := trace.FromContext(ctx); span != nil {
+		data.TraceID = span.SpanContext().TraceID.String()
+		data.SpanID = span.SpanContext().SpanID.String()
 	}
 
 	for exporter := range exporters {

--- a/log/logger.go
+++ b/log/logger.go
@@ -1,0 +1,140 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"go.opencensus.io/tag"
+)
+
+// Logger defines the standard opencensus logger.
+//
+// To simplify testing, it can be instantiated directly.  In production cases,
+// there should be no need to directly access Logger.
+//
+// Logger can be safely instantiated via logger := &Logger{}
+type Logger struct {
+	mutex     sync.Mutex
+	config    Config
+	exporters map[Exporter]struct{}
+}
+
+// ApplyConfig applies configuration to logger
+func (l *Logger) ApplyConfig(cfg Config) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	l.config = cfg
+}
+
+// RegisterExporter adds to the list of Exporters that will receive log data.
+//
+// Binaries can register exporters, libraries shouldn't register exporters.
+func (l *Logger) RegisterExporter(e Exporter) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	// treat l.exporters as immutable
+	exporters := map[Exporter]struct{}{}
+	for exporter := range l.exporters {
+		exporters[exporter] = struct{}{}
+	}
+
+	exporters[e] = struct{}{}
+	l.exporters = exporters
+}
+
+// UnregisterExporter removes from the list of Exporters the Exporter that was
+// registered with the given name.
+func (l *Logger) UnregisterExporter(e Exporter) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	// treat l.exporters as immutable
+	exporters := map[Exporter]struct{}{}
+	for exporter := range l.exporters {
+		exporters[exporter] = struct{}{}
+	}
+
+	delete(exporters, e)
+	l.exporters = exporters
+}
+
+// now returns the current time
+func (l *Logger) now(fn func() time.Time) time.Time {
+	if fn != nil {
+		return fn()
+	}
+
+	return time.Now()
+}
+
+// tags returns a map of tags found in the current context
+func (l *Logger) tags(ctx context.Context, tagKeys []tag.Key) map[string]string {
+	var tags map[string]string
+
+	tagMap := tag.FromContext(ctx)
+	for _, key := range tagKeys {
+		if v, ok := tagMap.Value(key); ok {
+			if tags == nil {
+				tags = map[string]string{}
+			}
+			tags[key.Name()] = v
+		}
+	}
+
+	return tags
+}
+
+// log defines an internal helper method to log at any level
+func (l *Logger) log(ctx context.Context, level Level, message string, fields ...Field) {
+	l.mutex.Lock()
+	config := l.config
+	exporters := l.exporters
+	l.mutex.Unlock()
+
+	if level < config.LogLevel {
+		return
+	}
+
+	var (
+		now          = l.now(config.TimeFunc)
+		tags         = l.tags(ctx, config.Tags)
+		mergedFields = mergeFields(fields, config.Fields)
+	)
+
+	data := Data{
+		LogLevel:  level,
+		Timestamp: now,
+		Message:   message,
+		Tags:      tags,
+		Fields:    mergedFields,
+	}
+
+	for exporter := range exporters {
+		exporter.ExportLog(data)
+	}
+}
+
+func (l *Logger) Debug(ctx context.Context, message string, fields ...Field) {
+	l.log(ctx, DebugLevel, message, fields...)
+}
+
+func (l *Logger) Info(ctx context.Context, message string, fields ...Field) {
+	l.log(ctx, InfoLevel, message, fields...)
+}

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -1,0 +1,184 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"go.opencensus.io/log"
+	"go.opencensus.io/tag"
+)
+
+type Capturer struct {
+	Records []log.Data
+}
+
+func (c *Capturer) ExportLog(d log.Data) {
+	c.Records = append(c.Records, d)
+}
+
+func TestLoggerInfo(t *testing.T) {
+	exporter := &Capturer{}
+	logger := &log.Logger{}
+	logger.RegisterExporter(exporter)
+
+	// When
+	message := "hello world"
+	logger.Info(context.Background(), message)
+
+	// Then
+	if got := len(exporter.Records); got != 1 {
+		t.Fatalf("got %v; want 1 record", got)
+	}
+
+	data := exporter.Records[0]
+	if data.Message != message {
+		t.Errorf("got %v; want %v", message, data.Message)
+	}
+	if data.Timestamp.IsZero() {
+		t.Error("expected Timestamp to be set")
+	}
+	if want := log.InfoLevel; data.LogLevel != want {
+		t.Errorf("got %v; want %v", data.LogLevel, want)
+	}
+}
+
+func TestLoggerDebug(t *testing.T) {
+	exporter := &Capturer{}
+	logger := &log.Logger{}
+	logger.RegisterExporter(exporter)
+
+	// When
+	message := "hello world"
+	logger.Debug(context.Background(), message)
+
+	// Then
+	if got := len(exporter.Records); got != 1 {
+		t.Fatalf("got %v; want 1 record", got)
+	}
+
+	data := exporter.Records[0]
+	if want := log.DebugLevel; data.LogLevel != want {
+		t.Errorf("got %v; want %v", data.LogLevel, want)
+	}
+}
+
+func TestLoggerHandlesMultipleExporters(t *testing.T) {
+	e1 := &Capturer{}
+	e2 := &Capturer{}
+	logger := &log.Logger{}
+	logger.RegisterExporter(e1)
+	logger.RegisterExporter(e2)
+
+	// When
+	logger.Info(context.Background(), "hello world")
+
+	// Then
+	if got := len(e1.Records); got != 1 {
+		t.Fatalf("got %v; want 1 record", got)
+	}
+	if got := len(e2.Records); got != 1 {
+		t.Fatalf("got %v; want 1 record", got)
+	}
+}
+
+func TestLoggerCustomTimeFunc(t *testing.T) {
+	now := time.Date(2018, time.July, 1, 2, 3, 4, 0, time.UTC)
+	e := &Capturer{}
+	logger := &log.Logger{}
+	logger.RegisterExporter(e)
+	logger.ApplyConfig(log.Config{
+		TimeFunc: func() time.Time { return now },
+	})
+
+	logger.Info(context.Background(), "hello world")
+
+	// Then
+	if got := len(e.Records); got != 1 {
+		t.Fatalf("got %v; want 1 record", got)
+	}
+
+	if data := e.Records[0]; data.Timestamp != now {
+		t.Errorf("got %v; want %v", data.Timestamp.Format(time.RFC3339), now.Format(time.RFC3339))
+	}
+}
+
+func TestLoggerGlobalFields(t *testing.T) {
+	e := &Capturer{}
+	logger := &log.Logger{}
+	logger.RegisterExporter(e)
+	global := log.String("global", "field")
+	logger.ApplyConfig(log.Config{
+		Fields: []log.Field{
+			global,
+		},
+	})
+
+	logger.Info(context.Background(), "hello world")
+
+	// Then
+	if got := len(e.Records); got != 1 {
+		t.Fatalf("got %v; want 1 record", got)
+	}
+
+	data := e.Records[0]
+	if want := []log.Field{global}; !reflect.DeepEqual(data.Fields, want) {
+		t.Errorf("got %v; want %v", data.Fields, want)
+	}
+}
+
+func TestLoggerTags(t *testing.T) {
+	key, _ := tag.NewKey("uid")
+
+	e := &Capturer{}
+	logger := &log.Logger{}
+	logger.RegisterExporter(e)
+	logger.ApplyConfig(log.Config{
+		Tags: []tag.Key{
+			key,
+		},
+	})
+
+	ctx, _ := tag.New(context.Background(), tag.Insert(key, "abc"))
+	logger.Info(ctx, "hello world")
+
+	// Then
+	if got := len(e.Records); got != 1 {
+		t.Fatalf("got %v; want 1 record", got)
+	}
+
+	data := e.Records[0]
+	if want := map[string]string{"uid": "abc"}; !reflect.DeepEqual(data.Tags, want) {
+		t.Errorf("got %v; want %v", data.Tags, want)
+	}
+}
+
+func TestLoggerUnregisterExporter(t *testing.T) {
+	exporter := &Capturer{}
+	logger := &log.Logger{}
+	logger.RegisterExporter(exporter)
+	logger.UnregisterExporter(exporter)
+
+	// When
+	logger.Info(context.Background(), "hello world")
+
+	// Then
+	if len(exporter.Records) != 0 {
+		t.Fatalf("expected 0 records to be captured when no exporter registered")
+	}
+}


### PR DESCRIPTION
I saw the request posted for a log package posted here, https://github.com/census-instrumentation/opencensus-go/issues/762, and wanted to propose this package.  

* Exporters using same pattern as stats and trace
* capturing TraceID and SpanID from current span (if present)
* capturing specified tags from context
* customizable time function

Per Dave Cheney's post, https://dave.cheney.net/2015/11/05/lets-talk-about-logging, the package only supports Debug and Info level logs.

