### PR TITLE
zpages: fix countFormatter code and add tests

### DIFF
--- a/zpages/formatter_test.go
+++ b/zpages/formatter_test.go
@@ -1,0 +1,40 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package zpages
+
+import "testing"
+
+func TestCountFormatter(t *testing.T) {
+	tests := []struct {
+		in   int
+		want string
+	}{
+		{-1, " "},
+		{0, " "},
+		{1, "1"},
+		{1024, "1024"},
+		{1e5, "100000"},
+		{1e6, "1.000 M "},
+		{1e9, "1.000 G "},
+		{1e8 + 2e9, "2.100 G "},
+	}
+
+	for _, tt := range tests {
+		if g, w := countFormatter(tt.in), tt.want; g != w {
+			t.Errorf("%d got %q want %q", tt.in, g, w)
+		}
+	}
+}

--- a/zpages/templates.go
+++ b/zpages/templates.go
@@ -66,16 +66,15 @@ func countFormatter(num int) string {
 
 	num64 := int64(num)
 
-	switch {
-	case num64 <= 1e6:
-		floatVal = float64(num64) / 1e3
-		suffix = " M "
-	case num64 <= 1e9:
-		floatVal = float64(num64) / 1e6
-		suffix = " G "
-	default:
-		floatVal = float64(num64) / 1e9
+	if num64 >= 1e12 {
+		floatVal = float64(num64) / 1e12
 		suffix = " T "
+	} else if num64 >= 1e9 {
+		floatVal = float64(num64) / 1e9
+		suffix = " G "
+	} else if num64 >= 1e6 {
+		floatVal = float64(num64) / 1e6
+		suffix = " M "
 	}
 
 	if floatVal != 0 {


### PR DESCRIPTION
Fix countFormatter code due to a bug that
I advertently introduced with a suggestion
in PR 894, due to change of signs:
from >= to <=
it should have just been the int64 cast.

However, also fix a long standing bug in the
original code for the case num >= 12, where
the divisor was copy-pasted as 1e9 instead
of 1e12 for Tera* values.

This change also adds tests to ensure such
problems could be caught in the first place
but that we never regress.