### PR TITLE
Keep pointer receiver name consistency for stats.Measure types

### DIFF
--- a/stats/measure.go
+++ b/stats/measure.go
@@ -68,21 +68,6 @@ func (m *measureDescriptor) subscribed() bool {
 	return atomic.LoadInt32(&m.subs) == 1
 }
 
-// Name returns the name of the measure.
-func (m *measureDescriptor) Name() string {
-	return m.name
-}
-
-// Description returns the description of the measure.
-func (m *measureDescriptor) Description() string {
-	return m.description
-}
-
-// Unit returns the unit of the measure.
-func (m *measureDescriptor) Unit() string {
-	return m.unit
-}
-
 var (
 	mu       sync.RWMutex
 	measures = make(map[string]*measureDescriptor)
@@ -108,8 +93,9 @@ func registerMeasureHandle(name, desc, unit string) *measureDescriptor {
 // provides methods to create measurements of their kind. For example, Int64Measure
 // provides M to convert an int64 into a measurement.
 type Measurement struct {
-	v float64
-	m *measureDescriptor
+	v    float64
+	m    Measure
+	desc *measureDescriptor
 }
 
 // Value returns the value of the Measurement as a float64.

--- a/stats/measure_float64.go
+++ b/stats/measure_float64.go
@@ -17,13 +17,17 @@ package stats
 
 // Float64Measure is a measure for float64 values.
 type Float64Measure struct {
-	*measureDescriptor
+	desc *measureDescriptor
 }
 
 // M creates a new float64 measurement.
 // Use Record to record measurements.
 func (m *Float64Measure) M(v float64) Measurement {
-	return Measurement{m: m.measureDescriptor, v: v}
+	return Measurement{
+		m:    m,
+		desc: m.desc,
+		v:    v,
+	}
 }
 
 // Float64 creates a new measure for float64 values.
@@ -33,4 +37,19 @@ func (m *Float64Measure) M(v float64) Measurement {
 func Float64(name, description, unit string) *Float64Measure {
 	mi := registerMeasureHandle(name, description, unit)
 	return &Float64Measure{mi}
+}
+
+// Name returns the name of the measure.
+func (m *Float64Measure) Name() string {
+	return m.desc.name
+}
+
+// Description returns the description of the measure.
+func (m *Float64Measure) Description() string {
+	return m.desc.description
+}
+
+// Unit returns the unit of the measure.
+func (m *Float64Measure) Unit() string {
+	return m.desc.unit
 }

--- a/stats/measure_int64.go
+++ b/stats/measure_int64.go
@@ -17,13 +17,17 @@ package stats
 
 // Int64Measure is a measure for int64 values.
 type Int64Measure struct {
-	*measureDescriptor
+	desc *measureDescriptor
 }
 
 // M creates a new int64 measurement.
 // Use Record to record measurements.
 func (m *Int64Measure) M(v int64) Measurement {
-	return Measurement{m: m.measureDescriptor, v: float64(v)}
+	return Measurement{
+		m:    m,
+		desc: m.desc,
+		v:    float64(v),
+	}
 }
 
 // Int64 creates a new measure for int64 values.
@@ -33,4 +37,19 @@ func (m *Int64Measure) M(v int64) Measurement {
 func Int64(name, description, unit string) *Int64Measure {
 	mi := registerMeasureHandle(name, description, unit)
 	return &Int64Measure{mi}
+}
+
+// Name returns the name of the measure.
+func (m *Int64Measure) Name() string {
+	return m.desc.name
+}
+
+// Description returns the description of the measure.
+func (m *Int64Measure) Description() string {
+	return m.desc.description
+}
+
+// Unit returns the unit of the measure.
+func (m *Int64Measure) Unit() string {
+	return m.desc.unit
 }

--- a/stats/record.go
+++ b/stats/record.go
@@ -43,7 +43,7 @@ func Record(ctx context.Context, ms ...Measurement) {
 	}
 	record := false
 	for _, m := range ms {
-		if m.m.subscribed() {
+		if m.desc.subscribed() {
 			record = true
 			break
 		}


### PR DESCRIPTION
Fixing the receiver name inconsistency from:
type Float64Measure
    func Float64(name, description, unit string) *Float64Measure
    func (m Float64Measure) Description() string
    func (m *Float64Measure) M(v float64) Measurement
    func (m Float64Measure) Name() string
    func (m Float64Measure) Unit() string

to:
type Float64Measure
    func Float64(name, description, unit string) *Float64Measure
    func (m *Float64Measure) Description() string
    func (m *Float64Measure) M(v float64) Measurement
    func (m *Float64Measure) Name() string
    func (m *Float64Measure) Unit() string

Fixes #974.