### PR TITLE
Allow setting the http route from HTTP handlers

### DIFF
--- a/plugin/ochttp/route.go
+++ b/plugin/ochttp/route.go
@@ -15,10 +15,20 @@
 package ochttp
 
 import (
+	"context"
 	"net/http"
 
 	"go.opencensus.io/tag"
 )
+
+// SetRoute sets the http_server_route tag to the given value.
+// It's useful when an HTTP framework does not support the http.Handler interface
+// and using WithRouteTag is not an option, but provides a way to hook into the request flow.
+func SetRoute(ctx context.Context, route string) {
+	if a, ok := ctx.Value(addedTagsKey{}).(*addedTags); ok {
+		a.t = append(a.t, tag.Upsert(KeyServerRoute, route))
+	}
+}
 
 // WithRouteTag returns an http.Handler that records stats with the
 // http_server_route tag set to the given value.

--- a/plugin/ochttp/route_test.go
+++ b/plugin/ochttp/route_test.go
@@ -61,6 +61,43 @@ func TestWithRouteTag(t *testing.T) {
 	}
 }
 
+func TestSetRoute(t *testing.T) {
+	v := &view.View{
+		Name:        "request_total",
+		Measure:     ochttp.ServerLatency,
+		Aggregation: view.Count(),
+		TagKeys:     []tag.Key{ochttp.KeyServerRoute},
+	}
+	view.Register(v)
+	var e testStatsExporter
+	view.RegisterExporter(&e)
+	defer view.UnregisterExporter(&e)
+
+	mux := http.NewServeMux()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ochttp.SetRoute(r.Context(), "/a/")
+		w.WriteHeader(204)
+	})
+	mux.Handle("/a/", handler)
+	plugin := ochttp.Handler{Handler: mux}
+	req, _ := http.NewRequest("GET", "/a/b/c", nil)
+	rr := httptest.NewRecorder()
+	plugin.ServeHTTP(rr, req)
+	if got, want := rr.Code, 204; got != want {
+		t.Fatalf("Unexpected response, got %d; want %d", got, want)
+	}
+
+	view.Unregister(v) // trigger exporting
+
+	got := e.rowsForView("request_total")
+	want := []*view.Row{
+		{Data: &view.CountData{Value: 1}, Tags: []tag.Tag{{Key: ochttp.KeyServerRoute, Value: "/a/"}}},
+	}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Unexpected view data exported, -got, +want: %s", diff)
+	}
+}
+
 type testStatsExporter struct {
 	vd []*view.Data
 }


### PR DESCRIPTION
This PR implements the proposed and discussed fix in #944 

I think it would be nice to rewrite the test to a table drive approach, the current testing code contains duplications. If you agree, I will update the tests as well.