### PR TITLE
Don't rely on global trace.ApplyConfig in tests

### DIFF
--- a/plugin/ochttp/propagation_test.go
+++ b/plugin/ochttp/propagation_test.go
@@ -36,8 +36,7 @@ func TestRoundTripAllFormats(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
-	ctx, span := trace.StartSpan(ctx, "test")
+	ctx, span := trace.StartSpan(ctx, "test", trace.WithSampler(trace.AlwaysSample()))
 	sc := span.SpanContext()
 	wantStr := fmt.Sprintf("trace_id=%x, span_id=%x, options=%d", sc.TraceID, sc.SpanID, sc.TraceOptions)
 	defer span.End()

--- a/plugin/ochttp/span_annotating_client_trace_test.go
+++ b/plugin/ochttp/span_annotating_client_trace_test.go
@@ -36,7 +36,12 @@ func TestSpanAnnotatingClientTrace(t *testing.T) {
 
 	trace.RegisterExporter(recorder)
 
-	tr := ochttp.Transport{NewClientTrace: ochttp.NewSpanAnnotatingClientTrace}
+	tr := ochttp.Transport{
+		NewClientTrace: ochttp.NewSpanAnnotatingClientTrace,
+		StartOptions: trace.StartOptions{
+			Sampler: trace.AlwaysSample(),
+		},
+	}
 
 	req, err := http.NewRequest("POST", server.URL, strings.NewReader("req-body"))
 	if err != nil {
@@ -55,7 +60,7 @@ func TestSpanAnnotatingClientTrace(t *testing.T) {
 	}
 
 	if got, want := len(recorder.spans), 1; got != want {
-		t.Errorf("span count=%d; want=%d", got, want)
+		t.Fatalf("span count=%d; want=%d", got, want)
 	}
 
 	var annotations []string


### PR DESCRIPTION
Some tests are relying on previous tests changing the global sampler
leading to random failures when tests are run in isolation.

Set an explicit sampler rather than relying on globals.