### PR TITLE
Follow modification to TraceContext HTTP propagation specs

### DIFF
--- a/plugin/ochttp/propagation/tracecontext/propagation.go
+++ b/plugin/ochttp/propagation/tracecontext/propagation.go
@@ -29,7 +29,7 @@ import (
 const (
 	supportedVersion = 0
 	maxVersion       = 254
-	header           = "Trace-Parent"
+	header           = "traceparent"
 )
 
 var _ propagation.HTTPFormat = (*HTTPFormat)(nil)

--- a/plugin/ochttp/propagation/tracecontext/propagation_test.go
+++ b/plugin/ochttp/propagation/tracecontext/propagation_test.go
@@ -73,7 +73,7 @@ func TestHTTPFormat_FromRequest(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req, _ := http.NewRequest("GET", "http://example.com", nil)
-			req.Header.Set("Trace-Parent", tt.header)
+			req.Header.Set("traceparent", tt.header)
 
 			gotSc, gotOk := f.SpanContextFromRequest(req)
 			if !reflect.DeepEqual(gotSc, tt.wantSc) {
@@ -106,7 +106,7 @@ func TestHTTPFormat_ToRequest(t *testing.T) {
 			req, _ := http.NewRequest("GET", "http://example.com", nil)
 			f.SpanContextToRequest(tt.sc, req)
 
-			h := req.Header.Get("Trace-Parent")
+			h := req.Header.Get("traceparent")
 			if got, want := h, tt.wantHeader; got != want {
 				t.Errorf("HTTPFormat.ToRequest() header = %v, want %v", got, want)
 			}


### PR DESCRIPTION
Hi,

According to [the TraceContext specification](https://github.com/w3c/distributed-tracing/blob/master/trace_context/HTTP_HEADER_FORMAT.md#header-name), it should use `traceparent` in HTTP request header when propagating context.

This PR is that follow modification to specs.
I changed to use`traceparent` instead of `Trace-Parent`.