### PR TITLE
optimizes Span.End() to return faster if possible

### DIFF
--- a/plugin/ocgrpc/grpc_test.go
+++ b/plugin/ocgrpc/grpc_test.go
@@ -15,6 +15,7 @@
 package ocgrpc
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -127,9 +128,12 @@ func TestServerHandler(t *testing.T) {
 }
 
 type traceExporter struct {
+	mu     sync.Mutex
 	buffer []*trace.SpanData
 }
 
 func (e *traceExporter) ExportSpan(sd *trace.SpanData) {
+	e.mu.Lock()
 	e.buffer = append(e.buffer, sd)
+	e.mu.Unlock()
 }


### PR DESCRIPTION
Currently Span.End() will create SpanData and place a lock around exporter iteration regardless of the spandata being consumed or actual exporters being registered.

This PR solves that issue by keeping an atomic exporter counter and testing if span data will be consumed by either SpanStore or any Exporter. If no exporters are registered the lock will not be taken and if SpanData is not needed it will not be created.

This solves #681.