### PR TITLE
exporter/jaeger: ensure non-zero status code sets error tag

### DIFF
--- a/exporter/jaeger/jaeger.go
+++ b/exporter/jaeger/jaeger.go
@@ -192,6 +192,11 @@ func (e *Exporter) ExportSpan(data *trace.SpanData) {
 	// TODO(jbd): Handle oversized bundlers.
 }
 
+// As per the OpenCensus Status code mapping in
+//    https://opencensus.io/tracing/span/status/
+// the status is OK if the code is 0.
+const opencensusStatusCodeOK = 0
+
 func spanDataToThrift(data *trace.SpanData) *gen.Span {
 	tags := make([]*gen.Tag, 0, len(data.Attributes))
 	for k, v := range data.Attributes {
@@ -205,6 +210,12 @@ func spanDataToThrift(data *trace.SpanData) *gen.Span {
 		attributeToTag("status.code", data.Status.Code),
 		attributeToTag("status.message", data.Status.Message),
 	)
+
+	// Ensure that if Status.Code is not OK, that we set the "error" tag on the Jaeger span.
+	// See Issue https://github.com/census-instrumentation/opencensus-go/issues/1041
+	if data.Status.Code != opencensusStatusCodeOK {
+		tags = append(tags, attributeToTag("error", true))
+	}
 
 	var logs []*gen.Log
 	for _, a := range data.Annotations {

--- a/exporter/jaeger/jaeger_test.go
+++ b/exporter/jaeger/jaeger_test.go
@@ -64,6 +64,7 @@ func Test_spanDataToThrift(t *testing.T) {
 	resultValue := true
 	statusCodeValue := int64(2)
 	doubleValue := float64(123.456)
+	boolTrue := true
 	statusMessage := "error"
 
 	tests := []struct {
@@ -113,6 +114,7 @@ func Test_spanDataToThrift(t *testing.T) {
 				Tags: []*gen.Tag{
 					{Key: "double", VType: gen.TagType_DOUBLE, VDouble: &doubleValue},
 					{Key: "key", VType: gen.TagType_STRING, VStr: &keyValue},
+					{Key: "error", VType: gen.TagType_BOOL, VBool: &boolTrue},
 					{Key: "status.code", VType: gen.TagType_LONG, VLong: &statusCodeValue},
 					{Key: "status.message", VType: gen.TagType_STRING, VStr: &statusMessage},
 				},
@@ -139,7 +141,7 @@ func Test_spanDataToThrift(t *testing.T) {
 				return tt.want.Tags[i].Key < tt.want.Tags[j].Key
 			})
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("spanDataToThrift() = %v, want %v", got, tt.want)
+				t.Errorf("spanDataToThrift()\nGot:\n%v\nWant;\n%v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
During conversion from OpenCensus-Go SpanData to Jaeger spans,
ensure that if a Status' code is non-zero (0 being "OK"
according to the OpenCensus data model), that we set the
"error" tag on the corresponding Jaeger span.

Fixes #1041