### PR TITLE
[travis] Run test suite against 386 arch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,6 @@ script:
   - if [ -n "$(gofmt -s -l $GO_FILES)" ]; then echo "gofmt the following files:"; gofmt -s -l $GO_FILES; exit 1; fi
   - go vet ./...
   - go test -v -race $PKGS            # Run all the tests with the race detector enabled
+  - GOARCH=386 go test -v $PKGS       # Run all tests against a 386 architecture
   - 'if [[ $TRAVIS_GO_VERSION = 1.8* ]]; then ! golint ./... | grep -vE "(_mock|_string|\.pb)\.go:"; fi'
   - go run internal/check/version.go


### PR DESCRIPTION
Notice: Build time for this change is increasing: `Ran for 4 min 21 sec`. Previously it was about 3min.

Besides that, we have a better coverage for problems targeting a 386 architecture.

[Closes #868]