### PR TITLE
Provide ways to avoid propagating trace and tag metadata

### DIFF
--- a/plugin/ocgrpc/client_stats_handler.go
+++ b/plugin/ocgrpc/client_stats_handler.go
@@ -25,7 +25,7 @@ import (
 )
 
 // statsTagRPC gets the tag.Map populated by the application code, serializes
-// its tags into the GRPC metadata in order to be sent to the server.
+// its tags into the gRPC metadata in order to be sent to the server.
 func (h *ClientHandler) statsTagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
 	startTime := time.Now()
 	if info == nil {

--- a/plugin/ocgrpc/grpc_test.go
+++ b/plugin/ocgrpc/grpc_test.go
@@ -68,9 +68,9 @@ func TestClientHandler(t *testing.T) {
 
 func TestServerHandler(t *testing.T) {
 	tests := []struct {
-		name         string
-		newTrace     bool
-		expectTraces int
+		name           string
+		publicEndpoint bool
+		expectTraces   int
 	}{
 		{"trust_metadata", false, 1},
 		{"no_trust_metadata", true, 0},
@@ -82,7 +82,7 @@ func TestServerHandler(t *testing.T) {
 			ctx := context.Background()
 
 			handler := &ServerHandler{
-				IsPublicEndpoint: test.newTrace,
+				IsPublicEndpoint: test.publicEndpoint,
 				StartOptions: trace.StartOptions{
 					Sampler: trace.ProbabilitySampler(0.0),
 				},

--- a/plugin/ocgrpc/server.go
+++ b/plugin/ocgrpc/server.go
@@ -37,6 +37,8 @@ type ServerHandler struct {
 	// Be aware that if you leave this false (the default) on a public-facing
 	// server, callers will be able to send tracing metadata in gRPC headers
 	// and trigger traces in your backend.
+	//
+	// Tags will only be read from incoming RPCs if IsPublicEndpoint is true.
 	IsPublicEndpoint bool
 
 	// StartOptions to use for to spans started around RPCs handled by this server.

--- a/plugin/ocgrpc/server_stats_handler.go
+++ b/plugin/ocgrpc/server_stats_handler.go
@@ -39,8 +39,10 @@ func (h *ServerHandler) statsTagRPC(ctx context.Context, info *stats.RPCTagInfo)
 		startTime: startTime,
 		method:    info.FullMethodName,
 	}
-	propagated := h.extractPropagatedTags(ctx)
-	ctx = tag.NewContext(ctx, propagated)
+	if !h.IsPublicEndpoint {
+		propagated := h.extractPropagatedTags(ctx)
+		ctx = tag.NewContext(ctx, propagated)
+	}
 	ctx, _ = tag.New(ctx, tag.Upsert(KeyServerMethod, methodName(info.FullMethodName)))
 	return context.WithValue(ctx, rpcDataKey, d)
 }

--- a/plugin/ochttp/propagation/none.go
+++ b/plugin/ochttp/propagation/none.go
@@ -1,0 +1,41 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package propagation contains implementations of common HTTP propagation
+// formats. Most formats are found in named sub-packages.
+package propagation // import "go.opencensus.io/plugin/ochttp/propagation"
+
+import (
+	"net/http"
+
+	"go.opencensus.io/trace"
+	"go.opencensus.io/trace/propagation"
+)
+
+// None returns a propagation format that ignores any incoming headers and
+// doesn't write any outbound headers. This is appropriate to use if you do
+// not want to continue traces from requests your server receives, or if you do
+// not want to propagate traces on outbound requests.
+func None() propagation.HTTPFormat {
+	return (*noPropagation)(nil)
+}
+
+type noPropagation struct{}
+
+func (f *noPropagation) SpanContextFromRequest(_ *http.Request) (trace.SpanContext, bool) {
+	return trace.SpanContext{}, false
+}
+
+func (f *noPropagation) SpanContextToRequest(_ trace.SpanContext, _ *http.Request) {
+}


### PR DESCRIPTION
In certain situations it is undesirable to propagate trace or tag
metadata on outbound requests. Nevertheless, it may still be
desirable to instrument these requests using ocgrpc or ochttp so
that stats and in-process spans may be collected.

This change provides ways to accomplish this for both ocgrpc and
ochttp.