### PR TITLE
Add possibility to Jaeger to add process tags

### DIFF
--- a/exporter/jaeger/example/main.go
+++ b/exporter/jaeger/example/main.go
@@ -30,8 +30,10 @@ func main() {
 	// Register the Jaeger exporter to be able to retrieve
 	// the collected spans.
 	exporter, err := jaeger.NewExporter(jaeger.Options{
-		Endpoint:    "http://localhost:14268",
-		ServiceName: "trace-demo",
+		Endpoint: "http://localhost:14268",
+		Process: jaeger.Process{
+			ServiceName: "trace-demo",
+		},
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/exporter/jaeger/example_test.go
+++ b/exporter/jaeger/example_test.go
@@ -25,8 +25,10 @@ func ExampleNewExporter_collector() {
 	// Register the Jaeger exporter to be able to retrieve
 	// the collected spans.
 	exporter, err := jaeger.NewExporter(jaeger.Options{
-		Endpoint:    "http://localhost:14268",
-		ServiceName: "trace-demo",
+		Endpoint: "http://localhost:14268",
+		Process: jaeger.Process{
+			ServiceName: "trace-demo",
+		},
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -39,7 +41,31 @@ func ExampleNewExporter_agent() {
 	// the collected spans.
 	exporter, err := jaeger.NewExporter(jaeger.Options{
 		AgentEndpoint: "localhost:6831",
-		ServiceName:   "trace-demo",
+		Process: jaeger.Process{
+			ServiceName: "trace-demo",
+		},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	trace.RegisterExporter(exporter)
+}
+
+// ExampleNewExporter_processTags shows how to set ProcessTags
+// on a Jaeger exporter. These tags will be added to the exported
+// Jaeger process.
+func ExampleNewExporter_processTags() {
+	// Register the Jaeger exporter to be able to retrieve
+	// the collected spans.
+	exporter, err := jaeger.NewExporter(jaeger.Options{
+		AgentEndpoint: "localhost:6831",
+		Process: jaeger.Process{
+			ServiceName: "trace-demo",
+			ProcessTags: []jaeger.Tag{
+				jaeger.StringTag("ip", "127.0.0.1"),
+				jaeger.BoolTag("demo", true),
+			},
+		},
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/exporter/jaeger/example_test.go
+++ b/exporter/jaeger/example_test.go
@@ -61,7 +61,7 @@ func ExampleNewExporter_processTags() {
 		AgentEndpoint: "localhost:6831",
 		Process: jaeger.Process{
 			ServiceName: "trace-demo",
-			ProcessTags: []jaeger.Tag{
+			Tags: []jaeger.Tag{
 				jaeger.StringTag("ip", "127.0.0.1"),
 				jaeger.BoolTag("demo", true),
 			},

--- a/exporter/jaeger/jaeger.go
+++ b/exporter/jaeger/jaeger.go
@@ -58,10 +58,10 @@ type Options struct {
 	Password string
 
 	// ServiceName is the Jaeger service name.
-	// deprecated: specify Process instead
+	// Deprecated: Specify Process instead.
 	ServiceName string
 
-	// Process contains the information about the exporting process
+	// Process contains the information about the exporting process.
 	Process Process
 }
 
@@ -97,8 +97,8 @@ func NewExporter(o Options) (*Exporter, error) {
 	} else if service == "" {
 		service = defaultServiceName
 	}
-	tags := make([]*gen.Tag, len(o.Process.ProcessTags))
-	for i, tag := range o.Process.ProcessTags {
+	tags := make([]*gen.Tag, len(o.Process.Tags))
+	for i, tag := range o.Process.Tags {
 		tags[i] = attributeToTag(tag.key, tag.value)
 	}
 	e := &Exporter{
@@ -127,8 +127,8 @@ type Process struct {
 	// ServiceName is the Jaeger service name.
 	ServiceName string
 
-	// ProcessTags are added to Jaeger Process exports
-	ProcessTags []Tag
+	// Tags are added to Jaeger Process exports
+	Tags []Tag
 }
 
 // Tag defines a key-value pair


### PR DESCRIPTION
Jaeger allows to attach tags to it's process, which this patch
allows to specify.
Currently this is limited to bool, string, int64 and int32, as
attributeToTag is used for converting it to *jaeger.Tag.

For reference see the official Jaeger client go:
https://github.com/jaegertracing/jaeger-client-go/blob/252d853b2a4f3cfc98bb89c3a8bb3d3aa50ed4d6/tracer.go#L64

This change helps to specify tags, such as 'ip', which has a special
handling in Jaeger (for example jaeger-query skips clock skew
adjustments for processes from the same IP).