### PR TITLE
add initial version of W3C tracestate

### DIFF
--- a/trace/trace.go
+++ b/trace/trace.go
@@ -295,14 +295,6 @@ func (s *Span) SpanContext() SpanContext {
 	return s.spanContext
 }
 
-// Tracestate returns the Tracestate of the span context.
-func (s *Span) Tracestate() *Tracestate {
-	if s == nil {
-		return nil
-	}
-	return s.spanContext.Tracestate
-}
-
 // SetName sets the name of the span, if it is recording events.
 func (s *Span) SetName(name string) {
 	if !s.IsRecordingEvents() {

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -191,10 +191,12 @@ func startSpanInternal(name string, hasParent bool, parent SpanContext, remotePa
 
 	cfg := config.Load().(*Config)
 
-	if hasParent {
+	if !hasParent {
+		span.spanContext.TraceID = cfg.IDGenerator.NewTraceID()
+	}
+	if hasParent && parent.Tracestate != nil {
 		span.spanContext.Tracestate = parent.Tracestate.Fork()
 	} else {
-		span.spanContext.TraceID = cfg.IDGenerator.NewTraceID()
 		span.spanContext.Tracestate = &Tracestate{}
 	}
 	span.spanContext.SpanID = cfg.IDGenerator.NewSpanID()

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -108,6 +108,7 @@ func TestSampling(t *testing.T) {
 				TraceID:      tid,
 				SpanID:       sid,
 				TraceOptions: test.parentTraceOptions,
+				Tracestate:   &Tracestate{},
 			}
 			ctx, _ = StartSpanWithRemoteParent(context.Background(), "foo", sc, WithSampler(test.sampler))
 		} else if test.localParent {
@@ -189,6 +190,7 @@ func TestStartSpanWithRemoteParent(t *testing.T) {
 		TraceID:      tid,
 		SpanID:       sid,
 		TraceOptions: 0x0,
+		Tracestate:   &Tracestate{},
 	}
 	ctx, _ := StartSpanWithRemoteParent(context.Background(), "startSpanWithRemoteParent", sc)
 	if err := checkChild(sc, FromContext(ctx)); err != nil {
@@ -204,6 +206,7 @@ func TestStartSpanWithRemoteParent(t *testing.T) {
 		TraceID:      tid,
 		SpanID:       sid,
 		TraceOptions: 0x1,
+		Tracestate:   &Tracestate{},
 	}
 	ctx, _ = StartSpanWithRemoteParent(context.Background(), "startSpanWithRemoteParent", sc)
 	if err := checkChild(sc, FromContext(ctx)); err != nil {
@@ -229,6 +232,7 @@ func startSpan(o StartOptions) *Span {
 			TraceID:      tid,
 			SpanID:       sid,
 			TraceOptions: 1,
+			Tracestate:   &Tracestate{},
 		},
 		WithSampler(o.Sampler),
 		WithSpanKind(o.SpanKind),
@@ -299,6 +303,7 @@ func TestSpanKind(t *testing.T) {
 					TraceID:      tid,
 					SpanID:       SpanID{},
 					TraceOptions: 0x1,
+					Tracestate:   &Tracestate{},
 				},
 				ParentSpanID:    sid,
 				Name:            "span0",
@@ -316,6 +321,7 @@ func TestSpanKind(t *testing.T) {
 					TraceID:      tid,
 					SpanID:       SpanID{},
 					TraceOptions: 0x1,
+					Tracestate:   &Tracestate{},
 				},
 				ParentSpanID:    sid,
 				Name:            "span0",
@@ -333,6 +339,7 @@ func TestSpanKind(t *testing.T) {
 					TraceID:      tid,
 					SpanID:       SpanID{},
 					TraceOptions: 0x1,
+					Tracestate:   &Tracestate{},
 				},
 				ParentSpanID:    sid,
 				Name:            "span0",
@@ -367,6 +374,7 @@ func TestSetSpanAttributes(t *testing.T) {
 			TraceID:      tid,
 			SpanID:       SpanID{},
 			TraceOptions: 0x1,
+			Tracestate:   &Tracestate{},
 		},
 		ParentSpanID:    sid,
 		Name:            "span0",
@@ -398,6 +406,7 @@ func TestAnnotations(t *testing.T) {
 			TraceID:      tid,
 			SpanID:       SpanID{},
 			TraceOptions: 0x1,
+			Tracestate:   &Tracestate{},
 		},
 		ParentSpanID: sid,
 		Name:         "span0",
@@ -432,6 +441,7 @@ func TestMessageEvents(t *testing.T) {
 			TraceID:      tid,
 			SpanID:       SpanID{},
 			TraceOptions: 0x1,
+			Tracestate:   &Tracestate{},
 		},
 		ParentSpanID: sid,
 		Name:         "span0",
@@ -510,6 +520,7 @@ func TestSetSpanStatus(t *testing.T) {
 			TraceID:      tid,
 			SpanID:       SpanID{},
 			TraceOptions: 0x1,
+			Tracestate:   &Tracestate{},
 		},
 		ParentSpanID:    sid,
 		Name:            "span0",
@@ -539,6 +550,7 @@ func TestAddLink(t *testing.T) {
 			TraceID:      tid,
 			SpanID:       SpanID{},
 			TraceOptions: 0x1,
+			Tracestate:   &Tracestate{},
 		},
 		ParentSpanID: sid,
 		Name:         "span0",

--- a/trace/tracestate.go
+++ b/trace/tracestate.go
@@ -63,6 +63,11 @@ func (ts *Tracestate) Fork() *Tracestate {
 	return &retval
 }
 
+/*
+TODO: we're making Tracestate immutable for now, ramonza and reyang to figure
+      out how to change it.
+      https://github.com/census-instrumentation/opencensus-go/pull/887
+
 func (ts *Tracestate) Get(key string) string {
 	for _, entry := range ts.entries {
 		if entry.key == key {
@@ -94,6 +99,7 @@ func (ts *Tracestate) Set(key string, value string) string {
 	}
 	return retval
 }
+*/
 
 func (ts *Tracestate) String() string {
 	return fmt.Sprintf("tracestate%s", ts.entries)

--- a/trace/tracestate.go
+++ b/trace/tracestate.go
@@ -1,0 +1,100 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"fmt"
+	"regexp"
+)
+
+const (
+	KEY_WITHOUT_VENDOR_FORMAT = `[a-z][_0-9a-z\-\*\/]{0,255}`
+	KEY_WITH_VENDOR_FORMAT = `[a-z][_0-9a-z\-\*\/]{0,240}@[a-z][_0-9a-z\-\*\/]{0,13}`
+	KEY_FORMAT = `(` + KEY_WITHOUT_VENDOR_FORMAT + `)|(` + KEY_WITH_VENDOR_FORMAT + `)`
+	VALUE_FORMAT = `[\x20-\x2b\x2d-\x3c\x3e-\x7e]{0,255}[\x21-\x2b\x2d-\x3c\x3e-\x7e]`
+)
+
+var KEY_VALIDATION_RE = regexp.MustCompile(`^(` + KEY_FORMAT + `)$`)
+var VALUE_VALIDATION_RE = regexp.MustCompile(`^(` + VALUE_FORMAT + `)$`)
+
+type TracestateEntry struct {
+	key string
+	value string
+}
+
+func (ts *TracestateEntry) IsValid() bool {
+	return KEY_VALIDATION_RE.MatchString(ts.key) &&
+		VALUE_VALIDATION_RE.MatchString(ts.value)
+}
+
+// TraceState is a tracing-system specific context in a list of key-value pairs.
+// TraceState allows different vendors propagate additional information and
+// inter-operate with their legacy Id formats.
+type Tracestate struct {
+	entries []TracestateEntry
+}
+
+func (ts *Tracestate) IsValid() bool {
+	if len(ts.entries) == 0 || len(ts.entries) > 32 {
+		return false
+	}
+	for _, entry := range ts.entries {
+		if !entry.IsValid() {
+			return false
+		}
+	}
+	return true
+}
+
+func (ts *Tracestate) Fork() *Tracestate {
+	retval := Tracestate{entries: ts.entries}
+	return &retval
+}
+
+func (ts *Tracestate) Get(key string) string {
+	for _, entry := range ts.entries {
+		if entry.key == key {
+			return entry.value
+		}
+	}
+	return ""
+}
+
+func (ts *Tracestate) Remove(key string) string {
+	return ts.Set(key, "")
+}
+
+func (ts *Tracestate) Set(key string, value string) string {
+	retval := ""
+	newEntry := TracestateEntry{key: key, value: value}
+	if !newEntry.IsValid() && value != "" {
+		return retval
+	}
+	for index, entry := range ts.entries {
+		if entry.key == key {
+			ts.entries = append(ts.entries[:index], ts.entries[index + 1:]...)
+			retval = entry.value
+			break
+		}
+	}
+	if value != "" {
+		ts.entries = append([]TracestateEntry{newEntry}, ts.entries...)
+	}
+	return retval
+}
+
+func (ts *Tracestate) String() string {
+	return fmt.Sprintf("tracestate%s", ts.entries)
+}

--- a/trace/tracestate.go
+++ b/trace/tracestate.go
@@ -63,11 +63,6 @@ func (ts *Tracestate) Fork() *Tracestate {
 	return &retval
 }
 
-/*
-TODO: we're making Tracestate immutable for now, ramonza and reyang to figure
-      out how to change it.
-      https://github.com/census-instrumentation/opencensus-go/pull/887
-
 func (ts *Tracestate) Get(key string) string {
 	for _, entry := range ts.entries {
 		if entry.key == key {
@@ -76,6 +71,11 @@ func (ts *Tracestate) Get(key string) string {
 	}
 	return ""
 }
+
+/*
+TODO: we're making Tracestate immutable for now, ramonza and reyang to figure
+      out how to change it.
+      https://github.com/census-instrumentation/opencensus-go/pull/887
 
 func (ts *Tracestate) Remove(key string) string {
 	return ts.Set(key, "")

--- a/trace/tracestate.go
+++ b/trace/tracestate.go
@@ -20,14 +20,14 @@ import (
 )
 
 const (
-	KEY_WITHOUT_VENDOR_FORMAT = `[a-z][_0-9a-z\-\*\/]{0,255}`
-	KEY_WITH_VENDOR_FORMAT    = `[a-z][_0-9a-z\-\*\/]{0,240}@[a-z][_0-9a-z\-\*\/]{0,13}`
-	KEY_FORMAT                = `(` + KEY_WITHOUT_VENDOR_FORMAT + `)|(` + KEY_WITH_VENDOR_FORMAT + `)`
-	VALUE_FORMAT              = `[\x20-\x2b\x2d-\x3c\x3e-\x7e]{0,255}[\x21-\x2b\x2d-\x3c\x3e-\x7e]`
+	keyWithoutVendorFormat = `[a-z][_0-9a-z\-\*\/]{0,255}`
+	keyWithVendorFormat    = `[a-z][_0-9a-z\-\*\/]{0,240}@[a-z][_0-9a-z\-\*\/]{0,13}`
+	keyFormat                = `(` + keyWithoutVendorFormat + `)|(` + keyWithVendorFormat + `)`
+	valueFormat              = `[\x20-\x2b\x2d-\x3c\x3e-\x7e]{0,255}[\x21-\x2b\x2d-\x3c\x3e-\x7e]`
 )
 
-var KEY_VALIDATION_RE = regexp.MustCompile(`^(` + KEY_FORMAT + `)$`)
-var VALUE_VALIDATION_RE = regexp.MustCompile(`^(` + VALUE_FORMAT + `)$`)
+var keyValidationRegExp = regexp.MustCompile(`^(` + keyFormat + `)$`)
+var valueValidationRegExp = regexp.MustCompile(`^(` + valueFormat + `)$`)
 
 type TracestateEntry struct {
 	key   string
@@ -35,12 +35,12 @@ type TracestateEntry struct {
 }
 
 func (ts *TracestateEntry) IsValid() bool {
-	return KEY_VALIDATION_RE.MatchString(ts.key) &&
-		VALUE_VALIDATION_RE.MatchString(ts.value)
+	return keyValidationRegExp.MatchString(ts.key) &&
+		valueValidationRegExp.MatchString(ts.value)
 }
 
-// TraceState is a tracing-system specific context in a list of key-value pairs.
-// TraceState allows different vendors propagate additional information and
+// Tracestate is a tracing-system specific context in a list of key-value pairs.
+// Tracestate allows different vendors propagate additional information and
 // inter-operate with their legacy Id formats.
 type Tracestate struct {
 	entries []TracestateEntry

--- a/trace/tracestate.go
+++ b/trace/tracestate.go
@@ -22,8 +22,8 @@ import (
 const (
 	keyWithoutVendorFormat = `[a-z][_0-9a-z\-\*\/]{0,255}`
 	keyWithVendorFormat    = `[a-z][_0-9a-z\-\*\/]{0,240}@[a-z][_0-9a-z\-\*\/]{0,13}`
-	keyFormat                = `(` + keyWithoutVendorFormat + `)|(` + keyWithVendorFormat + `)`
-	valueFormat              = `[\x20-\x2b\x2d-\x3c\x3e-\x7e]{0,255}[\x21-\x2b\x2d-\x3c\x3e-\x7e]`
+	keyFormat              = `(` + keyWithoutVendorFormat + `)|(` + keyWithVendorFormat + `)`
+	valueFormat            = `[\x20-\x2b\x2d-\x3c\x3e-\x7e]{0,255}[\x21-\x2b\x2d-\x3c\x3e-\x7e]`
 )
 
 var keyValidationRegExp = regexp.MustCompile(`^(` + keyFormat + `)$`)

--- a/trace/tracestate.go
+++ b/trace/tracestate.go
@@ -21,16 +21,16 @@ import (
 
 const (
 	KEY_WITHOUT_VENDOR_FORMAT = `[a-z][_0-9a-z\-\*\/]{0,255}`
-	KEY_WITH_VENDOR_FORMAT = `[a-z][_0-9a-z\-\*\/]{0,240}@[a-z][_0-9a-z\-\*\/]{0,13}`
-	KEY_FORMAT = `(` + KEY_WITHOUT_VENDOR_FORMAT + `)|(` + KEY_WITH_VENDOR_FORMAT + `)`
-	VALUE_FORMAT = `[\x20-\x2b\x2d-\x3c\x3e-\x7e]{0,255}[\x21-\x2b\x2d-\x3c\x3e-\x7e]`
+	KEY_WITH_VENDOR_FORMAT    = `[a-z][_0-9a-z\-\*\/]{0,240}@[a-z][_0-9a-z\-\*\/]{0,13}`
+	KEY_FORMAT                = `(` + KEY_WITHOUT_VENDOR_FORMAT + `)|(` + KEY_WITH_VENDOR_FORMAT + `)`
+	VALUE_FORMAT              = `[\x20-\x2b\x2d-\x3c\x3e-\x7e]{0,255}[\x21-\x2b\x2d-\x3c\x3e-\x7e]`
 )
 
 var KEY_VALIDATION_RE = regexp.MustCompile(`^(` + KEY_FORMAT + `)$`)
 var VALUE_VALIDATION_RE = regexp.MustCompile(`^(` + VALUE_FORMAT + `)$`)
 
 type TracestateEntry struct {
-	key string
+	key   string
 	value string
 }
 
@@ -84,7 +84,7 @@ func (ts *Tracestate) Set(key string, value string) string {
 	}
 	for index, entry := range ts.entries {
 		if entry.key == key {
-			ts.entries = append(ts.entries[:index], ts.entries[index + 1:]...)
+			ts.entries = append(ts.entries[:index], ts.entries[index+1:]...)
 			retval = entry.value
 			break
 		}


### PR DESCRIPTION
This is the initial implementation of W3C tracestate in Go.

This is my first time writing program in Go, couple notes/questions:
1. I want to discuss if want to put thread safety guard on Tracestate.Fork(), or leave it as a responsibility for the API consumer.
2. Currently the Tracestate object will be copied every time when a new span got created, I plan to implement COW (copy on write) to improve perf.
3. My next pull request will implement the ochttp integration, which will propagate tracestate in HTTP headers.
