### PR TITLE
Root span performance improvement: re-use  lower 64 bits of TraceID for SpanID

### DIFF
--- a/trace/trace.go
+++ b/trace/trace.go
@@ -192,8 +192,10 @@ func startSpanInternal(name string, hasParent bool, parent SpanContext, remotePa
 
 	if !hasParent {
 		span.spanContext.TraceID = cfg.IDGenerator.NewTraceID()
+		copy(span.spanContext.SpanID[:], span.spanContext.TraceID[8:])
+	} else {
+		span.spanContext.SpanID = cfg.IDGenerator.NewSpanID()
 	}
-	span.spanContext.SpanID = cfg.IDGenerator.NewSpanID()
 	sampler := cfg.DefaultSampler
 
 	if !hasParent || remoteParent || o.Sampler != nil {

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -80,6 +80,21 @@ func TestStartSpan(t *testing.T) {
 	}
 }
 
+func TestRootSpanIdentifiers(t *testing.T) {
+	_, span := StartSpan(context.Background(), "StartSpan")
+	if span == nil {
+		t.Error("StartSpan: expected valid Span")
+	}
+	var (
+		spanContext = span.SpanContext()
+		got         = spanContext.SpanID.String()
+		want        = fmt.Sprintf("%02x", spanContext.TraceID[8:])
+	)
+	if got != want {
+		t.Errorf("got Span ID %s, want %s", got, want)
+	}
+}
+
 func TestSampling(t *testing.T) {
 	for _, test := range []struct {
 		remoteParent       bool


### PR DESCRIPTION
To avoid using an extra lock and needing to generate additional 64 random bits for the SpanID for Root Spans this PR will re-use the lower 64 bits of the newly generated TraceID as SpanID.