### PR TITLE
[DO NOT MERGE] Exemplar: Refactor Attachment to be similar to Attribute.

### DIFF
--- a/metric/metricdata/exemplar.go
+++ b/metric/metricdata/exemplar.go
@@ -16,6 +16,13 @@ package metricdata
 
 import (
 	"time"
+
+	"go.opencensus.io/trace"
+)
+
+// Exemplars keys.
+const (
+	AttachmentKeySpanContext = "SpanContext"
 )
 
 // Exemplar is an example data point associated with each bucket of a
@@ -24,10 +31,23 @@ import (
 // Their purpose is to provide an example of the kind of thing
 // (request, RPC, trace span, etc.) that resulted in that measurement.
 type Exemplar struct {
-	Value       float64     // the value that was recorded
-	Timestamp   time.Time   // the time the value was recorded
-	Attachments Attachments // attachments (if any)
+	Value       float64                // the value that was recorded
+	Timestamp   time.Time              // the time the value was recorded
+	Attachments map[string]interface{} // attachments (if any)
 }
 
-// Attachments is a map of extra values associated with a recorded data point.
-type Attachments map[string]interface{}
+// Attachment is a key-value pair associated with a recorded example data point.
+type Attachment struct {
+	Key   string
+	Value interface{}
+}
+
+// SpanContextAttachment returns a span context valued attachment.
+func SpanContextAttachment(key string, value trace.SpanContext) Attachment {
+	return Attachment{Key: key, Value: value}
+}
+
+// StringAttachment returns a string attachment.
+func StringAttachment(key string, value string) Attachment {
+	return Attachment{Key: key, Value: value}
+}

--- a/stats/internal/record.go
+++ b/stats/internal/record.go
@@ -15,11 +15,12 @@
 package internal
 
 import (
+	"go.opencensus.io/metric/metricdata"
 	"go.opencensus.io/tag"
 )
 
 // DefaultRecorder will be called for each Record call.
-var DefaultRecorder func(tags *tag.Map, measurement interface{}, attachments map[string]interface{})
+var DefaultRecorder func(tags *tag.Map, measurement interface{}, attachments []metricdata.Attachment)
 
 // SubscriptionReporter reports when a view subscribed with a measure.
 var SubscriptionReporter func(measure string)

--- a/stats/record_test.go
+++ b/stats/record_test.go
@@ -1,0 +1,95 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stats_test
+
+import (
+	"context"
+	"log"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"go.opencensus.io/metric/metricdata"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+	"go.opencensus.io/trace"
+)
+
+var (
+	tid     = trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 4, 8, 16, 32, 64, 128}
+	sid     = trace.SpanID{1, 2, 4, 8, 16, 32, 64, 128}
+	spanCtx = trace.SpanContext{
+		TraceID:      tid,
+		SpanID:       sid,
+		TraceOptions: 1,
+	}
+)
+
+func TestRecordWithAttachments(t *testing.T) {
+	k1, _ := tag.NewKey("k1")
+	k2, _ := tag.NewKey("k2")
+	distribution := view.Distribution(5, 10)
+	m := stats.Int64("TestRecordWithAttachments/m1", "", stats.UnitDimensionless)
+	v := &view.View{
+		Name:        "test_view",
+		TagKeys:     []tag.Key{k1, k2},
+		Measure:     m,
+		Aggregation: distribution,
+	}
+	view.SetReportingPeriod(100 * time.Millisecond)
+	if err := view.Register(v); err != nil {
+		log.Fatalf("Failed to register views: %v", err)
+	}
+
+	attachments := []metricdata.Attachment{metricdata.SpanContextAttachment(metricdata.AttachmentKeySpanContext, spanCtx)}
+	stats.RecordWithAttachments(context.Background(), attachments, m.M(12))
+	rows, err := view.RetrieveData("test_view")
+	if err != nil {
+		t.Errorf("Failed to retrieve data %v", err)
+	}
+	if len(rows) == 0 {
+		t.Errorf("No data was recorded.")
+	}
+	data := rows[0].Data
+	dis, ok := data.(*view.DistributionData)
+	if !ok {
+		t.Errorf("want DistributionData, got %+v", data)
+	}
+	wantBuckets := []int64{0, 0, 1}
+	if !reflect.DeepEqual(dis.CountPerBucket, wantBuckets) {
+		t.Errorf("want buckets %v, got %v", wantBuckets, dis.CountPerBucket)
+	}
+	for i, e := range dis.ExemplarsPerBucket {
+		// Exemplar slice should be [nil, nil, exemplar]
+		if i != 2 && e != nil {
+			t.Errorf("want nil exemplar, got %v", e)
+		}
+		if i == 2 {
+			wantExemplar := &metricdata.Exemplar{Value: 12, Attachments: map[string]interface{}{metricdata.AttachmentKeySpanContext: spanCtx}}
+			if diff := cmpExemplar(e, wantExemplar); diff != "" {
+				t.Fatalf("Unexpected Exemplar -got +want: %s", diff)
+			}
+		}
+	}
+}
+
+// Compare exemplars while ignoring exemplar timestamp, since timestamp is non-deterministic.
+func cmpExemplar(got, want *metricdata.Exemplar) string {
+	return cmp.Diff(got, want, cmpopts.IgnoreFields(metricdata.Exemplar{}, "Timestamp"), cmpopts.IgnoreUnexported(metricdata.Exemplar{}))
+}

