### PR TITLE
fix buckets in example/quickstart

### DIFF
--- a/examples/quickstart/stats.go
+++ b/examples/quickstart/stats.go
@@ -90,7 +90,7 @@ var (
 		Description: "Groups the lengths of keys in buckets",
 		Measure:     mLineLengths,
 		// Lengths: [>=0B, >=5B, >=10B, >=15B, >=20B, >=40B, >=60B, >=80, >=100B, >=200B, >=400, >=600, >=800, >=1000]
-		Aggregation: view.Distribution(5, 2000, 15, 20, 40, 60, 80, 100, 200, 400, 600, 800, 1000),
+		Aggregation: view.Distribution(5, 10, 15, 20, 40, 60, 80, 100, 200, 400, 600, 800, 1000),
 	}
 )
 


### PR DESCRIPTION
Buckets for the distribution are not correctly aligned with what is present in the accompanying comment. This PR fixes that.