### PR TITLE
Exemplar: Use generic interface for attachment values.

### DIFF
--- a/metric/metricdata/exemplar.go
+++ b/metric/metricdata/exemplar.go
@@ -30,4 +30,4 @@ type Exemplar struct {
 }
 
 // Attachments is a map of extra values associated with a recorded data point.
-type Attachments map[string]string
+type Attachments map[string]interface{}

--- a/stats/internal/record.go
+++ b/stats/internal/record.go
@@ -19,7 +19,7 @@ import (
 )
 
 // DefaultRecorder will be called for each Record call.
-var DefaultRecorder func(tags *tag.Map, measurement interface{}, attachments map[string]string)
+var DefaultRecorder func(tags *tag.Map, measurement interface{}, attachments map[string]interface{})
 
 // SubscriptionReporter reports when a view subscribed with a measure.
 var SubscriptionReporter func(measure string)

--- a/stats/record.go
+++ b/stats/record.go
@@ -51,7 +51,7 @@ func Record(ctx context.Context, ms ...Measurement) {
 		return
 	}
 	// TODO(songy23): fix attachments.
-	recorder(tag.FromContext(ctx), ms, map[string]string{})
+	recorder(tag.FromContext(ctx), ms, map[string]interface{}{})
 }
 
 // RecordWithTags records one or multiple measurements at once.

--- a/stats/view/aggregation_data.go
+++ b/stats/view/aggregation_data.go
@@ -102,7 +102,7 @@ type DistributionData struct {
 	SumOfSquaredDev float64 // sum of the squared deviation from the mean
 	CountPerBucket  []int64 // number of occurrences per bucket
 	// ExemplarsPerBucket is slice the same length as CountPerBucket containing
-	// an emexplar for the associated bucket, or nil.
+	// an exemplar for the associated bucket, or nil.
 	ExemplarsPerBucket []*metricdata.Exemplar
 	bounds             []float64 // histogram distribution of the values
 }

--- a/stats/view/aggregation_data.go
+++ b/stats/view/aggregation_data.go
@@ -17,6 +17,7 @@ package view
 
 import (
 	"math"
+	"time"
 
 	"go.opencensus.io/metric/metricdata"
 )
