### PR TITLE
Add constructor functions for Handler and Transport

### DIFF
--- a/plugin/ochttp/example_test.go
+++ b/plugin/ochttp/example_test.go
@@ -19,7 +19,6 @@ import (
 	"net/http"
 
 	"go.opencensus.io/plugin/ochttp"
-	"go.opencensus.io/plugin/ochttp/propagation/b3"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 )
@@ -48,7 +47,7 @@ func ExampleTransport() {
 	}
 
 	client := &http.Client{
-		Transport: &ochttp.Transport{},
+		Transport: ochttp.NewTransport(),
 	}
 
 	// Use client to perform requests.
@@ -60,19 +59,7 @@ var usersHandler http.Handler
 func ExampleHandler() {
 	// import "go.opencensus.io/plugin/ochttp"
 
-	http.Handle("/users", ochttp.WithRouteTag(usersHandler, "/users"))
-
-	// If no handler is specified, the default mux is used.
-	log.Fatal(http.ListenAndServe("localhost:8080", &ochttp.Handler{}))
-}
-
-func ExampleHandler_mux() {
-	// import "go.opencensus.io/plugin/ochttp"
-
 	mux := http.NewServeMux()
 	mux.Handle("/users", ochttp.WithRouteTag(usersHandler, "/users"))
-	log.Fatal(http.ListenAndServe("localhost:8080", &ochttp.Handler{
-		Handler:     mux,
-		Propagation: &b3.HTTPFormat{},
-	}))
+	log.Fatal(http.ListenAndServe("localhost:8080", ochttp.NewHandler(mux)))
 }

--- a/plugin/ochttp/trace.go
+++ b/plugin/ochttp/trace.go
@@ -15,18 +15,22 @@
 package ochttp
 
 import (
+	"go.opencensus.io/plugin/ochttp/propagation/b3"
+	"go.opencensus.io/plugin/ochttp/propagation/tracecontext"
 	"io"
 	"net/http"
 	"net/http/httptrace"
 
-	"go.opencensus.io/plugin/ochttp/propagation/b3"
 	"go.opencensus.io/trace"
 	"go.opencensus.io/trace/propagation"
 )
 
-// TODO(jbd): Add godoc examples.
-
-var defaultFormat propagation.HTTPFormat = &b3.HTTPFormat{}
+var (
+	defaultFormat = &tracecontext.HTTPFormat{}
+	// for backwards compatibility with previous releases, we still use B3 as
+	// default if users rely on the zero value of Transport/Handler.
+	compatibilityFormat = &b3.HTTPFormat{}
+)
 
 // Attributes recorded on the span for the requests.
 // Only trace exporters will need them.


### PR DESCRIPTION
These set the default propagation format to TraceContext.