### PR TITLE
use lower 64 bits of TraceID as SpanID for Root Spans

### DIFF
--- a/plugin/ochttp/client.go
+++ b/plugin/ochttp/client.go
@@ -16,6 +16,7 @@ package ochttp
 
 import (
 	"net/http"
+	"net/http/httptrace"
 
 	"go.opencensus.io/trace"
 	"go.opencensus.io/trace/propagation"
@@ -51,6 +52,11 @@ type Transport struct {
 	// name equals the URL Path.
 	FormatSpanName func(*http.Request) string
 
+	// ClientTracer may be set to a function allowing OpenCensus to annotate the
+	// current span with HTTP request event information emitted by the httptrace
+	// package.
+	ClientTracer func(*trace.Span) *httptrace.ClientTrace
+
 	// TODO: Implement tag propagation for HTTP.
 }
 
@@ -77,6 +83,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 			SpanKind: trace.SpanKindClient,
 		},
 		formatSpanName: spanNameFormatter,
+		clientTracer:   t.ClientTracer,
 	}
 	rt = statsTransport{base: rt}
 	return rt.RoundTrip(req)

--- a/plugin/ochttp/client_trace.go
+++ b/plugin/ochttp/client_trace.go
@@ -1,0 +1,174 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ochttp
+
+import (
+	"crypto/tls"
+	"net/http/httptrace"
+	"strings"
+
+	"go.opencensus.io/trace"
+)
+
+// ClientTrace implements the annotation of all available hooks for
+// httptrace.ClientTrace.
+type ClientTrace struct {
+	*trace.Span
+}
+
+// ClientTracer returns a httptrace.ClientTrace instance which instruments all
+// emitted httptrace events on the provided Span.
+func ClientTracer(s *trace.Span) *httptrace.ClientTrace {
+	clientTrace := ClientTrace{s}
+
+	return &httptrace.ClientTrace{
+		GetConn:              clientTrace.GetConn,
+		GotConn:              clientTrace.GotConn,
+		PutIdleConn:          clientTrace.PutIdleConn,
+		GotFirstResponseByte: clientTrace.GotFirstResponseByte,
+		Got100Continue:       clientTrace.Got100Continue,
+		DNSStart:             clientTrace.DNSStart,
+		DNSDone:              clientTrace.DNSDone,
+		ConnectStart:         clientTrace.ConnectStart,
+		ConnectDone:          clientTrace.ConnectDone,
+		TLSHandshakeStart:    clientTrace.TLSHandshakeStart,
+		TLSHandshakeDone:     clientTrace.TLSHandshakeDone,
+		WroteHeaders:         clientTrace.WroteHeaders,
+		Wait100Continue:      clientTrace.Wait100Continue,
+		WroteRequest:         clientTrace.WroteRequest,
+	}
+}
+
+// GetConn implements a httptrace.ClientTrace hook
+func (c ClientTrace) GetConn(hostPort string) {
+	attrs := []trace.Attribute{
+		trace.StringAttribute("httptrace.get_connection.host_port", hostPort),
+	}
+	c.Annotate(attrs, "GetConn")
+}
+
+// GotConn implements a httptrace.ClientTrace hook
+func (c ClientTrace) GotConn(info httptrace.GotConnInfo) {
+	attrs := []trace.Attribute{
+		trace.BoolAttribute("httptrace.got_connection.reused", info.Reused),
+		trace.BoolAttribute("httptrace.got_connection.was_idle", info.WasIdle),
+	}
+	if info.WasIdle {
+		attrs = append(attrs,
+			trace.StringAttribute("httptrace.got_connection.idle_time", info.IdleTime.String()))
+	}
+	c.Annotate(attrs, "GotConn")
+}
+
+// PutIdleConn implements a httptrace.ClientTrace hook
+func (c ClientTrace) PutIdleConn(err error) {
+	var attrs []trace.Attribute
+	if err != nil {
+		attrs = append(attrs,
+			trace.StringAttribute("httptrace.put_idle_connection.error", err.Error()))
+	}
+	c.Annotate(attrs, "PutIdleConn")
+}
+
+// GotFirstResponseByte implements a httptrace.ClientTrace hook
+func (c ClientTrace) GotFirstResponseByte() {
+	c.Annotate(nil, "GotFirstResponseByte")
+}
+
+// Got100Continue implements a httptrace.ClientTrace hook
+func (c ClientTrace) Got100Continue() {
+	c.Annotate(nil, "Got100Continue")
+}
+
+// DNSStart implements a httptrace.ClientTrace hook
+func (c ClientTrace) DNSStart(info httptrace.DNSStartInfo) {
+	attrs := []trace.Attribute{
+		trace.StringAttribute("httptrace.dns_start.host", info.Host),
+	}
+	c.Annotate(attrs, "DNSStart")
+}
+
+// DNSDone implements a httptrace.ClientTrace hook
+func (c ClientTrace) DNSDone(info httptrace.DNSDoneInfo) {
+	var addrs []string
+	for _, addr := range info.Addrs {
+		addrs = append(addrs, addr.String())
+	}
+	attrs := []trace.Attribute{
+		trace.StringAttribute("httptrace.dns_done.addrs", strings.Join(addrs, " , ")),
+	}
+	if info.Err != nil {
+		attrs = append(attrs,
+			trace.StringAttribute("httptrace.dns_done.error", info.Err.Error()))
+	}
+	c.Annotate(attrs, "DNSDone")
+}
+
+// ConnectStart implements a httptrace.ClientTrace hook
+func (c ClientTrace) ConnectStart(network, addr string) {
+	attrs := []trace.Attribute{
+		trace.StringAttribute("httptrace.connect_start.network", network),
+		trace.StringAttribute("httptrace.connect_start.addr", addr),
+	}
+	c.Annotate(attrs, "ConnectStart")
+}
+
+// ConnectDone implements a httptrace.ClientTrace hook
+func (c ClientTrace) ConnectDone(network, addr string, err error) {
+	attrs := []trace.Attribute{
+		trace.StringAttribute("httptrace.connect_done.network", network),
+		trace.StringAttribute("httptrace.connect_done.addr", addr),
+	}
+	if err != nil {
+		attrs = append(attrs,
+			trace.StringAttribute("httptrace.connect_done.error", err.Error()))
+	}
+	c.Annotate(attrs, "ConnectDone")
+}
+
+// TLSHandshakeStart implements a httptrace.ClientTrace hook
+func (c ClientTrace) TLSHandshakeStart() {
+	c.Annotate(nil, "TLSHandshakeStart")
+}
+
+// TLSHandshakeDone implements a httptrace.ClientTrace hook
+func (c ClientTrace) TLSHandshakeDone(_ tls.ConnectionState, err error) {
+	var attrs []trace.Attribute
+	if err != nil {
+		attrs = append(attrs,
+			trace.StringAttribute("httptrace.tls_handshake_done.error", err.Error()))
+	}
+	c.Annotate(attrs, "TLSHandshakeDone")
+}
+
+// WroteHeaders implements a httptrace.ClientTrace hook
+func (c ClientTrace) WroteHeaders() {
+	c.Annotate(nil, "WroteHeaders")
+}
+
+// Wait100Continue implements a httptrace.ClientTrace hook
+func (c ClientTrace) Wait100Continue() {
+	c.Annotate(nil, "Wait100Continue")
+}
+
+// WroteRequest implements a httptrace.ClientTrace hook
+func (c ClientTrace) WroteRequest(info httptrace.WroteRequestInfo) {
+	var attrs []trace.Attribute
+	if info.Err != nil {
+		attrs = append(attrs,
+			trace.StringAttribute("httptrace.wrote_request.error", info.Err.Error()))
+	}
+	c.Annotate(attrs, "WroteRequest")
+}

