### PR TITLE
add constant labels to gauges

### DIFF
--- a/metric/gauge.go
+++ b/metric/gauge.go
@@ -32,11 +32,12 @@ import (
 //
 // gauge should not be used directly, use Float64Gauge or Int64Gauge.
 type gauge struct {
-	vals  sync.Map
-	desc  metricdata.Descriptor
-	start time.Time
-	keys  []string
-	gType gaugeType
+	vals             sync.Map
+	desc             metricdata.Descriptor
+	start            time.Time
+	keys             []string
+	constLabelValues []metricdata.LabelValue
+	gType            gaugeType
 }
 
 type gaugeEntry interface {
@@ -142,6 +143,7 @@ func (e *Float64Entry) read(t time.Time) metricdata.Point {
 // The number of label values supplied must be exactly the same as the number
 // of keys supplied when this gauge was created.
 func (g *Float64Gauge) GetEntry(labelVals ...metricdata.LabelValue) (*Float64Entry, error) {
+	labelVals = append(g.g.constLabelValues, labelVals...)
 	entry, err := g.g.entryForValues(labelVals, func() gaugeEntry {
 		return &Float64Entry{}
 	})

--- a/metric/gauge_test.go
+++ b/metric/gauge_test.go
@@ -93,7 +93,6 @@ func TestGaugeConstLabel(t *testing.T) {
 	e.Set(5)
 	e, _ = f.GetEntry(metricdata.NewLabelValue("k1v1"))
 	e.Add(1)
-	e, _ = f.GetEntry(metricdata.NewLabelValue("k1v1"))
 	m := r.Read()
 	want := []*metricdata.Metric{
 		{


### PR DESCRIPTION
This PR adds support for constant labels on gauges. 

The proposed syntax is:
```go
r := NewRegistry()

 	f, _ := r.AddFloat64Gauge("TestGaugeWithConstLabel",
		WithLabelKeys("k1"), WithConstLabel("const", "same"), WithConstLabel("const2", "same2"))
```

@rghetia this is my first contribution and as you were the one who created the issue, could you review this?

closes #1112 
