### PR TITLE
Improve the accuracy of the response size in ochttp

### DIFF
--- a/plugin/ochttp/client_stats.go
+++ b/plugin/ochttp/client_stats.go
@@ -61,6 +61,7 @@ func (t statsTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		track.end()
 	} else {
 		track.statusCode = resp.StatusCode
+		track.respContentLength = resp.ContentLength
 		if resp.Body == nil {
 			track.end()
 		} else {
@@ -82,13 +83,14 @@ func (t statsTransport) CancelRequest(req *http.Request) {
 }
 
 type tracker struct {
-	ctx        context.Context
-	respSize   int64
-	reqSize    int64
-	start      time.Time
-	body       io.ReadCloser
-	statusCode int
-	endOnce    sync.Once
+	ctx               context.Context
+	respSize          int64
+	respContentLength int64
+	reqSize           int64
+	start             time.Time
+	body              io.ReadCloser
+	statusCode        int
+	endOnce           sync.Once
 }
 
 var _ io.ReadCloser = (*tracker)(nil)
@@ -96,9 +98,13 @@ var _ io.ReadCloser = (*tracker)(nil)
 func (t *tracker) end() {
 	t.endOnce.Do(func() {
 		latencyMs := float64(time.Since(t.start)) / float64(time.Millisecond)
+		respSize := t.respSize
+		if t.respSize == 0 && t.respContentLength > 0 {
+			respSize = t.respContentLength
+		}
 		m := []stats.Measurement{
 			ClientSentBytes.M(t.reqSize),
-			ClientReceivedBytes.M(t.respSize),
+			ClientReceivedBytes.M(respSize),
 			ClientRoundtripLatency.M(latencyMs),
 			ClientLatency.M(latencyMs),
 			ClientResponseBytes.M(t.respSize),
@@ -116,9 +122,9 @@ func (t *tracker) end() {
 
 func (t *tracker) Read(b []byte) (int, error) {
 	n, err := t.body.Read(b)
+	t.respSize += int64(n)
 	switch err {
 	case nil:
-		t.respSize += int64(n)
 		return n, nil
 	case io.EOF:
 		t.end()

--- a/plugin/ochttp/client_stats.go
+++ b/plugin/ochttp/client_stats.go
@@ -61,7 +61,9 @@ func (t statsTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		track.end()
 	} else {
 		track.statusCode = resp.StatusCode
-		track.respContentLength = resp.ContentLength
+		if req.Method != "HEAD" {
+			track.respContentLength = resp.ContentLength
+		}
 		if resp.Body == nil {
 			track.end()
 		} else {


### PR DESCRIPTION
Hi

In this PR, I fixed 2 things to improve the accuracy of the response size in the `ochttp` package.

#### 1.
 In function `func (t *tracker) Read(b []byte) (int, error)`, we are counting only when the error is nil.
This means that when we got an `EOF` the `t.respSize` is not incremented. 
Then the value of `t.respSize` is ussually smaller than the actual size. 

 `Reader`'s godoc.
```
When Read encounters an error or end-of-file condition after successfully reading n > 0 bytes, it returns the number of bytes read. 
```

So it would be better to always increase the `t.respSize` even if we have an error to get a closer value.

#### 2. 
The `respSize` is always zero when the dev code does not read the data from the response body, but they just closes the body. 
In that case I think the `ContentLength` from the response is a good choise. 
Then if `t.respSize != 0`, we use `t.respSize`. 
If `t.respSize == 0 && resp.ContentLength > 0`, we use the ContentLength.

Thanks.