--- a/plugin/ochttp/client_trace_test.go
+++ b/plugin/ochttp/client_trace_test.go
@@ -1,0 +1,106 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ochttp_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"go.opencensus.io/plugin/ochttp"
+	"go.opencensus.io/trace"
+)
+
+func TestClientTracer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+		resp.Write([]byte("Hello, world!"))
+	}))
+	defer server.Close()
+
+	recorder := &testExporter{}
+
+	trace.RegisterExporter(recorder)
+
+	tr := ochttp.Transport{
+		ClientTracer: ochttp.ClientTracer,
+	}
+
+	req, err := http.NewRequest("POST", server.URL, strings.NewReader("req-body"))
+	if err != nil {
+		t.Errorf("error creating request: %v", err)
+	}
+
+	resp, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Errorf("response error: %v", err)
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Errorf("error closing response body: %v", err)
+	}
+	if got, want := resp.StatusCode, 200; got != want {
+		t.Errorf("resp.StatusCode=%d; want=%d", got, want)
+	}
+
+	if got, want := len(recorder.spans), 1; got != want {
+		t.Errorf("span count=%d; want=%d", got, want)
+	}
+
+	var annotations []string
+	for _, annotation := range recorder.spans[0].Annotations {
+		annotations = append(annotations, annotation.Message)
+	}
+
+	required := []string{
+		"GetConn", "GotConn", "GotFirstResponseByte", "ConnectStart",
+		"ConnectDone", "WroteHeaders", "WroteRequest",
+	}
+
+	if errs := requiredAnnotations(required, annotations); len(errs) > 0 {
+		for _, err := range errs {
+			t.Error(err)
+		}
+	}
+
+}
+
+type testExporter struct {
+	mu    sync.Mutex
+	spans []*trace.SpanData
+}
+
+func (t *testExporter) ExportSpan(s *trace.SpanData) {
+	t.mu.Lock()
+	t.spans = append(t.spans, s)
+	t.mu.Unlock()
+}
+
+func requiredAnnotations(required []string, list []string) []error {
+	var errs []error
+	for _, item := range required {
+		var found bool
+		for _, v := range list {
+			if v == item {
+				found = true
+			}
+		}
+		if !found {
+			errs = append(errs, errors.New("missing expected annotation: "+item))
+		}
+	}
+	return errs
+}

