### PR TITLE
RFC: add SpanContext.LocalRootSpanID

### DIFF
--- a/trace/export.go
+++ b/trace/export.go
@@ -73,10 +73,11 @@ func UnregisterExporter(e Exporter) {
 // SpanData contains all the information collected by a Span.
 type SpanData struct {
 	SpanContext
-	ParentSpanID SpanID
-	SpanKind     int
-	Name         string
-	StartTime    time.Time
+	ParentSpanID    SpanID
+	LocalRootSpanID SpanID
+	SpanKind        int
+	Name            string
+	StartTime       time.Time
 	// The wall clock time of EndTime will be adjusted to always be offset
 	// from StartTime by the duration of the span.
 	EndTime time.Time

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -100,10 +100,11 @@ func (t TraceOptions) IsSampled() bool {
 // SpanContext is not an implementation of context.Context.
 // TODO: add reference to external Census docs for SpanContext.
 type SpanContext struct {
-	TraceID      TraceID
-	SpanID       SpanID
-	TraceOptions TraceOptions
-	Tracestate   *tracestate.Tracestate
+	TraceID         TraceID
+	SpanID          SpanID
+	LocalRootSpanID SpanID
+	TraceOptions    TraceOptions
+	Tracestate      *tracestate.Tracestate
 }
 
 type contextKey struct{}
@@ -212,6 +213,10 @@ func startSpanInternal(name string, hasParent bool, parent SpanContext, remotePa
 	}
 	span.spanContext.SpanID = cfg.IDGenerator.NewSpanID()
 	sampler := cfg.DefaultSampler
+
+	if !hasParent || remoteParent {
+		span.spanContext.LocalRootSpanID = span.spanContext.SpanID
+	}
 
 	if !hasParent || remoteParent || o.Sampler != nil {
 		// If this span is the child of a local span and no Sampler is set in the

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -39,9 +39,10 @@ type Span struct {
 	// It will be non-nil if we are exporting the span or recording events for it.
 	// Otherwise, data is nil, and the Span is simply a carrier for the
 	// SpanContext, so that the trace ID is propagated.
-	data        *SpanData
-	mu          sync.Mutex // protects the contents of *data (but not the pointer value.)
-	spanContext SpanContext
+	data            *SpanData
+	mu              sync.Mutex // protects the contents of *data (but not the pointer value.)
+	spanContext     SpanContext
+	localRootSpanID SpanID
 
 	// lruAttributes are capped at configured limit. When the capacity is reached an oldest entry
 	// is removed to create room for a new entry.
@@ -100,11 +101,10 @@ func (t TraceOptions) IsSampled() bool {
 // SpanContext is not an implementation of context.Context.
 // TODO: add reference to external Census docs for SpanContext.
 type SpanContext struct {
-	TraceID         TraceID
-	SpanID          SpanID
-	LocalRootSpanID SpanID
-	TraceOptions    TraceOptions
-	Tracestate      *tracestate.Tracestate
+	TraceID      TraceID
+	SpanID       SpanID
+	TraceOptions TraceOptions
+	Tracestate   *tracestate.Tracestate
 }
 
 type contextKey struct{}
@@ -170,14 +170,16 @@ func WithSampler(sampler Sampler) StartOption {
 func StartSpan(ctx context.Context, name string, o ...StartOption) (context.Context, *Span) {
 	var opts StartOptions
 	var parent SpanContext
+	var localRoot SpanID
 	if p := FromContext(ctx); p != nil {
 		p.addChild()
 		parent = p.spanContext
+		localRoot = p.localRootSpanID
 	}
 	for _, op := range o {
 		op(&opts)
 	}
-	span := startSpanInternal(name, parent != SpanContext{}, parent, false, opts)
+	span := startSpanInternal(name, parent != SpanContext{}, parent, localRoot, false, opts)
 
 	ctx, end := startExecutionTracerTask(ctx, name)
 	span.executionTracerTaskEnd = end
@@ -196,15 +198,16 @@ func StartSpanWithRemoteParent(ctx context.Context, name string, parent SpanCont
 	for _, op := range o {
 		op(&opts)
 	}
-	span := startSpanInternal(name, parent != SpanContext{}, parent, true, opts)
+	span := startSpanInternal(name, parent != SpanContext{}, parent, SpanID{}, true, opts)
 	ctx, end := startExecutionTracerTask(ctx, name)
 	span.executionTracerTaskEnd = end
 	return NewContext(ctx, span), span
 }
 
-func startSpanInternal(name string, hasParent bool, parent SpanContext, remoteParent bool, o StartOptions) *Span {
+func startSpanInternal(name string, hasParent bool, parent SpanContext, localRoot SpanID, remoteParent bool, o StartOptions) *Span {
 	span := &Span{}
 	span.spanContext = parent
+	span.localRootSpanID = localRoot
 
 	cfg := config.Load().(*Config)
 
@@ -214,8 +217,8 @@ func startSpanInternal(name string, hasParent bool, parent SpanContext, remotePa
 	span.spanContext.SpanID = cfg.IDGenerator.NewSpanID()
 	sampler := cfg.DefaultSampler
 
-	if !hasParent || remoteParent {
-		span.spanContext.LocalRootSpanID = span.spanContext.SpanID
+	if localRoot == (SpanID{}) {
+		span.localRootSpanID = span.spanContext.SpanID
 	}
 
 	if !hasParent || remoteParent || o.Sampler != nil {
@@ -241,6 +244,7 @@ func startSpanInternal(name string, hasParent bool, parent SpanContext, remotePa
 
 	span.data = &SpanData{
 		SpanContext:     span.spanContext,
+		LocalRootSpanID: span.localRootSpanID,
 		StartTime:       time.Now(),
 		SpanKind:        o.SpanKind,
 		Name:            name,

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -232,27 +232,27 @@ func TestStartSpanWithRemoteParent(t *testing.T) {
 
 func TestLocalRootSpanID(t *testing.T) {
 	ctx, span1 := StartSpan(context.Background(), "span1")
-	if span1.spanContext.LocalRootSpanID == (SpanID{}) {
-		t.Errorf("exporting root span: expected nonzero LocalRootSpanID")
+	if span1.localRootSpanID == (SpanID{}) {
+		t.Errorf("exporting root span: expected nonzero localRootSpanID")
 	}
 
 	_, span2 := StartSpan(ctx, "span2")
 	if err := checkChild(span1.spanContext, span2); err != nil {
 		t.Error(err)
 	}
-	if got, want := span2.spanContext.LocalRootSpanID, span2.spanContext.LocalRootSpanID; got != want {
-		t.Errorf("span2.LocalRootSpanID=%q; want %q (span1.LocalRootSpanID)", got, want)
+	if got, want := span2.localRootSpanID, span2.localRootSpanID; got != want {
+		t.Errorf("span2.localRootSpanID=%q; want %q (span1.localRootSpanID)", got, want)
 	}
 
 	_, span3 := StartSpanWithRemoteParent(context.Background(), "span3", span2.SpanContext())
 	if err := checkChild(span3.spanContext, span2); err != nil {
 		t.Error(err)
 	}
-	if span3.spanContext.LocalRootSpanID == (SpanID{}) {
-		t.Errorf("exporting span with remote parent: expected nonzero LocalRootSpanID")
+	if span3.localRootSpanID == (SpanID{}) {
+		t.Errorf("exporting span with remote parent: expected nonzero localRootSpanID")
 	}
-	if got, want := span3.spanContext.LocalRootSpanID, span2.spanContext.LocalRootSpanID; got == want {
-		t.Errorf("span2.LocalRootSpanID=%q; expected different value to span1.LocalRootSpanID, got same", got)
+	if got, want := span3.localRootSpanID, span2.localRootSpanID; got == want {
+		t.Errorf("span2.localRootSpanID=%q; expected different value to span1.localRootSpanID, got same", got)
 	}
 }
 
@@ -300,11 +300,11 @@ func endSpan(span *Span) (*SpanData, error) {
 	if got.SpanContext.SpanID == (SpanID{}) {
 		return nil, fmt.Errorf("exporting span: expected nonzero SpanID")
 	}
-	if got.SpanContext.LocalRootSpanID == (SpanID{}) {
+	if got.LocalRootSpanID == (SpanID{}) {
 		return nil, fmt.Errorf("exporting span: expected nonzero LocalRootSpanID")
 	}
 	got.SpanContext.SpanID = SpanID{}
-	got.SpanContext.LocalRootSpanID = SpanID{}
+	got.LocalRootSpanID = SpanID{}
 	if !checkTime(&got.StartTime) {
 		return nil, fmt.Errorf("exporting span: expected nonzero StartTime")
 	}

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -240,7 +240,7 @@ func TestLocalRootSpanID(t *testing.T) {
 	if err := checkChild(span1.spanContext, span2); err != nil {
 		t.Error(err)
 	}
-	if got, want := span2.localRootSpanID, span2.localRootSpanID; got != want {
+	if got, want := span2.localRootSpanID, span1.localRootSpanID; got != want {
 		t.Errorf("span2.localRootSpanID=%q; want %q (span1.localRootSpanID)", got, want)
 	}
 
@@ -252,7 +252,7 @@ func TestLocalRootSpanID(t *testing.T) {
 		t.Errorf("exporting span with remote parent: expected nonzero localRootSpanID")
 	}
 	if got, want := span3.localRootSpanID, span2.localRootSpanID; got == want {
-		t.Errorf("span2.localRootSpanID=%q; expected different value to span1.localRootSpanID, got same", got)
+		t.Errorf("span3.localRootSpanID=%q; expected different value to span2.localRootSpanID, got same", got)
 	}
 }
 


### PR DESCRIPTION
This is a companion to https://github.com/census-instrumentation/opencensus-specs/issues/229. These are the changes that would be necessary in order for Elastic APM to implement an exporter, as in https://github.com/elastic/apm-agent-go/compare/master...axw:opencensus.

I'd appreciate feedback either here or on the spec issue, indicating whether this might be acceptable.