### PR TITLE
Don't trace /healthz

### DIFF
--- a/plugin/ochttp/client.go
+++ b/plugin/ochttp/client.go
@@ -57,6 +57,9 @@ type Transport struct {
 // RoundTrip implements http.RoundTripper, delegating to Base and recording stats and traces for the request.
 func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	rt := t.base()
+	if isHealthEndpoint(req.URL.Path) {
+		return rt.RoundTrip(req)
+	}
 	// TODO: remove excessive nesting of http.RoundTrippers here.
 	format := t.Propagation
 	if format == nil {

--- a/plugin/ochttp/server.go
+++ b/plugin/ochttp/server.go
@@ -84,6 +84,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) startTrace(w http.ResponseWriter, r *http.Request) (*http.Request, func()) {
+	if isHealthEndpoint(r.URL.Path) {
+		return r, func() {}
+	}
 	var name string
 	if h.FormatSpanName == nil {
 		name = spanNameFromURL(r)

--- a/plugin/ochttp/trace.go
+++ b/plugin/ochttp/trace.go
@@ -197,3 +197,15 @@ var codeToStr = map[int32]string{
 	trace.StatusCodeDataLoss:           `"DATA_LOSS"`,
 	trace.StatusCodeUnauthenticated:    `"UNAUTHENTICATED"`,
 }
+
+func isHealthEndpoint(path string) bool {
+	// Health checking is pretty frequent and
+	// traces collected for health endpoints
+	// can be extremely noisy and expensive.
+	// Disable canonical health checking endpoints
+	// like /healthz and /_ah/health for now.
+	if path == "/healthz" || path == "/_ah/health" {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
Kubernetes users end up having tons of /healthz traces
which is costly and no-value.

Disable /healthz tracing until we have a better solution.