### PR TITLE
stats/view: implement Flush

### DIFF
--- a/stats/view/view_measure_test.go
+++ b/stats/view/view_measure_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestMeasureFloat64AndInt64(t *testing.T) {
+	restart()
+
 	// Recording through both a Float64Measure and Int64Measure with the
 	// same name should work.
 

--- a/stats/view/worker_commands.go
+++ b/stats/view/worker_commands.go
@@ -73,6 +73,17 @@ func (cmd *registerViewReq) handleCommand(w *worker) {
 	}
 }
 
+// flushReq is the command to flush all recorded
+// data regardless of time period and buffering.
+type flushReq struct {
+	c chan bool
+}
+
+func (fr *flushReq) handleCommand(w *worker) {
+	w.reportUsage(time.Now())
+	fr.c <- true
+}
+
 // unregisterFromViewReq is the command to unregister to a view. Has no
 // impact on the data collection for client that are pulling data from the
 // library.


### PR DESCRIPTION
Flush is a global function that immediately reports
all collected data by the worker, regardless of the
reporting duration or buffering.

Added tests but also ensured that calling (*worker).stop()
then Flush doesn't block and returns ASAP if the state
is "quit". The required protected w.quit from double close
but also using a select to detect cases of forever waiting
channel `w.quit` which was closed.

Fixes #862