### PR TITLE
Document that ExportView is only called from one Goroutine

### DIFF
--- a/stats/view/export.go
+++ b/stats/view/export.go
@@ -27,6 +27,9 @@ var (
 // Exporter takes a significant amount of time to
 // process a Data, that work should be done on another goroutine.
 //
+// It is safe to assume that ExportView will not be called concurrently from
+// multiple goroutines.
+//
 // The Data should not be modified.
 type Exporter interface {
 	ExportView(viewData *Data)


### PR DESCRIPTION
This allows Exporter implementations to avoid unnecessary internal
synchronization.