### PR TITLE
Check measures on record rather than measurement creation

### DIFF
--- a/exporter/prometheus/prometheus_test.go
+++ b/exporter/prometheus/prometheus_test.go
@@ -307,7 +307,7 @@ func TestCumulativenessFromHistograms(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	ms := make([]stats.Measurement, len(values))
+	ms := make([]stats.Measurement, 0, len(values))
 	for _, value := range values {
 		mx := m.M(value)
 		ms = append(ms, mx)

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999
 	github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973
 	github.com/golang/protobuf v1.2.0
+	github.com/google/go-cmp v0.2.0
 	github.com/matttproud/golang_protobuf_extensions v1.0.1
 	github.com/openzipkin/zipkin-go v0.1.1
 	github.com/prometheus/client_golang v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLM
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
+github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/openzipkin/zipkin-go v0.1.1 h1:A/ADD6HaPnAKj3yS7HjGHRK77qi41Hi0DirOOIQAeIw=

--- a/stats/measure.go
+++ b/stats/measure.go
@@ -68,6 +68,21 @@ func (m *measureDescriptor) subscribed() bool {
 	return atomic.LoadInt32(&m.subs) == 1
 }
 
+// Name returns the name of the measure.
+func (m *measureDescriptor) Name() string {
+	return m.name
+}
+
+// Description returns the description of the measure.
+func (m *measureDescriptor) Description() string {
+	return m.description
+}
+
+// Unit returns the unit of the measure.
+func (m *measureDescriptor) Unit() string {
+	return m.unit
+}
+
 var (
 	mu       sync.RWMutex
 	measures = make(map[string]*measureDescriptor)
@@ -94,7 +109,7 @@ func registerMeasureHandle(name, desc, unit string) *measureDescriptor {
 // provides M to convert an int64 into a measurement.
 type Measurement struct {
 	v float64
-	m Measure
+	m *measureDescriptor
 }
 
 // Value returns the value of the Measurement as a float64.

--- a/stats/measure_float64.go
+++ b/stats/measure_float64.go
@@ -17,31 +17,13 @@ package stats
 
 // Float64Measure is a measure for float64 values.
 type Float64Measure struct {
-	md *measureDescriptor
-}
-
-// Name returns the name of the measure.
-func (m *Float64Measure) Name() string {
-	return m.md.name
-}
-
-// Description returns the description of the measure.
-func (m *Float64Measure) Description() string {
-	return m.md.description
-}
-
-// Unit returns the unit of the measure.
-func (m *Float64Measure) Unit() string {
-	return m.md.unit
+	*measureDescriptor
 }
 
 // M creates a new float64 measurement.
 // Use Record to record measurements.
 func (m *Float64Measure) M(v float64) Measurement {
-	if !m.md.subscribed() {
-		return Measurement{}
-	}
-	return Measurement{m: m, v: v}
+	return Measurement{m: m.measureDescriptor, v: v}
 }
 
 // Float64 creates a new measure for float64 values.

--- a/stats/measure_int64.go
+++ b/stats/measure_int64.go
@@ -17,31 +17,13 @@ package stats
 
 // Int64Measure is a measure for int64 values.
 type Int64Measure struct {
-	md *measureDescriptor
-}
-
-// Name returns the name of the measure.
-func (m *Int64Measure) Name() string {
-	return m.md.name
-}
-
-// Description returns the description of the measure.
-func (m *Int64Measure) Description() string {
-	return m.md.description
-}
-
-// Unit returns the unit of the measure.
-func (m *Int64Measure) Unit() string {
-	return m.md.unit
+	*measureDescriptor
 }
 
 // M creates a new int64 measurement.
 // Use Record to record measurements.
 func (m *Int64Measure) M(v int64) Measurement {
-	if !m.md.subscribed() {
-		return Measurement{}
-	}
-	return Measurement{m: m, v: float64(v)}
+	return Measurement{m: m.measureDescriptor, v: float64(v)}
 }
 
 // Int64 creates a new measure for int64 values.

--- a/stats/record.go
+++ b/stats/record.go
@@ -30,15 +30,19 @@ func init() {
 	}
 }
 
-// Record records one or multiple measurements with the same tags at once.
+// Record records one or multiple measurements with the same context at once.
 // If there are any tags in the context, measurements will be tagged with them.
 func Record(ctx context.Context, ms ...Measurement) {
+	recorder := internal.DefaultRecorder
+	if recorder == nil {
+		return
+	}
 	if len(ms) == 0 {
 		return
 	}
-	var record bool
+	record := false
 	for _, m := range ms {
-		if (m != Measurement{}) {
+		if m.m.subscribed() {
 			record = true
 			break
 		}
@@ -46,7 +50,5 @@ func Record(ctx context.Context, ms ...Measurement) {
 	if !record {
 		return
 	}
-	if internal.DefaultRecorder != nil {
-		internal.DefaultRecorder(tag.FromContext(ctx), ms)
-	}
+	recorder(tag.FromContext(ctx), ms)
 }

--- a/stats/view/doc.go
+++ b/stats/view/doc.go
@@ -13,33 +13,34 @@
 // limitations under the License.
 //
 
-/*
-Package view contains support for collecting and exposing aggregates over stats.
-
-In order to collect measurements, views need to be defined and registered.
-A view allows recorded measurements to be filtered and aggregated over a time window.
-
-All recorded measurements can be filtered by a list of tags.
-
-OpenCensus provides several aggregation methods: count, distribution and sum.
-Count aggregation only counts the number of measurement points. Distribution
-aggregation provides statistical summary of the aggregated data. Sum distribution
-sums up the measurement points. Aggregations are cumulative.
-
-Users can dynamically create and delete views.
-
-Libraries can export their own views and claim the view names
-by registering them themselves.
-
-Exporting
-
-Collected and aggregated data can be exported to a metric collection
-backend by registering its exporter.
-
-Multiple exporters can be registered to upload the data to various
-different backends. Users need to unregister the exporters once they
-no longer are needed.
-*/
+// Package view contains support for collecting and exposing aggregates over stats.
+//
+// In order to collect measurements, views need to be defined and registered.
+// A view allows recorded measurements to be filtered and aggregated.
+//
+// All recorded measurements can be grouped by a list of tags.
+//
+// OpenCensus provides several aggregation methods: Count, Distribution and Sum.
+//
+// Count only counts the number of measurement points recorded.
+// Distribution provides statistical summary of the aggregated data by counting
+// how many recorded measurements fall into each bucket.
+// Sum adds up the measurement values.
+// LastValue just keeps track of the most recently recorded measurement value.
+// All aggregations are cumulative.
+//
+// Views can be registerd and unregistered at any time during program execution.
+//
+// Libraries can define views but it is recommended that in most cases registering
+// views be left up to applications.
+//
+// Exporting
+//
+// Collected and aggregated data can be exported to a metric collection
+// backend by registering its exporter.
+//
+// Multiple exporters can be registered to upload the data to various
+// different back ends.
 package view // import "go.opencensus.io/stats/view"
 
 // TODO(acetechnologist): Add a link to the language independent OpenCensus

--- a/stats/view/view_test.go
+++ b/stats/view/view_test.go
@@ -399,3 +399,39 @@ func TestRegisterUnregisterParity(t *testing.T) {
 		}
 	}
 }
+
+func TestRegisterAfterMeasurement(t *testing.T) {
+	// Tests that we can register views after measurements are created and
+	// they still take effect.
+
+	m := stats.Int64(t.Name(), "", stats.UnitDimensionless)
+	mm := m.M(1)
+	ctx := context.Background()
+
+	stats.Record(ctx, mm)
+	v := &View{
+		Measure:     m,
+		Aggregation: Count(),
+	}
+	if err := Register(v); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := RetrieveData(v.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) > 0 {
+		t.Error("View should not have data")
+	}
+
+	stats.Record(ctx, mm)
+
+	rows, err = RetrieveData(v.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) == 0 {
+		t.Error("View should have data")
+	}
+}


### PR DESCRIPTION
Previously, we short-circuited recording with a check at
measurement creation time. This could produce incorrect behavior
if users construct measurements ahead of time and record them
multiple times.

This change moves the check into the record call itself.