### PR TITLE
[refactor] Change SpanAnnotator to SpanAnnotatingClientTrace

### DIFF
--- a/plugin/ochttp/span_annotating_client_trace.go
+++ b/plugin/ochttp/span_annotating_client_trace.go
@@ -27,9 +27,16 @@ type spanAnnotator struct {
 	sp *trace.Span
 }
 
-// NewSpanAnnotator returns a httptrace.ClientTrace which annotates all emitted
-// httptrace events on the provided Span.
-func NewSpanAnnotator(_ *http.Request, s *trace.Span) *httptrace.ClientTrace {
+// TODO: Remove NewSpanAnnotator at the next release.
+
+// Deprecated: Use NewSpanAnnotatingClientTrace instead
+func NewSpanAnnotator(r *http.Request, s *trace.Span) *httptrace.ClientTrace {
+	return NewSpanAnnotatingClientTrace(r, s)
+}
+
+// NewSpanAnnotatingClientTrace returns a httptrace.ClientTrace which annotates
+// all emitted httptrace events on the provided Span.
+func NewSpanAnnotatingClientTrace(_ *http.Request, s *trace.Span) *httptrace.ClientTrace {
 	sa := spanAnnotator{sp: s}
 
 	return &httptrace.ClientTrace{

--- a/plugin/ochttp/span_annotating_client_trace_test.go
+++ b/plugin/ochttp/span_annotating_client_trace_test.go
@@ -26,7 +26,7 @@ import (
 	"go.opencensus.io/trace"
 )
 
-func TestSpanAnnotator(t *testing.T) {
+func TestSpanAnnotatingClientTrace(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 		resp.Write([]byte("Hello, world!"))
 	}))
@@ -36,7 +36,7 @@ func TestSpanAnnotator(t *testing.T) {
 
 	trace.RegisterExporter(recorder)
 
-	tr := ochttp.Transport{NewClientTrace: ochttp.NewSpanAnnotator}
+	tr := ochttp.Transport{NewClientTrace: ochttp.NewSpanAnnotatingClientTrace}
 
 	req, err := http.NewRequest("POST", server.URL, strings.NewReader("req-body"))
 	if err != nil {


### PR DESCRIPTION
Currently the `SpanAnnotator` type is in fact a httptrace's `ClientTrace` (a collection of hooks called during the roundtrip flow).

Trying to pass the idea that it's still a ClientTrace that annotates the given Span with information from http events, this change renames it to `SpanAnnotatingClientTrace`.

[Closes #860]