### PR TITLE
improve W3C Trace Context compliance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,11 @@ module go.opencensus.io
 require (
 	git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999
 	github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973
+	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/golang/protobuf v1.2.0
 	github.com/google/go-cmp v0.2.0
+	github.com/grpc-ecosystem/grpc-gateway v1.5.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1
 	github.com/openzipkin/zipkin-go v0.1.1
 	github.com/prometheus/client_golang v0.8.0
@@ -18,4 +21,5 @@ require (
 	google.golang.org/api v0.0.0-20180910000450-7ca32eb868bf
 	google.golang.org/genproto v0.0.0-20180831171423-11092d34479b
 	google.golang.org/grpc v1.14.0
+	gopkg.in/yaml.v2 v2.2.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -3,10 +3,16 @@ git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999 h1:sihTnRgTOUSCQz0i
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
+github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/grpc-ecosystem/grpc-gateway v1.5.0 h1:WcmKMm43DR7RdtlkEXQJyo5ws8iTp98CyhCCbOHMvNI=
+github.com/grpc-ecosystem/grpc-gateway v1.5.0/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/openzipkin/zipkin-go v0.1.1 h1:A/ADD6HaPnAKj3yS7HjGHRK77qi41Hi0DirOOIQAeIw=
@@ -36,3 +42,6 @@ google.golang.org/genproto v0.0.0-20180831171423-11092d34479b h1:lohp5blsw53GBXt
 google.golang.org/genproto v0.0.0-20180831171423-11092d34479b/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/grpc v1.14.0 h1:ArxJuB1NWfPY6r9Gp9gqwplT0Ge7nqv9msgu03lHLmo=
 google.golang.org/grpc v1.14.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
+gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/plugin/ochttp/client_stats.go
+++ b/plugin/ochttp/client_stats.go
@@ -34,8 +34,11 @@ type statsTransport struct {
 // RoundTrip implements http.RoundTripper, delegating to Base and recording stats for the request.
 func (t statsTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	ctx, _ := tag.New(req.Context(),
+		tag.Upsert(KeyClientHost, req.URL.Host),
 		tag.Upsert(Host, req.URL.Host),
+		tag.Upsert(KeyClientPath, req.URL.Path),
 		tag.Upsert(Path, req.URL.Path),
+		tag.Upsert(KeyClientMethod, req.Method),
 		tag.Upsert(Method, req.Method))
 	req = req.WithContext(ctx)
 	track := &tracker{
@@ -92,15 +95,21 @@ var _ io.ReadCloser = (*tracker)(nil)
 
 func (t *tracker) end() {
 	t.endOnce.Do(func() {
+		latencyMs := float64(time.Since(t.start)) / float64(time.Millisecond)
 		m := []stats.Measurement{
-			ClientLatency.M(float64(time.Since(t.start)) / float64(time.Millisecond)),
+			ClientSentBytes.M(t.reqSize),
+			ClientReceivedBytes.M(t.respSize),
+			ClientRoundtripLatency.M(latencyMs),
+			ClientLatency.M(latencyMs),
 			ClientResponseBytes.M(t.respSize),
 		}
 		if t.reqSize >= 0 {
 			m = append(m, ClientRequestBytes.M(t.reqSize))
 		}
+
 		stats.RecordWithTags(t.ctx, []tag.Mutator{
 			tag.Upsert(StatusCode, strconv.Itoa(t.statusCode)),
+			tag.Upsert(KeyClientStatus, strconv.Itoa(t.statusCode)),
 		}, m...)
 	})
 }

--- a/plugin/ochttp/client_test.go
+++ b/plugin/ochttp/client_test.go
@@ -30,7 +30,104 @@ import (
 
 const reqCount = 5
 
-func TestClient(t *testing.T) {
+func TestClientNew(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+		resp.Write([]byte("Hello, world!"))
+	}))
+	defer server.Close()
+
+	if err := view.Register(
+		ochttp.ClientSentBytesDistribution,
+		ochttp.ClientReceivedBytesDistribution,
+		ochttp.ClientRoundtripLatencyDistribution,
+		ochttp.ClientCompletedCount,
+	); err != nil {
+		t.Fatalf("Failed to register ochttp.DefaultClientViews error: %v", err)
+	}
+
+	views := []string{
+		"opencensus.io/http/client/sent_bytes",
+		"opencensus.io/http/client/received_bytes",
+		"opencensus.io/http/client/roundtrip_latency",
+		"opencensus.io/http/client/completed_count",
+	}
+	for _, name := range views {
+		v := view.Find(name)
+		if v == nil {
+			t.Errorf("view not found %q", name)
+			continue
+		}
+	}
+
+	var wg sync.WaitGroup
+	var tr ochttp.Transport
+	errs := make(chan error, reqCount)
+	wg.Add(reqCount)
+
+	for i := 0; i < reqCount; i++ {
+		go func() {
+			defer wg.Done()
+			req, err := http.NewRequest("POST", server.URL, strings.NewReader("req-body"))
+			if err != nil {
+				errs <- fmt.Errorf("error creating request: %v", err)
+			}
+			resp, err := tr.RoundTrip(req)
+			if err != nil {
+				errs <- fmt.Errorf("response error: %v", err)
+			}
+			if err := resp.Body.Close(); err != nil {
+				errs <- fmt.Errorf("error closing response body: %v", err)
+			}
+			if got, want := resp.StatusCode, 200; got != want {
+				errs <- fmt.Errorf("resp.StatusCode=%d; wantCount %d", got, want)
+			}
+		}()
+	}
+
+	go func() {
+		wg.Wait()
+		close(errs)
+	}()
+
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for _, viewName := range views {
+		v := view.Find(viewName)
+		if v == nil {
+			t.Errorf("view not found %q", viewName)
+			continue
+		}
+		rows, err := view.RetrieveData(v.Name)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		if got, want := len(rows), 1; got != want {
+			t.Errorf("len(%q) = %d; want %d", viewName, got, want)
+			continue
+		}
+		data := rows[0].Data
+		var count int64
+		switch data := data.(type) {
+		case *view.CountData:
+			count = data.Value
+		case *view.DistributionData:
+			count = data.Count
+		default:
+			t.Errorf("Unkown data type: %v", data)
+			continue
+		}
+		if got := count; got != reqCount {
+			t.Fatalf("%s = %d; want %d", viewName, got, reqCount)
+		}
+	}
+}
+
+func TestClientOld(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 		resp.Write([]byte("Hello, world!"))
 	}))

--- a/plugin/ochttp/example_test.go
+++ b/plugin/ochttp/example_test.go
@@ -32,15 +32,14 @@ func ExampleTransport() {
 
 	if err := view.Register(
 		// Register a few default views.
-		ochttp.ClientRequestCountByMethod,
-		ochttp.ClientResponseCountByStatusCode,
-		ochttp.ClientLatencyView,
-
+		ochttp.ClientSentBytesDistribution,
+		ochttp.ClientReceivedBytesDistribution,
+		ochttp.ClientRoundtripLatencyDistribution,
 		// Register a custom view.
 		&view.View{
-			Name:        "httpclient_latency_by_hostpath",
-			TagKeys:     []tag.Key{ochttp.Host, ochttp.Path},
-			Measure:     ochttp.ClientLatency,
+			Name:        "httpclient_latency_by_path",
+			TagKeys:     []tag.Key{ochttp.KeyClientPath},
+			Measure:     ochttp.ClientRoundtripLatency,
 			Aggregation: ochttp.DefaultLatencyDistribution,
 		},
 	); err != nil {

--- a/plugin/ochttp/propagation/tracecontext/propagation.go
+++ b/plugin/ochttp/propagation/tracecontext/propagation.go
@@ -20,12 +20,12 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 
 	"go.opencensus.io/trace"
 	"go.opencensus.io/trace/propagation"
 	"go.opencensus.io/trace/tracestate"
-	"regexp"
 )
 
 const (

--- a/plugin/ochttp/propagation/tracecontext/propagation_test.go
+++ b/plugin/ochttp/propagation/tracecontext/propagation_test.go
@@ -48,10 +48,14 @@ func TestHTTPFormat_FromRequest(t *testing.T) {
 		wantOk bool
 	}{
 		{
-			name:   "unsupported version",
+			name:   "future version",
 			header: "02-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
-			wantSc: trace.SpanContext{},
-			wantOk: false,
+			wantSc: trace.SpanContext{
+				TraceID:      trace.TraceID{75, 249, 47, 53, 119, 179, 77, 166, 163, 206, 146, 157, 14, 14, 71, 54},
+				SpanID:       trace.SpanID{0, 240, 103, 170, 11, 169, 2, 183},
+				TraceOptions: trace.TraceOptions(1),
+			},
+			wantOk: true,
 		},
 		{
 			name:   "zero trace ID and span ID",
@@ -70,17 +74,13 @@ func TestHTTPFormat_FromRequest(t *testing.T) {
 			wantOk: true,
 		},
 		{
-			name:   "no options",
+			name:   "missing options",
 			header: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7",
-			wantSc: trace.SpanContext{
-				TraceID:      trace.TraceID{75, 249, 47, 53, 119, 179, 77, 166, 163, 206, 146, 157, 14, 14, 71, 54},
-				SpanID:       trace.SpanID{0, 240, 103, 170, 11, 169, 2, 183},
-				TraceOptions: trace.TraceOptions(0),
-			},
-			wantOk: true,
+			wantSc: trace.SpanContext{},
+			wantOk: false,
 		},
 		{
-			name:   "missing options",
+			name:   "empty options",
 			header: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-",
 			wantSc: trace.SpanContext{},
 			wantOk: false,

--- a/plugin/ochttp/propagation/tracecontext/propagation_test.go
+++ b/plugin/ochttp/propagation/tracecontext/propagation_test.go
@@ -18,11 +18,11 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 
 	"go.opencensus.io/trace"
 	"go.opencensus.io/trace/tracestate"
-	"strings"
 )
 
 var (

--- a/plugin/ochttp/server.go
+++ b/plugin/ochttp/server.go
@@ -168,6 +168,7 @@ func (t *trackingResponseWriter) end(tags *addedTags) {
 
 		span := trace.FromContext(t.ctx)
 		span.SetStatus(TraceStatus(t.statusCode, t.statusLine))
+		span.AddAttributes(trace.Int64Attribute(StatusCodeAttribute, int64(t.statusCode)))
 
 		m := []stats.Measurement{
 			ServerLatency.M(float64(time.Since(t.start)) / float64(time.Millisecond)),

--- a/plugin/ochttp/stats.go
+++ b/plugin/ochttp/stats.go
@@ -22,10 +22,32 @@ import (
 
 // The following client HTTP measures are supported for use in custom views.
 var (
-	ClientRequestCount  = stats.Int64("opencensus.io/http/client/request_count", "Number of HTTP requests started", stats.UnitDimensionless)
-	ClientRequestBytes  = stats.Int64("opencensus.io/http/client/request_bytes", "HTTP request body size if set as ContentLength (uncompressed)", stats.UnitBytes)
+	// Deprecated: Use a Count aggregation over one of the other client measures to achieve the same effect.
+	ClientRequestCount = stats.Int64("opencensus.io/http/client/request_count", "Number of HTTP requests started", stats.UnitDimensionless)
+	// Deprecated: Use ClientSentBytes.
+	ClientRequestBytes = stats.Int64("opencensus.io/http/client/request_bytes", "HTTP request body size if set as ContentLength (uncompressed)", stats.UnitBytes)
+	// Deprecated: Use ClientReceivedBytes.
 	ClientResponseBytes = stats.Int64("opencensus.io/http/client/response_bytes", "HTTP response body size (uncompressed)", stats.UnitBytes)
-	ClientLatency       = stats.Float64("opencensus.io/http/client/latency", "End-to-end latency", stats.UnitMilliseconds)
+	// Deprecated: Use ClientRoundtripLatency.
+	ClientLatency = stats.Float64("opencensus.io/http/client/latency", "End-to-end latency", stats.UnitMilliseconds)
+)
+
+var (
+	ClientSentBytes = stats.Int64(
+		"opencensus.io/http/client/sent_bytes",
+		"Total bytes sent in request body (not including headers)",
+		stats.UnitBytes,
+	)
+	ClientReceivedBytes = stats.Int64(
+		"opencensus.io/http/client/received_bytes",
+		"Total bytes received in response bodies (not including headers but including error responses with bodies)",
+		stats.UnitBytes,
+	)
+	ClientRoundtripLatency = stats.Float64(
+		"opencensus.io/http/client/roundtrip_latency",
+		"Time between first byte of request headers sent to last byte of response received, or terminal error",
+		stats.UnitMilliseconds,
+	)
 )
 
 // The following server HTTP measures are supported for use in custom views:
@@ -67,6 +89,18 @@ var (
 	KeyServerRoute, _ = tag.NewKey("http_server_route")
 )
 
+// Client tag keys.
+var (
+	// KeyClientMethod is the HTTP method, capitalized (i.e. GET, POST, PUT, DELETE, etc.).
+	KeyClientMethod, _ = tag.NewKey("http_client_method")
+	// KeyClientPath is the URL path (not including query string).
+	KeyClientPath, _ = tag.NewKey("http_client_path")
+	// KeyClientStatus is the HTTP status code as an integer (e.g. 200, 404, 500.), or "error" if no response status line was received.
+	KeyClientStatus, _ = tag.NewKey("http_client_status")
+	// KeyClientHost is the value of the request Host header.
+	KeyClientHost, _ = tag.NewKey("http_client_host")
+)
+
 // Default distributions used by views in this package.
 var (
 	DefaultSizeDistribution    = view.Distribution(0, 1024, 2048, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864, 268435456, 1073741824, 4294967296)
@@ -74,8 +108,43 @@ var (
 )
 
 // Package ochttp provides some convenience views.
-// You need to register the views for data to actually be collected.
+// You still need to register these views for data to actually be collected.
 var (
+	ClientSentBytesDistribution = &view.View{
+		Name:        "opencensus.io/http/client/sent_bytes",
+		Measure:     ClientSentBytes,
+		Aggregation: DefaultSizeDistribution,
+		Description: "Total bytes sent in request body (not including headers), by HTTP method and response status",
+		TagKeys:     []tag.Key{KeyClientMethod, KeyClientStatus},
+	}
+
+	ClientReceivedBytesDistribution = &view.View{
+		Name:        "opencensus.io/http/client/received_bytes",
+		Measure:     ClientReceivedBytes,
+		Aggregation: DefaultSizeDistribution,
+		Description: "Total bytes received in response bodies (not including headers but including error responses with bodies), by HTTP method and response status",
+		TagKeys:     []tag.Key{KeyClientMethod, KeyClientStatus},
+	}
+
+	ClientRoundtripLatencyDistribution = &view.View{
+		Name:        "opencensus.io/http/client/roundtrip_latency",
+		Measure:     ClientRoundtripLatency,
+		Aggregation: DefaultLatencyDistribution,
+		Description: "End-to-end latency, by HTTP method and response status",
+		TagKeys:     []tag.Key{KeyClientMethod, KeyClientStatus},
+	}
+
+	ClientCompletedCount = &view.View{
+		Name:        "opencensus.io/http/client/completed_count",
+		Measure:     ClientRoundtripLatency,
+		Aggregation: view.Count(),
+		Description: "Count of completed requests, by HTTP method and response status",
+		TagKeys:     []tag.Key{KeyClientMethod, KeyClientStatus},
+	}
+)
+
+var (
+	// Deprecated: No direct replacement, but see ClientCompletedCount.
 	ClientRequestCountView = &view.View{
 		Name:        "opencensus.io/http/client/request_count",
 		Description: "Count of HTTP requests started",
@@ -83,43 +152,50 @@ var (
 		Aggregation: view.Count(),
 	}
 
+	// Deprecated: Use ClientSentBytesDistribution.
 	ClientRequestBytesView = &view.View{
 		Name:        "opencensus.io/http/client/request_bytes",
 		Description: "Size distribution of HTTP request body",
-		Measure:     ClientRequestBytes,
+		Measure:     ClientSentBytes,
 		Aggregation: DefaultSizeDistribution,
 	}
 
+	// Deprecated: Use ClientReceivedBytesDistribution.
 	ClientResponseBytesView = &view.View{
 		Name:        "opencensus.io/http/client/response_bytes",
 		Description: "Size distribution of HTTP response body",
-		Measure:     ClientResponseBytes,
+		Measure:     ClientReceivedBytes,
 		Aggregation: DefaultSizeDistribution,
 	}
 
+	// Deprecated: Use ClientRoundtripLatencyDistribution.
 	ClientLatencyView = &view.View{
 		Name:        "opencensus.io/http/client/latency",
 		Description: "Latency distribution of HTTP requests",
-		Measure:     ClientLatency,
+		Measure:     ClientRoundtripLatency,
 		Aggregation: DefaultLatencyDistribution,
 	}
 
+	// Deprecated: Use ClientCompletedCount.
 	ClientRequestCountByMethod = &view.View{
 		Name:        "opencensus.io/http/client/request_count_by_method",
 		Description: "Client request count by HTTP method",
 		TagKeys:     []tag.Key{Method},
-		Measure:     ClientRequestCount,
+		Measure:     ClientSentBytes,
 		Aggregation: view.Count(),
 	}
 
+	// Deprecated: Use ClientCompletedCount.
 	ClientResponseCountByStatusCode = &view.View{
 		Name:        "opencensus.io/http/client/response_count_by_status_code",
 		Description: "Client response count by status code",
 		TagKeys:     []tag.Key{StatusCode},
-		Measure:     ClientLatency,
+		Measure:     ClientRoundtripLatency,
 		Aggregation: view.Count(),
 	}
+)
 
+var (
 	ServerRequestCountView = &view.View{
 		Name:        "opencensus.io/http/server/request_count",
 		Description: "Count of HTTP requests started",
@@ -166,6 +242,7 @@ var (
 )
 
 // DefaultClientViews are the default client views provided by this package.
+// Deprecated: No replacement. Register the views you would like individually.
 var DefaultClientViews = []*view.View{
 	ClientRequestCountView,
 	ClientRequestBytesView,
@@ -176,6 +253,7 @@ var DefaultClientViews = []*view.View{
 }
 
 // DefaultServerViews are the default server views provided by this package.
+// Deprecated: No replacement. Register the views you would like individually.
 var DefaultServerViews = []*view.View{
 	ServerRequestCountView,
 	ServerRequestBytesView,

--- a/plugin/ochttp/stats_test.go
+++ b/plugin/ochttp/stats_test.go
@@ -1,0 +1,88 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ochttp
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+func TestClientViews(t *testing.T) {
+	for _, v := range []*view.View{
+		ClientSentBytesDistribution,
+		ClientReceivedBytesDistribution,
+		ClientRoundtripLatencyDistribution,
+		ClientCompletedCount,
+	} {
+
+		if v.Measure == nil {
+			t.Fatalf("nil measure: %v", v)
+		}
+		if m := v.Measure.Name(); !strings.HasPrefix(m, "opencensus.io/http/client/") {
+			t.Errorf("Unexpected measure name prefix: %v", v)
+		}
+		if v.Name == "" {
+			t.Errorf("Empty name: %v", v)
+		}
+		if !strings.HasPrefix(v.Name, "opencensus.io/http/client/") {
+			t.Errorf("Unexpected prefix: %s", v.Name)
+		}
+		if v.Description == "" {
+			t.Errorf("Empty description: %s", v.Name)
+		}
+		if !reflect.DeepEqual(v.TagKeys, []tag.Key{KeyClientMethod, KeyClientStatus}) {
+			t.Errorf("Unexpected tags for client view %s: %v", v.Name, v.TagKeys)
+		}
+		if strings.HasSuffix(v.Description, ".") {
+			t.Errorf("View description should not end with a period: %s", v.Name)
+		}
+	}
+}
+
+func TestClientTagKeys(t *testing.T) {
+	for _, k := range []tag.Key{
+		KeyClientStatus,
+		KeyClientMethod,
+		KeyClientHost,
+		KeyClientPath,
+	} {
+		if !strings.HasPrefix(k.Name(), "http_client_") {
+			t.Errorf("Unexpected prefix: %s", k.Name())
+		}
+	}
+}
+
+func TestClientMeasures(t *testing.T) {
+	for _, m := range []stats.Measure{
+		ClientSentBytes,
+		ClientReceivedBytes,
+		ClientRoundtripLatency,
+	} {
+		if !strings.HasPrefix(m.Name(), "opencensus.io/http/client/") {
+			t.Errorf("Unexpected prefix: %v", m)
+		}
+		if strings.HasSuffix(m.Description(), ".") {
+			t.Errorf("View description should not end with a period: %s", m.Name())
+		}
+		if len(m.Unit()) == 0 {
+			t.Errorf("No unit: %s", m.Name())
+		}
+	}
+}


### PR DESCRIPTION
Trying to improve the compliance by fixing:
1. Current version allows trace options to be optional, which is against https://github.com/w3c/distributed-tracing/blob/master/trace_context/HTTP_HEADER_FORMAT.md#traceparent-field.
2. Current implementation doesn't combine multiple headers with the same name.
3. Version compatibility.