@@ -26,7 +27,7 @@ import (
 // Mosts users won't directly access aggregration data.
 type AggregationData interface {
 	isAggregationData() bool
-	addSample(v float64)
+	addSample(v float64, attachments map[string]interface{}, t time.Time)
 	clone() AggregationData
 	equal(other AggregationData) bool
 }
@@ -43,7 +44,7 @@ type CountData struct {
 
 func (a *CountData) isAggregationData() bool { return true }
 
-func (a *CountData) addSample(_ float64) {
+func (a *CountData) addSample(_ float64, _ map[string]interface{}, _ time.Time) {
 	a.Value = a.Value + 1
 }
 
@@ -70,7 +71,7 @@ type SumData struct {
 
 func (a *SumData) isAggregationData() bool { return true }
 
-func (a *SumData) addSample(v float64) {
+func (a *SumData) addSample(v float64, _ map[string]interface{}, _ time.Time) {
 	a.Value += v
 }
 
@@ -101,7 +102,7 @@ type DistributionData struct {
 	SumOfSquaredDev float64 // sum of the squared deviation from the mean
 	CountPerBucket  []int64 // number of occurrences per bucket
 	// ExemplarsPerBucket is slice the same length as CountPerBucket containing
-	// an metricdata for the associated bucket, or nil.
+	// an emexplar for the associated bucket, or nil.
 	ExemplarsPerBucket []*metricdata.Exemplar
 	bounds             []float64 // histogram distribution of the values
 }
@@ -130,7 +131,7 @@ func (a *DistributionData) variance() float64 {
 func (a *DistributionData) isAggregationData() bool { return true }
 
 // TODO(songy23): support exemplar attachments.
-func (a *DistributionData) addSample(v float64) {
+func (a *DistributionData) addSample(v float64, attachments map[string]interface{}, t time.Time) {
 	if v < a.Min {
 		a.Min = v
 	}
@@ -138,7 +139,7 @@ func (a *DistributionData) addSample(v float64) {
 		a.Max = v
 	}
 	a.Count++
-	a.addToBucket(v)
+	a.addToBucket(v, attachments, t)
 
 	if a.Count == 1 {
 		a.Mean = v
@@ -150,18 +151,35 @@ func (a *DistributionData) addSample(v float64) {
 	a.SumOfSquaredDev = a.SumOfSquaredDev + (v-oldMean)*(v-a.Mean)
 }
 
-func (a *DistributionData) addToBucket(v float64) {
+func (a *DistributionData) addToBucket(v float64, attachments map[string]interface{}, t time.Time) {
 	var count *int64
-	for i, b := range a.bounds {
+	var i int
+	var b float64
+	for i, b = range a.bounds {
 		if v < b {
 			count = &a.CountPerBucket[i]
 			break
 		}
 	}
 	if count == nil { // Last bucket.
-		count = &a.CountPerBucket[len(a.bounds)]
+		i = len(a.bounds)
+		count = &a.CountPerBucket[i]
 	}
 	*count++
+	if exemplar := getExemplar(v, attachments, t); exemplar != nil {
+		a.ExemplarsPerBucket[i] = exemplar
+	}
+}
+
+func getExemplar(v float64, attachments map[string]interface{}, t time.Time) *metricdata.Exemplar {
+	if len(attachments) == 0 {
+		return nil
+	}
+	return &metricdata.Exemplar{
+		Value:       v,
+		Timestamp:   t,
+		Attachments: attachments,
+	}
 }
 
 func (a *DistributionData) clone() AggregationData {
@@ -199,7 +217,7 @@ func (l *LastValueData) isAggregationData() bool {
 	return true
 }
 
-func (l *LastValueData) addSample(v float64) {
+func (l *LastValueData) addSample(v float64, _ map[string]interface{}, _ time.Time) {
 	l.Value = v
 }
 

--- a/stats/view/aggregation_data_test.go
+++ b/stats/view/aggregation_data_test.go
@@ -68,7 +68,7 @@ func TestDataClone(t *testing.T) {
 func TestDistributionData_addSample(t *testing.T) {
 	dd := newDistributionData([]float64{1, 2})
 	attachments1 := map[string]interface{}{"key1": "value1"}
-	t1, _ := time.Parse("Mon Jan 2 15:04:05 -0700 MST 2006", "Mon Jan 2 15:04:05 -0700 MST 2006")
+	t1 := time.Now()
 	dd.addSample(0.5, attachments1, t1)
 
 	e1 := &metricdata.Exemplar{Value: 0.5, Timestamp: t1, Attachments: attachments1}

--- a/stats/view/collector.go
+++ b/stats/view/collector.go
@@ -17,6 +17,7 @@ package view
 
 import (
 	"sort"
+	"time"
 
 	"go.opencensus.io/internal/tagencoding"
 	"go.opencensus.io/tag"
@@ -31,13 +32,13 @@ type collector struct {
 	a *Aggregation
 }
 
-func (c *collector) addSample(s string, v float64) {
+func (c *collector) addSample(s string, v float64, attachments map[string]interface{}, t time.Time) {
 	aggregator, ok := c.signatures[s]
 	if !ok {
 		aggregator = c.a.newData()
 		c.signatures[s] = aggregator
 	}
-	aggregator.addSample(v)
+	aggregator.addSample(v, attachments, t)
 }
 
 // collectRows returns a snapshot of the collected Row values.

--- a/stats/view/view.go
+++ b/stats/view/view.go
@@ -150,12 +150,12 @@ func (v *viewInternal) collectedRows() []*Row {
 	return v.collector.collectedRows(v.view.TagKeys)
 }
 
-func (v *viewInternal) addSample(m *tag.Map, val float64) {
+func (v *viewInternal) addSample(m *tag.Map, val float64, attachments map[string]interface{}, t time.Time) {
 	if !v.isSubscribed() {
 		return
 	}
 	sig := string(encodeWithKeys(m, v.view.TagKeys))
-	v.collector.addSample(sig, val)
+	v.collector.addSample(sig, val, attachments, t)
 }
 
 // A Data is a set of rows about usage of the single measure associated

--- a/stats/view/view_test.go
+++ b/stats/view/view_test.go
@@ -18,6 +18,7 @@ package view
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 
@@ -177,7 +178,7 @@ func Test_View_MeasureFloat64_AggregationDistribution(t *testing.T) {
 			if err != nil {
 				t.Errorf("%v: New = %v", tc.label, err)
 			}
-			view.addSample(tag.FromContext(ctx), r.f)
+			view.addSample(tag.FromContext(ctx), r.f, nil, time.Now())
 		}
 
 		gotRows := view.collectedRows()
@@ -293,7 +294,7 @@ func Test_View_MeasureFloat64_AggregationSum(t *testing.T) {
 			if err != nil {
 				t.Errorf("%v: New = %v", tt.label, err)
 			}
-			view.addSample(tag.FromContext(ctx), r.f)
+			view.addSample(tag.FromContext(ctx), r.f, nil, time.Now())
 		}
 
 		gotRows := view.collectedRows()

--- a/stats/view/worker.go
+++ b/stats/view/worker.go
@@ -102,7 +102,7 @@ func RetrieveData(viewName string) ([]*Row, error) {
 	return resp.rows, resp.err
 }
 
-func record(tags *tag.Map, ms interface{}, attachments map[string]string) {
+func record(tags *tag.Map, ms interface{}, attachments map[string]interface{}) {
 	req := &recordReq{
 		tm:          tags,
 		ms:          ms.([]stats.Measurement),

--- a/stats/view/worker_commands.go
+++ b/stats/view/worker_commands.go
@@ -148,7 +148,7 @@ func (cmd *retrieveDataReq) handleCommand(w *worker) {
 type recordReq struct {
 	tm          *tag.Map
 	ms          []stats.Measurement
-	attachments map[string]string
+	attachments map[string]interface{}
 	t           time.Time
 }
 
@@ -159,7 +159,7 @@ func (cmd *recordReq) handleCommand(w *worker) {
 		}
 		ref := w.getMeasureRef(m.Measure().Name())
 		for v := range ref.views {
-			v.addSample(cmd.tm, m.Value())
+			v.addSample(cmd.tm, m.Value(), cmd.attachments, time.Now())
 		}
 	}
 }


### PR DESCRIPTION
Updates #1058.

Similar to Java PR https://github.com/census-instrumentation/opencensus-java/pull/1779. Though in Go I think we can take advantage of the flexibility on `interface`s so I just used `interface{}` for generic attachment values. WDYT?