### PR TITLE
add constant labels to gauges and cumulative metrics

### DIFF
--- a/metric/common.go
+++ b/metric/common.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"go.opencensus.io/internal/tagencoding"
+
 	"go.opencensus.io/metric/metricdata"
 )
 
@@ -30,11 +31,12 @@ import (
 // baseMetric should not be used directly, use metric specific type such as
 // Float64Gauge or Int64Gauge.
 type baseMetric struct {
-	vals   sync.Map
-	desc   metricdata.Descriptor
-	start  time.Time
-	keys   []metricdata.LabelKey
-	bmType baseMetricType
+	vals             sync.Map
+	desc             metricdata.Descriptor
+	start            time.Time
+	keys             []metricdata.LabelKey
+	constLabelValues []metricdata.LabelValue
+	bmType           baseMetricType
 }
 
 type baseMetricType int
@@ -118,6 +120,7 @@ func (bm *baseMetric) decodeLabelVals(s string) []metricdata.LabelValue {
 }
 
 func (bm *baseMetric) entryForValues(labelVals []metricdata.LabelValue, newEntry func() baseEntry) (interface{}, error) {
+	labelVals = append(bm.constLabelValues, labelVals...)
 	if len(labelVals) != len(bm.keys) {
 		return nil, errKeyValueMismatch
 	}

--- a/metric/cumulative_test.go
+++ b/metric/cumulative_test.go
@@ -90,8 +90,8 @@ func TestCumulativeConstLabel(t *testing.T) {
 	f, _ := r.AddFloat64Cumulative("TestCumulativeWithConstLabel",
 		WithLabelKeys("k1"),
 		WithConstLabel(map[metricdata.LabelKey]metricdata.LabelValue{
-			metricdata.LabelKey{Key: "const"}:  metricdata.NewLabelValue("same"),
-			metricdata.LabelKey{Key: "const2"}: metricdata.NewLabelValue("same2"),
+			{Key: "const"}:  metricdata.NewLabelValue("same"),
+			{Key: "const2"}: metricdata.NewLabelValue("same2"),
 		}))
 
 	e, _ := f.GetEntry(metricdata.LabelValue{})

--- a/metric/cumulative_test.go
+++ b/metric/cumulative_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+
 	"go.opencensus.io/metric/metricdata"
 )
 
@@ -68,6 +69,62 @@ func TestCumulative(t *testing.T) {
 					LabelValues: []metricdata.LabelValue{
 						metricdata.NewLabelValue("k1v2"),
 						metricdata.NewLabelValue("k2v2"),
+					},
+					Points: []metricdata.Point{
+						metricdata.NewFloat64Point(time.Time{}, 1),
+					},
+				},
+			},
+		},
+	}
+	canonicalize(m)
+	canonicalize(want)
+	if diff := cmp.Diff(m, want, cmp.Comparer(ignoreTimes)); diff != "" {
+		t.Errorf("-got +want: %s", diff)
+	}
+}
+
+func TestCumulativeConstLabel(t *testing.T) {
+	r := NewRegistry()
+
+	f, _ := r.AddFloat64Cumulative("TestCumulativeWithConstLabel",
+		WithLabelKeys("k1"),
+		WithConstLabel(map[metricdata.LabelKey]metricdata.LabelValue{
+			metricdata.LabelKey{Key: "const"}:  metricdata.NewLabelValue("same"),
+			metricdata.LabelKey{Key: "const2"}: metricdata.NewLabelValue("same2"),
+		}))
+
+	e, _ := f.GetEntry(metricdata.LabelValue{})
+	e.Inc(5)
+	e, _ = f.GetEntry(metricdata.NewLabelValue("k1v1"))
+	e.Inc(1)
+	e, _ = f.GetEntry(metricdata.NewLabelValue("k1v1"))
+	m := r.Read()
+	want := []*metricdata.Metric{
+		{
+			Descriptor: metricdata.Descriptor{
+				Name: "TestCumulativeWithConstLabel",
+				LabelKeys: []metricdata.LabelKey{
+					{Key: "const"},
+					{Key: "const2"},
+					{Key: "k1"}},
+				Type: metricdata.TypeCumulativeFloat64,
+			},
+			TimeSeries: []*metricdata.TimeSeries{
+				{
+					LabelValues: []metricdata.LabelValue{
+						metricdata.NewLabelValue("same"),
+						metricdata.NewLabelValue("same2"),
+						{}},
+					Points: []metricdata.Point{
+						metricdata.NewFloat64Point(time.Time{}, 5),
+					},
+				},
+				{
+					LabelValues: []metricdata.LabelValue{
+						metricdata.NewLabelValue("same"),
+						metricdata.NewLabelValue("same2"),
+						metricdata.NewLabelValue("k1v1"),
 					},
 					Points: []metricdata.Point{
 						metricdata.NewFloat64Point(time.Time{}, 1),

--- a/metric/cumulative_test.go
+++ b/metric/cumulative_test.go
@@ -98,7 +98,6 @@ func TestCumulativeConstLabel(t *testing.T) {
 	e.Inc(5)
 	e, _ = f.GetEntry(metricdata.NewLabelValue("k1v1"))
 	e.Inc(1)
-	e, _ = f.GetEntry(metricdata.NewLabelValue("k1v1"))
 	m := r.Read()
 	want := []*metricdata.Metric{
 		{

--- a/metric/gauge_test.go
+++ b/metric/gauge_test.go
@@ -92,8 +92,8 @@ func TestGaugeConstLabel(t *testing.T) {
 	f, _ := r.AddFloat64Gauge("TestGaugeWithConstLabel",
 		WithLabelKeys("k1"),
 		WithConstLabel(map[metricdata.LabelKey]metricdata.LabelValue{
-			metricdata.LabelKey{Key: "const"}:  metricdata.NewLabelValue("same"),
-			metricdata.LabelKey{Key: "const2"}: metricdata.NewLabelValue("same2"),
+			{Key: "const"}:  metricdata.NewLabelValue("same"),
+			{Key: "const2"}: metricdata.NewLabelValue("same2"),
 		}))
 
 	e, _ := f.GetEntry(metricdata.LabelValue{})

--- a/metric/gauge_test.go
+++ b/metric/gauge_test.go
@@ -100,7 +100,6 @@ func TestGaugeConstLabel(t *testing.T) {
 	e.Set(5)
 	e, _ = f.GetEntry(metricdata.NewLabelValue("k1v1"))
 	e.Add(1)
-	e, _ = f.GetEntry(metricdata.NewLabelValue("k1v1"))
 	m := r.Read()
 	want := []*metricdata.Metric{
 		{

--- a/metric/gauge_test.go
+++ b/metric/gauge_test.go
@@ -16,12 +16,13 @@ package metric
 
 import (
 	"fmt"
-	"go.opencensus.io/metric/metricdata"
 	"sort"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+
+	"go.opencensus.io/metric/metricdata"
 )
 
 func TestGauge(t *testing.T) {
@@ -70,6 +71,63 @@ func TestGauge(t *testing.T) {
 					LabelValues: []metricdata.LabelValue{
 						metricdata.NewLabelValue("k1v2"),
 						metricdata.NewLabelValue("k2v2"),
+					},
+					Points: []metricdata.Point{
+						metricdata.NewFloat64Point(time.Time{}, 1),
+					},
+				},
+			},
+		},
+	}
+	canonicalize(m)
+	canonicalize(want)
+	if diff := cmp.Diff(m, want, cmp.Comparer(ignoreTimes)); diff != "" {
+		t.Errorf("-got +want: %s", diff)
+	}
+}
+
+func TestGaugeConstLabel(t *testing.T) {
+	r := NewRegistry()
+
+	f, _ := r.AddFloat64Gauge("TestGaugeWithConstLabel",
+		WithLabelKeys("k1"),
+		WithConstLabel(map[metricdata.LabelKey]metricdata.LabelValue{
+			metricdata.LabelKey{Key: "const"}:  metricdata.NewLabelValue("same"),
+			metricdata.LabelKey{Key: "const2"}: metricdata.NewLabelValue("same2"),
+		}))
+
+	e, _ := f.GetEntry(metricdata.LabelValue{})
+	e.Set(5)
+	e, _ = f.GetEntry(metricdata.NewLabelValue("k1v1"))
+	e.Add(1)
+	e, _ = f.GetEntry(metricdata.NewLabelValue("k1v1"))
+	m := r.Read()
+	want := []*metricdata.Metric{
+		{
+			Descriptor: metricdata.Descriptor{
+				Name: "TestGaugeWithConstLabel",
+				LabelKeys: []metricdata.LabelKey{
+					{Key: "const"},
+					{Key: "const2"},
+					{Key: "k1"}},
+				Type: metricdata.TypeGaugeFloat64,
+			},
+			TimeSeries: []*metricdata.TimeSeries{
+				{
+					LabelValues: []metricdata.LabelValue{
+						metricdata.NewLabelValue("same"),
+						metricdata.NewLabelValue("same2"),
+						{},
+					},
+					Points: []metricdata.Point{
+						metricdata.NewFloat64Point(time.Time{}, 5),
+					},
+				},
+				{
+					LabelValues: []metricdata.LabelValue{
+						metricdata.NewLabelValue("same"),
+						metricdata.NewLabelValue("same2"),
+						metricdata.NewLabelValue("k1v1"),
 					},
 					Points: []metricdata.Point{
 						metricdata.NewFloat64Point(time.Time{}, 1),
@@ -330,20 +388,18 @@ func canonicalize(ms []*metricdata.Metric) {
 	for _, m := range ms {
 		sort.Slice(m.TimeSeries, func(i, j int) bool {
 			// sort time series by their label values
-			iLabels := m.TimeSeries[i].LabelValues
-			jLabels := m.TimeSeries[j].LabelValues
-			for k := 0; k < len(iLabels); k++ {
-				if !iLabels[k].Present {
-					if jLabels[k].Present {
-						return true
-					}
-				} else if !jLabels[k].Present {
-					return false
-				} else {
-					return iLabels[k].Value < jLabels[k].Value
-				}
+			iStr := ""
+
+			for _, label := range m.TimeSeries[i].LabelValues {
+				iStr += fmt.Sprintf("%+v", label)
 			}
-			panic("should have returned")
+
+			jStr := ""
+			for _, label := range m.TimeSeries[j].LabelValues {
+				jStr += fmt.Sprintf("%+v", label)
+			}
+
+			return iStr < jStr
 		})
 	}
 }


### PR DESCRIPTION
This PR adds support for constant labels on gauges. 

The proposed syntax is:
```go
r := NewRegistry()

 	f, _ := r.AddFloat64Gauge("TestGaugeWithConstLabel",
		WithLabelKeys("k1"), WithConstLabel("const", "same"), WithConstLabel("const2", "same2"))
```

@rghetia this is my first contribution and as you were the one who created the issue, could you review this?

closes #1112 