### PR TITLE
update issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,21 +1,26 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-
+labels: bug, triage-me
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+Please answer these questions before submitting a bug report.
 
-**To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+### What version of OpenCensus are you using?
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
 
-**Additional context**
+### What version of Node are you using?
+
+
+### What did you do?
+If possible, provide a recipe for reproducing the error.
+
+
+### What did you expect to see?
+
+
+### What did you see instead?
+
+
+### Additional context
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,7 +9,7 @@ Please answer these questions before submitting a bug report.
 ### What version of OpenCensus are you using?
 
 
-### What version of Node are you using?
+### What version of Go are you using?
 
 
 ### What did you do?

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,10 +1,11 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-
+labels: feature-request, triage-me
 ---
 
 **NB:** Before opening a feature request against this repo, consider whether the feature should/could be implemented in other the OpenCensus libraries in other languages. If so, please [open an issue on opencensus-specs](https://github.com/census-instrumentation/opencensus-specs/issues/new) first.
+
 
 
 **Is your feature request related to a problem? Please describe.**


### PR DESCRIPTION
This is to make issue template consistent with all OC repos. Copied from [Node](https://github.com/census-instrumentation/opencensus-node/tree/master/.github/ISSUE_TEMPLATE) implementation.