### PR TITLE
exporter/prometheus: allow labels to be configured

### DIFF
--- a/exporter/prometheus/prometheus.go
+++ b/exporter/prometheus/prometheus.go
@@ -44,9 +44,10 @@ type Exporter struct {
 
 // Options contains options for configuring the exporter.
 type Options struct {
-	Namespace string
-	Registry  *prometheus.Registry
-	OnError   func(err error)
+	Namespace   string
+	Registry    *prometheus.Registry
+	OnError     func(err error)
+	ConstLabels prometheus.Labels // ConstLabels will be set as labels on all views.
 }
 
 // NewExporter returns an exporter that exports stats to Prometheus.
@@ -80,7 +81,7 @@ func (c *collector) registerViews(views ...*view.View) {
 				viewName(c.opts.Namespace, view),
 				view.Description,
 				tagKeysToLabels(view.TagKeys),
-				nil,
+				c.opts.ConstLabels,
 			)
 			c.registeredViewsMu.Lock()
 			c.registeredViews[sig] = desc

--- a/exporter/prometheus/prometheus_test.go
+++ b/exporter/prometheus/prometheus_test.go
@@ -342,3 +342,94 @@ func TestCumulativenessFromHistograms(t *testing.T) {
 		t.Fatalf("\ngot:\n%s\n\nwant:\n%s\n", got, want)
 	}
 }
+
+func TestConstLabelsIncluded(t *testing.T) {
+	constLabels := prometheus.Labels{
+		"service": "spanner",
+	}
+	measureLabel, _ := tag.NewKey("method")
+
+	exporter, err := NewExporter(Options{
+		ConstLabels: constLabels,
+	})
+	if err != nil {
+		t.Fatalf("failed to create prometheus exporter: %v", err)
+	}
+	view.RegisterExporter(exporter)
+	defer view.UnregisterExporter(exporter)
+
+	names := []string{"foo", "bar", "baz"}
+
+	var measures mSlice
+	for _, name := range names {
+		measures.createAndAppend("tests/"+name, name, "")
+	}
+
+	var vc vCreator
+	for _, m := range measures {
+		vc.createAndAppend(m.Name(), m.Description(), []tag.Key{measureLabel}, m, view.Count())
+	}
+
+	if err := view.Register(vc...); err != nil {
+		t.Fatalf("failed to create views: %v", err)
+	}
+	defer view.Unregister(vc...)
+
+	view.SetReportingPeriod(time.Millisecond)
+
+	ctx, _ := tag.New(context.Background(), tag.Upsert(measureLabel, "issue961"))
+	for _, m := range measures {
+		stats.Record(ctx, m.M(1))
+	}
+
+	srv := httptest.NewServer(exporter)
+	defer srv.Close()
+
+	var i int
+	var output string
+	for {
+		time.Sleep(10 * time.Millisecond)
+		if i == 1000 {
+			t.Fatal("no output at /metrics (10s wait)")
+		}
+		i++
+
+		resp, err := http.Get(srv.URL)
+		if err != nil {
+			t.Fatalf("failed to get /metrics: %v", err)
+		}
+
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("failed to read body: %v", err)
+		}
+		resp.Body.Close()
+
+		output = string(body)
+		if output != "" {
+			break
+		}
+	}
+
+	if strings.Contains(output, "collected before with the same name and label values") {
+		t.Fatal("metric name and labels being duplicated but must be unique")
+	}
+
+	if strings.Contains(output, "error(s) occurred") {
+		t.Fatal("error reported by prometheus registry")
+	}
+
+	want := `# HELP tests_bar bar
+# TYPE tests_bar counter
+tests_bar{method="issue961",service="spanner"} 1
+# HELP tests_baz baz
+# TYPE tests_baz counter
+tests_baz{method="issue961",service="spanner"} 1
+# HELP tests_foo foo
+# TYPE tests_foo counter
+tests_foo{method="issue961",service="spanner"} 1
+`
+	if output != want {
+		t.Fatal("output differed from expected")
+	}
+}


### PR DESCRIPTION
Allows the user to configure labels consistent across
all views for the exporter.

Fixes #961