--- a/plugin/ochttp/trace.go
+++ b/plugin/ochttp/trace.go
@@ -17,6 +17,7 @@ package ochttp
 import (
 	"io"
 	"net/http"
+	"net/http/httptrace"
 
 	"go.opencensus.io/plugin/ochttp/propagation/b3"
 	"go.opencensus.io/trace"
@@ -42,6 +43,7 @@ type traceTransport struct {
 	startOptions   trace.StartOptions
 	format         propagation.HTTPFormat
 	formatSpanName func(*http.Request) string
+	clientTracer   func(*trace.Span) *httptrace.ClientTrace
 }
 
 // TODO(jbd): Add message events for request and response size.
@@ -57,7 +59,12 @@ func (t *traceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		trace.WithSampler(t.startOptions.Sampler),
 		trace.WithSpanKind(trace.SpanKindClient))
 
-	req = req.WithContext(ctx)
+	if t.clientTracer != nil {
+		req = req.WithContext(httptrace.WithClientTrace(ctx, t.clientTracer(span)))
+	} else {
+		req = req.WithContext(ctx)
+	}
+
 	if t.format != nil {
 		t.format.SpanContextToRequest(span.SpanContext(), req)
 	}

--- a/trace/config.go
+++ b/trace/config.go
@@ -15,8 +15,9 @@
 package trace
 
 import (
-	"go.opencensus.io/trace/internal"
 	"sync"
+
+	"go.opencensus.io/trace/internal"
 )
 
 // Config represents the global tracing configuration.

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -192,8 +192,10 @@ func startSpanInternal(name string, hasParent bool, parent SpanContext, remotePa
 
 	if !hasParent {
 		span.spanContext.TraceID = cfg.IDGenerator.NewTraceID()
+		copy(span.spanContext.SpanID[:], span.spanContext.TraceID[8:])
+	} else {
+		span.spanContext.SpanID = cfg.IDGenerator.NewSpanID()
 	}
-	span.spanContext.SpanID = cfg.IDGenerator.NewSpanID()
 	sampler := cfg.DefaultSampler
 
 	if !hasParent || remoteParent || o.Sampler != nil {

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -80,6 +80,25 @@ func TestStartSpan(t *testing.T) {
 	}
 }
 
+func TestRootSpanIdentifiers(t *testing.T) {
+	_, span := StartSpan(context.Background(), "StartSpan")
+
+	if span == nil {
+		t.Error("StartSpan: expected valid Span")
+	}
+
+	var (
+		spanContext = span.SpanContext()
+		got         = spanContext.SpanID.String()
+		want        = fmt.Sprintf("%02x", spanContext.TraceID[8:])
+	)
+
+	if got != want {
+		t.Errorf("got Span ID %s, want %s", got, want)
+	}
+
+}
+
 func TestSampling(t *testing.T) {
 	for _, test := range []struct {
 		remoteParent       bool


### PR DESCRIPTION
To avoid using an extra lock and needing to generate additional 64 random bits for the SpanID for Root Spans this PR will re-use the lower 64 bits of the newly generated TraceID as SpanID.