### PR TITLE
Increase time waited in TestHandlerImplementsHTTPCloseNotify

### DIFF
--- a/plugin/ochttp/server_test.go
+++ b/plugin/ochttp/server_test.go
@@ -543,7 +543,7 @@ func TestHandlerImplementsHTTPCloseNotify(t *testing.T) {
 	}
 
 	// Wait for a couple of milliseconds for the GoAway frames to be properly propagated
-	<-time.After(150 * time.Millisecond)
+	<-time.After(200 * time.Millisecond)
 
 	wantHTTP1Log := strings.Repeat("ended\n", len(transports))
 	wantHTTP2Log := strings.Repeat("ended\n", len(transports))


### PR DESCRIPTION
Currently this test sometimes fails with the last log message not making it.  In my testing, if I decreased this value the test does this every time so I believe that increasing it will prevent it from happening.

Given that this problem is hard to reproduce in its current form I completely understand if you don't want to accept this PR but as far as I can tell the only risk is slightly increasing the time that this test takes to run.

Fixes #926