### PR TITLE
fix inconsistent jaeger test.

### DIFF
--- a/exporter/jaeger/jaeger_test.go
+++ b/exporter/jaeger/jaeger_test.go
@@ -138,7 +138,7 @@ func Test_spanDataToThrift(t *testing.T) {
 			sort.Slice(tt.want.Tags, func(i, j int) bool {
 				return tt.want.Tags[i].Key < tt.want.Tags[j].Key
 			})
-			if got := spanDataToThrift(tt.data); !reflect.DeepEqual(got, tt.want) {
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("spanDataToThrift() = %v, want %v", got, tt.want)
 			}
 		})

--- a/exporter/jaeger/jaeger_test.go
+++ b/exporter/jaeger/jaeger_test.go
@@ -22,6 +22,7 @@ import (
 
 	gen "go.opencensus.io/exporter/jaeger/internal/gen-go/jaeger"
 	"go.opencensus.io/trace"
+	"sort"
 )
 
 // TODO(jbd): Test export.
@@ -130,6 +131,13 @@ func Test_spanDataToThrift(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			got := spanDataToThrift(tt.data)
+			sort.Slice(got.Tags, func(i, j int) bool {
+				return got.Tags[i].Key < got.Tags[j].Key
+			})
+			sort.Slice(tt.want.Tags, func(i, j int) bool {
+				return tt.want.Tags[i].Key < tt.want.Tags[j].Key
+			})
 			if got := spanDataToThrift(tt.data); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("spanDataToThrift() = %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
attributes (map) is converted to a Tags (array) during conversion. Since data in map is not guaranteed to be in any order the conversion to any array may result into different order then expected. Hence the test fails inconsistently.  The fix is to sort the array prior to comparison.
