### PR TITLE
Replace deprecated Endpoint of Jaeger example

### DIFF
--- a/exporter/jaeger/example/main.go
+++ b/exporter/jaeger/example/main.go
@@ -30,7 +30,7 @@ func main() {
 	// Register the Jaeger exporter to be able to retrieve
 	// the collected spans.
 	exporter, err := jaeger.NewExporter(jaeger.Options{
-		Endpoint: "http://localhost:14268",
+		CollectorEndpoint: "http://localhost:14268/api/traces",
 		Process: jaeger.Process{
 			ServiceName: "trace-demo",
 		},


### PR DESCRIPTION
Jaeger example shows a warning message.

```
2019/03/30 17:27:04 Endpoint has been deprecated. Please use CollectorEndpoint instead.
```