### PR TITLE
Bump up the version to 0.19.3

### DIFF
--- a/opencensus.go
+++ b/opencensus.go
@@ -17,5 +17,5 @@ package opencensus // import "go.opencensus.io"
 
 // Version is the current release version of OpenCensus in use.
 func Version() string {
-	return "0.20.0"
+	return "0.19.3"
 }


### PR DESCRIPTION
v0.19.3 contains all commits from v0.20.0 except https://github.com/census-instrumentation/opencensus-go/commit/3b8e2721f2c3c01fa1bf4a2e455874e7b8319cd7.

Reason for making this patch release: https://github.com/census-instrumentation/opencensus-go/pull/1052#issuecomment-479621304.