--- a/stats/view/aggregation_data_test.go
+++ b/stats/view/aggregation_data_test.go
@@ -67,11 +67,11 @@ func TestDataClone(t *testing.T) {
 
 func TestDistributionData_addSample(t *testing.T) {
 	dd := newDistributionData([]float64{1, 2})
-	attachments1 := map[string]interface{}{"key1": "value1"}
+	attachments1 := []metricdata.Attachment{metricdata.StringAttachment("k", "v")}
 	t1 := time.Now()
 	dd.addSample(0.5, attachments1, t1)
 
-	e1 := &metricdata.Exemplar{Value: 0.5, Timestamp: t1, Attachments: attachments1}
+	e1 := &metricdata.Exemplar{Value: 0.5, Timestamp: t1, Attachments: map[string]interface{}{"k": "v"}}
 	want := &DistributionData{
 		Count:              1,
 		CountPerBucket:     []int64{1, 0, 0},
@@ -85,12 +85,12 @@ func TestDistributionData_addSample(t *testing.T) {
 		t.Fatalf("Unexpected DistributionData -got +want: %s", diff)
 	}
 
-	attachments2 := map[string]interface{}{"key2": "value2"}
+	attachments2 := []metricdata.Attachment{metricdata.StringAttachment("k2", "v2")}
 	t2 := t1.Add(time.Microsecond)
 	dd.addSample(0.7, attachments2, t2)
 
 	// Previous exemplar should be overwritten.
-	e2 := &metricdata.Exemplar{Value: 0.7, Timestamp: t2, Attachments: attachments2}
+	e2 := &metricdata.Exemplar{Value: 0.7, Timestamp: t2, Attachments: map[string]interface{}{"k2": "v2"}}
 	want = &DistributionData{
 		Count:              2,
 		CountPerBucket:     []int64{2, 0, 0},
@@ -104,12 +104,12 @@ func TestDistributionData_addSample(t *testing.T) {
 		t.Fatalf("Unexpected DistributionData -got +want: %s", diff)
 	}
 
-	attachments3 := map[string]interface{}{"key3": "value3"}
+	attachments3 := []metricdata.Attachment{metricdata.StringAttachment("k3", "v3")}
 	t3 := t2.Add(time.Microsecond)
 	dd.addSample(1.2, attachments3, t3)
 
 	// e3 is at another bucket. e2 should still be there.
-	e3 := &metricdata.Exemplar{Value: 1.2, Timestamp: t3, Attachments: attachments3}
+	e3 := &metricdata.Exemplar{Value: 1.2, Timestamp: t3, Attachments: map[string]interface{}{"k3": "v3"}}
 	want = &DistributionData{
 		Count:              3,
 		CountPerBucket:     []int64{2, 1, 0},

--- a/stats/view/collector.go
+++ b/stats/view/collector.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"go.opencensus.io/internal/tagencoding"
+	"go.opencensus.io/metric/metricdata"
 	"go.opencensus.io/tag"
 )
 
@@ -32,7 +33,7 @@ type collector struct {
 	a *Aggregation
 }
 
-func (c *collector) addSample(s string, v float64, attachments map[string]interface{}, t time.Time) {
+func (c *collector) addSample(s string, v float64, attachments []metricdata.Attachment, t time.Time) {
 	aggregator, ok := c.signatures[s]
 	if !ok {
 		aggregator = c.a.newData()

--- a/stats/view/view.go
+++ b/stats/view/view.go
@@ -153,7 +153,7 @@ func (v *viewInternal) collectedRows() []*Row {
 	return v.collector.collectedRows(v.view.TagKeys)
 }
 
-func (v *viewInternal) addSample(m *tag.Map, val float64, attachments map[string]interface{}, t time.Time) {
+func (v *viewInternal) addSample(m *tag.Map, val float64, attachments []metricdata.Attachment, t time.Time) {
 	if !v.isSubscribed() {
 		return
 	}

--- a/stats/view/view_to_metric_test.go
+++ b/stats/view/view_to_metric_test.go
@@ -61,9 +61,6 @@ var (
 	aggL    *Aggregation
 	buckOpt *metricdata.BucketOptions
 
-	// exemplar objects.
-	attachments metricdata.Attachments
-
 	// views and descriptors
 	viewTypeFloat64Distribution         *View
 	viewTypeInt64Distribution           *View

--- a/stats/view/worker.go
+++ b/stats/view/worker.go
@@ -106,7 +106,7 @@ func RetrieveData(viewName string) ([]*Row, error) {
 	return resp.rows, resp.err
 }
 
-func record(tags *tag.Map, ms interface{}, attachments map[string]interface{}) {
+func record(tags *tag.Map, ms interface{}, attachments []metricdata.Attachment) {
 	req := &recordReq{
 		tm:          tags,
 		ms:          ms.([]stats.Measurement),

--- a/stats/view/worker_commands.go
+++ b/stats/view/worker_commands.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"go.opencensus.io/metric/metricdata"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/internal"
 	"go.opencensus.io/tag"
@@ -148,7 +149,7 @@ func (cmd *retrieveDataReq) handleCommand(w *worker) {
 type recordReq struct {
 	tm          *tag.Map
 	ms          []stats.Measurement
-	attachments map[string]interface{}
+	attachments []metricdata.Attachment
 	t           time.Time
 }
 


### PR DESCRIPTION
Created this PR for API discussion first.

Updated the exemplar APIs per https://github.com/census-instrumentation/opencensus-go/pull/1075#discussion_r268331566. Make the exemplar attachment more similar to trace attribute.