### PR TITLE
Allow other endpoint urls than the default

### DIFF
--- a/exporter/jaeger/jaeger.go
+++ b/exporter/jaeger/jaeger.go
@@ -39,6 +39,10 @@ type Options struct {
 	// For example, http://localhost:14268.
 	Endpoint string
 
+	// EndpointPath is the url path where spans are sent.
+	// For example, /api/traces
+	EndpointPath string
+
 	// AgentEndpoint instructs exporter to send spans to jaeger-agent at this address.
 	// For example, localhost:6831.
 	AgentEndpoint string
@@ -76,7 +80,12 @@ func NewExporter(o Options) (*Exporter, error) {
 	var client *agentClientUDP
 	var err error
 	if endpoint != "" {
-		endpoint = endpoint + "/api/traces?format=jaeger.thrift"
+		if o.EndpointPath != "" {
+			endpoint = endpoint + o.EndpointPath
+		} else {
+			endpoint = endpoint + "/api/traces"
+		}
+		endpoint = endpoint + "?format=jaeger.thrift"
 	} else {
 		client, err = newAgentClientUDP(o.AgentEndpoint, udpPacketMaxLength)
 		if err != nil {

--- a/exporter/jaeger/jaeger.go
+++ b/exporter/jaeger/jaeger.go
@@ -40,6 +40,7 @@ type Options struct {
 	Endpoint string
 
 	// EndpointPath is the url path where spans are sent.
+	// If this is not set, it will send to "/api/traces" as the default
 	// For example, /api/traces
 	EndpointPath string
 

--- a/exporter/jaeger/jaeger.go
+++ b/exporter/jaeger/jaeger.go
@@ -37,6 +37,8 @@ const defaultServiceName = "OpenCensus"
 type Options struct {
 	// Endpoint is the Jaeger HTTP Thrift endpoint.
 	// For example, http://localhost:14268.
+	//
+	// Deprecated: Use CollectorEndpoint instead.
 	Endpoint string
 
 	// CollectorEndpoint is the full url to the Jaeger HTTP Thrift collector.
@@ -81,6 +83,7 @@ func NewExporter(o Options) (*Exporter, error) {
 	var err error
 	if o.Endpoint != "" {
 		endpoint = o.Endpoint + "/api/traces?format=jaeger.thrift"
+		log.Printf("Endpoint has been deprecated. Please use CollectorEndpoint instead.")
 	} else if o.CollectorEndpoint != "" {
 		endpoint = o.CollectorEndpoint
 	} else {


### PR DESCRIPTION
This will allow configuring Thrift endpoints that are not at Jaeger's default `/api/traces`