### PR TITLE
DO NOT MERGE - Intended for discussion of local aggregations

### DIFF
--- a/stats/export.go
+++ b/stats/export.go
@@ -1,0 +1,64 @@
+package stats
+
+import (
+	"sync/atomic"
+
+	"go.opencensus.io/tag"
+)
+
+var (
+	registry     = map[Exporter]struct{}{}
+	registrySize int32
+)
+
+// Data encapsulates the contents of the stats to be exported
+type Data struct {
+	Tags         *tag.Map
+	Measurements []Measurement
+}
+
+// Exporter exports the collected records as view data.
+//
+// The ExportView method should return quickly; if an
+// Exporter takes a significant amount of time to
+// process a Data, that work should be done on another goroutine.
+//
+// The Data should not be modified.
+type Exporter interface {
+	ExportStats(data Data)
+}
+
+// RegisterExporter registers an exporter.
+// Collected data will be reported via all the
+// registered exporters. Once you no longer
+// want data to be exported, invoke UnregisterExporter
+// with the previously registered exporter.
+//
+// Binaries can register exporters, libraries shouldn't register exporters.
+func RegisterExporter(exporter Exporter) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	updated := map[Exporter]struct{}{}
+	for k, v := range registry {
+		updated[k] = v
+	}
+
+	updated[exporter] = struct{}{}
+	registry = updated
+	atomic.StoreInt32(&registrySize, int32(len(updated)))
+}
+
+// UnregisterExporter unregisters an exporter.
+func UnregisterExporter(exporter Exporter) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	updated := map[Exporter]struct{}{}
+	for k, v := range registry {
+		updated[k] = v
+	}
+
+	delete(updated, exporter)
+	registry = updated
+}

--- a/stats/export_test.go
+++ b/stats/export_test.go
@@ -1,0 +1,43 @@
+package stats
+
+import (
+	"context"
+	"testing"
+
+	"reflect"
+
+	"go.opencensus.io/tag"
+)
+
+type Capture struct {
+	Data []Data
+}
+
+func (c *Capture) ExportStats(data Data) {
+	c.Data = append(c.Data, data)
+}
+
+func TestExporter(t *testing.T) {
+	name := "blah"
+	value := "blah"
+	key, _ := tag.NewKey(name)
+	ctx, _ := tag.New(context.Background(), tag.Insert(key, value))
+
+	e := &Capture{}
+	RegisterExporter(e)
+	defer UnregisterExporter(e)
+
+	measure := Int64("name", "description", "kg")
+	m := measure.M(123)
+	Record(ctx, m)
+
+	if got := len(e.Data); got != 1 {
+		t.Fatalf("got %v, want 1", got)
+	}
+	if got := e.Data[0].Measurements; !reflect.DeepEqual(got, []Measurement{m}) {
+		t.Errorf("got %v, want %v", got, []Measurement{m})
+	}
+	if got, ok := e.Data[0].Tags.Value(key); !ok || got != value {
+		t.Errorf("got %v, want %v", got, value)
+	}
+}

--- a/stats/measure_float64.go
+++ b/stats/measure_float64.go
@@ -15,6 +15,8 @@
 
 package stats
 
+import "sync/atomic"
+
 // Float64Measure is a measure for float64 values.
 type Float64Measure struct {
 	md *measureDescriptor
@@ -38,7 +40,7 @@ func (m *Float64Measure) Unit() string {
 // M creates a new float64 measurement.
 // Use Record to record measurements.
 func (m *Float64Measure) M(v float64) Measurement {
-	if !m.md.subscribed() {
+	if n := atomic.LoadInt32(&registrySize); !m.md.subscribed() && n == 0 {
 		return Measurement{}
 	}
 	return Measurement{m: m, v: v}

--- a/stats/measure_int64.go
+++ b/stats/measure_int64.go
@@ -15,6 +15,8 @@
 
 package stats
 
+import "sync/atomic"
+
 // Int64Measure is a measure for int64 values.
 type Int64Measure struct {
 	md *measureDescriptor
@@ -38,7 +40,7 @@ func (m *Int64Measure) Unit() string {
 // M creates a new int64 measurement.
 // Use Record to record measurements.
 func (m *Int64Measure) M(v int64) Measurement {
-	if !m.md.subscribed() {
+	if n := atomic.LoadInt32(&registrySize); !m.md.subscribed() && n == 0 {
 		return Measurement{}
 	}
 	return Measurement{m: m, v: float64(v)}

--- a/stats/record.go
+++ b/stats/record.go
@@ -49,4 +49,18 @@ func Record(ctx context.Context, ms ...Measurement) {
 	if internal.DefaultRecorder != nil {
 		internal.DefaultRecorder(tag.FromContext(ctx), ms)
 	}
+
+	mu.Lock()
+	exporters := registry
+	mu.Unlock()
+
+	if len(exporters) > 0 {
+		data := Data{
+			Tags:         tag.FromContext(ctx),
+			Measurements: ms,
+		}
+		for exporter := range exporters {
+			exporter.ExportStats(data)
+		}
+	}
 }

--- a/stats/record_test.go
+++ b/stats/record_test.go
@@ -1,0 +1,26 @@
+package stats
+
+import (
+	"context"
+	"testing"
+)
+
+type NoOp struct {
+	count int64
+}
+
+func (_ NoOp) ExportStats(data Data) {
+}
+
+func BenchmarkRecordWithExporter(b *testing.B) {
+	e := NoOp{}
+	RegisterExporter(e)
+	defer UnregisterExporter(e)
+
+	measure := Int64("name", "description", "kg")
+	m := measure.M(123)
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		Record(ctx, m)
+	}
+}


### PR DESCRIPTION
Thought I would stir up discussion on support for local aggregation agents with a proof of concept, https://github.com/census-instrumentation/opencensus-specs/issues/63

The challenge, as I see it, is handling where the aggregation is to be done.  In the current opencensus-go implementation, the opencensus client handles aggregation and sends the server pre-aggregated results.  Clearly, there are many benefits to this.

The difficulty arises when one wants to be compatible with myriad of existing hosted stats services such as AWS CloudWatch, statsd, DataDog, etc.  Each of these solutions expects more raw data so they can do the aggregation themselves (either on an agent or the server).

So how to resolve this?  

* One solution would be what the DataDog team took.  Rather than support Sum and Counter types which would require de-aggregating the data, they opted to treat everything as a gauge, https://github.com/DataDog/opencensus-go-exporter-datadog/blob/c11c70d4821e451dfb12cca1e38f338d7cb26374/stats.go#L66  While a simpler solution, I think losing support for Sum/Counter is a hefty price to pay.
* Another alternative is to have each client de-aggregate the opencensus view.Aggregation  While this is possible, it seems like the additional round trip would be something to be avoided.
* Lastly is a solution proposed by this code.  Add an exporter to the stats package directly and allow exporters access to the raw Measurements.

The conflict I can see arising with this last approach is what ends up happening to the view package.  If I use opencensus with say DataDog or AWS CloudWatch, I wouldn't need to declare a view, that's what AWS and DataDog do.  I can simply declare a Measure and be done with it.

This seems less than ideal as over time, if many people use opencensus with cloud providers that do their own aggregation, the use of view may become inconsistent.

This leads me to believe that Measures and Views have a closer relationship than the current opencensus implementation would imply.

Would love to hear people's thoughts on this.