### PR TITLE
Add runtime metrics support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,11 @@ require (
 	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6
 	github.com/golang/protobuf v1.3.1
 	github.com/google/go-cmp v0.3.0
+	github.com/stretchr/testify v1.4.0
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859
 	golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd // indirect
 	golang.org/x/text v0.3.2 // indirect
+	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb // indirect
 	google.golang.org/grpc v1.20.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 h1:ZgQEtGgCBiWRM39fZuwSd1LwSqqSW0hOdXCYYDX0R3I=
@@ -12,6 +14,11 @@ github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -60,4 +67,7 @@ google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZi
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1 h1:Hz2g2wirWK7H0qIIhGIqRGTuMwTE8HEKFnDZZ7lm9NU=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/plugin/runmetrics/doc.go
+++ b/plugin/runmetrics/doc.go
@@ -14,12 +14,10 @@
 
 // Package runmetrics contains support for runtime metrics.
 //
-// To enable collecting runtime metrics, create a new Producer and register it:
+// To enable collecting runtime metrics, just call Enable():
 //
-//     runtimeMetrics, _ := runmetrics.NewProducer(RunMetricOptions{
+//     _ := runmetrics.Enable(runmetrics.RunMetricOptions{
 //         EnableCPU: true,
 //         EnableMemory: true,
 //     })
-//     metricproducer.GlobalManager().AddProducer(runtimeMetrics)
-//
 package runmetrics // import "go.opencensus.io/plugin/runmetrics"

--- a/plugin/runmetrics/doc.go
+++ b/plugin/runmetrics/doc.go
@@ -1,0 +1,25 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package runmetrics contains support for runtime metrics.
+//
+// To enable collecting runtime metrics, create a new Producer and register it:
+//
+//     runtimeMetrics, _ := runmetrics.NewProducer(ProducerOptions{
+//         EnableCPU: true,
+//         EnableMemory: true,
+//     })
+//     metricproducer.GlobalManager().AddProducer(runtimeMetrics)
+//
+package runmetrics // import "go.opencensus.io/plugin/runmetrics"

--- a/plugin/runmetrics/doc.go
+++ b/plugin/runmetrics/doc.go
@@ -16,7 +16,7 @@
 //
 // To enable collecting runtime metrics, create a new Producer and register it:
 //
-//     runtimeMetrics, _ := runmetrics.NewProducer(ProducerOptions{
+//     runtimeMetrics, _ := runmetrics.NewProducer(RunMetricOptions{
 //         EnableCPU: true,
 //         EnableMemory: true,
 //     })

--- a/plugin/runmetrics/example_test.go
+++ b/plugin/runmetrics/example_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"go.opencensus.io/metric/metricdata"
 	"go.opencensus.io/metric/metricexport"
-	"go.opencensus.io/metric/metricproducer"
 	"go.opencensus.io/plugin/runmetrics"
 	"log"
 	"sort"
@@ -38,10 +37,10 @@ func (l *printExporter) ExportMetrics(ctx context.Context, data []*metricdata.Me
 	return nil
 }
 
-func ExampleProducer() {
+func ExampleEnable() {
 
-	// Create a new runmetrics.Producer and supply options
-	runtimeMetrics, err := runmetrics.NewProducer(runmetrics.RunMetricOptions{
+	// Enable collection of runtime metrics and supply options
+	err := runmetrics.Enable(runmetrics.RunMetricOptions{
 		EnableCPU:    true,
 		EnableMemory: true,
 		Prefix:       "mayapp_",
@@ -49,9 +48,6 @@ func ExampleProducer() {
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	// Register the producer
-	metricproducer.GlobalManager().AddProducer(runtimeMetrics)
 
 	// Use your reader/exporter to extract values
 	// This part is not specific to runtime metrics and only here to make it a complete example.

--- a/plugin/runmetrics/example_test.go
+++ b/plugin/runmetrics/example_test.go
@@ -43,7 +43,7 @@ func ExampleEnable() {
 	err := runmetrics.Enable(runmetrics.RunMetricOptions{
 		EnableCPU:    true,
 		EnableMemory: true,
-		Prefix:       "mayapp_",
+		Prefix:       "mayapp/",
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -54,24 +54,24 @@ func ExampleEnable() {
 	metricexport.NewReader().ReadAndExport(&printExporter{})
 
 	// output:
-	// mayapp_cpu_cgo_calls 42
-	// mayapp_cpu_goroutines 42
-	// mayapp_heap_alloc 42
-	// mayapp_heap_idle 42
-	// mayapp_heap_inuse 42
-	// mayapp_heap_objects 42
-	// mayapp_heap_release 42
-	// mayapp_heap_sys 42
-	// mayapp_mem_alloc 42
-	// mayapp_mem_frees 42
-	// mayapp_mem_lookups 42
-	// mayapp_mem_malloc 42
-	// mayapp_mem_sys 42
-	// mayapp_mem_total 42
-	// mayapp_stack_inuse 42
-	// mayapp_stack_mcache_inuse 42
-	// mayapp_stack_mcache_sys 42
-	// mayapp_stack_mspan_inuse 42
-	// mayapp_stack_mspan_sys 42
-	// mayapp_stack_sys 42
+	// mayapp/process/cpu_cgo_calls 42
+	// mayapp/process/cpu_goroutines 42
+	// mayapp/process/heap_alloc 42
+	// mayapp/process/heap_idle 42
+	// mayapp/process/heap_inuse 42
+	// mayapp/process/heap_objects 42
+	// mayapp/process/heap_release 42
+	// mayapp/process/memory_alloc 42
+	// mayapp/process/memory_frees 42
+	// mayapp/process/memory_lookups 42
+	// mayapp/process/memory_malloc 42
+	// mayapp/process/stack_inuse 42
+	// mayapp/process/stack_mcache_inuse 42
+	// mayapp/process/stack_mspan_inuse 42
+	// mayapp/process/sys_heap 42
+	// mayapp/process/sys_memory_alloc 42
+	// mayapp/process/sys_stack 42
+	// mayapp/process/sys_stack_mcache 42
+	// mayapp/process/sys_stack_mspan 42
+	// mayapp/process/total_memory_alloc 42
 }

--- a/plugin/runmetrics/example_test.go
+++ b/plugin/runmetrics/example_test.go
@@ -41,7 +41,7 @@ func (l *printExporter) ExportMetrics(ctx context.Context, data []*metricdata.Me
 func ExampleProducer() {
 
 	// Create a new runmetrics.Producer and supply options
-	runtimeMetrics, err := runmetrics.NewProducer(runmetrics.ProducerOptions{
+	runtimeMetrics, err := runmetrics.NewProducer(runmetrics.RunMetricOptions{
 		EnableCPU:    true,
 		EnableMemory: true,
 		Prefix:       "mayapp_",

--- a/plugin/runmetrics/example_test.go
+++ b/plugin/runmetrics/example_test.go
@@ -1,0 +1,81 @@
+package runmetrics_test
+
+import (
+	"context"
+	"fmt"
+	"go.opencensus.io/metric/metricdata"
+	"go.opencensus.io/metric/metricexport"
+	"go.opencensus.io/metric/metricproducer"
+	"go.opencensus.io/plugin/runmetrics"
+	"log"
+	"sort"
+)
+
+type printExporter struct {
+}
+
+func (l *printExporter) ExportMetrics(ctx context.Context, data []*metricdata.Metric) error {
+	mapData := make(map[string]metricdata.Metric, 0)
+
+	for _, v := range data {
+		mapData[v.Descriptor.Name] = *v
+	}
+
+	mapKeys := make([]string, 0, len(mapData))
+	for key := range mapData {
+		mapKeys = append(mapKeys, key)
+	}
+	sort.Strings(mapKeys)
+
+	// for the sake of a simple example, we cannot use the real value here
+	simpleVal := func(v interface{}) int { return 42 }
+
+	for _, k := range mapKeys {
+		v := mapData[k]
+		fmt.Printf("%s %d\n", k, simpleVal(v.TimeSeries[0].Points[0].Value))
+	}
+
+	return nil
+}
+
+func ExampleProducer() {
+
+	// Create a new runmetrics.Producer and supply options
+	runtimeMetrics, err := runmetrics.NewProducer(runmetrics.ProducerOptions{
+		EnableCPU:    true,
+		EnableMemory: true,
+		Prefix:       "mayapp_",
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Register the producer
+	metricproducer.GlobalManager().AddProducer(runtimeMetrics)
+
+	// Use your reader/exporter to extract values
+	// This part is not specific to runtime metrics and only here to make it a complete example.
+	metricexport.NewReader().ReadAndExport(&printExporter{})
+
+	// output:
+	// mayapp_cpu_cgo_calls 42
+	// mayapp_cpu_goroutines 42
+	// mayapp_heap_alloc 42
+	// mayapp_heap_idle 42
+	// mayapp_heap_inuse 42
+	// mayapp_heap_objects 42
+	// mayapp_heap_release 42
+	// mayapp_heap_sys 42
+	// mayapp_mem_alloc 42
+	// mayapp_mem_frees 42
+	// mayapp_mem_lookups 42
+	// mayapp_mem_malloc 42
+	// mayapp_mem_sys 42
+	// mayapp_mem_total 42
+	// mayapp_stack_inuse 42
+	// mayapp_stack_mcache_inuse 42
+	// mayapp_stack_mcache_sys 42
+	// mayapp_stack_mspan_inuse 42
+	// mayapp_stack_mspan_sys 42
+	// mayapp_stack_sys 42
+}

--- a/plugin/runmetrics/producer.go
+++ b/plugin/runmetrics/producer.go
@@ -15,15 +15,15 @@ type (
 	// A Producer should then be registered with the global manager:
 	// metricproducer.GlobalManager().AddProducer()
 	Producer struct {
-		options ProducerOptions
+		options RunMetricOptions
 		reg     *metric.Registry
 
 		memStats *memStats
 		cpuStats *cpuStats
 	}
 
-	// ProducerOptions allows to configure Producer.
-	ProducerOptions struct {
+	// RunMetricOptions allows to configure Producer.
+	RunMetricOptions struct {
 		EnableCPU    bool   // EnableCPU whether CPU metrics shall be recorded
 		EnableMemory bool   // EnableMemory whether memory metrics shall be recorded
 		Prefix       string // Prefix is a custom prefix for metric names
@@ -64,9 +64,9 @@ var _ metricproducer.Producer = (*Producer)(nil)
 
 // NewProducer creates a new runtime metrics producer.
 //
-// Supply ProducerOptions to configure the behavior of the Producer.
+// Supply RunMetricOptions to configure the behavior of the Producer.
 // An error might be returned, if creating metrics gauges fails.
-func NewProducer(options ProducerOptions) (*Producer, error) {
+func NewProducer(options RunMetricOptions) (*Producer, error) {
 	collector := &Producer{options: options, reg: metric.NewRegistry()}
 	var err error
 

--- a/plugin/runmetrics/producer.go
+++ b/plugin/runmetrics/producer.go
@@ -126,94 +126,94 @@ func newMemStats(producer *producer) (*memStats, error) {
 	memStats := &memStats{}
 
 	// General
-	memStats.memAlloc, err = producer.createInt64GaugeEntry("mem_alloc", "Bytes of allocated heap objects", metricdata.UnitBytes)
+	memStats.memAlloc, err = producer.createInt64GaugeEntry("process/memory_alloc", "Number of bytes currently allocated in use", metricdata.UnitBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	memStats.memTotal, err = producer.createInt64GaugeEntry("mem_total", "Cumulative bytes allocated for heap objects", metricdata.UnitBytes)
+	memStats.memTotal, err = producer.createInt64GaugeEntry("process/total_memory_alloc", "Number of allocations in total", metricdata.UnitBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	memStats.memSys, err = producer.createInt64GaugeEntry("mem_sys", "Total bytes of memory obtained from the OS", metricdata.UnitBytes)
+	memStats.memSys, err = producer.createInt64GaugeEntry("process/sys_memory_alloc", "Number of bytes given to the process to use in total", metricdata.UnitBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	memStats.memLookups, err = producer.createInt64GaugeEntry("mem_lookups", "Number of pointer lookups performed by the runtime", metricdata.UnitDimensionless)
+	memStats.memLookups, err = producer.createInt64GaugeEntry("process/memory_lookups", "Number of pointer lookups performed by the runtime", metricdata.UnitDimensionless)
 	if err != nil {
 		return nil, err
 	}
 
-	memStats.memMalloc, err = producer.createInt64GaugeEntry("mem_malloc", "Cumulative count of heap objects allocated", metricdata.UnitDimensionless)
+	memStats.memMalloc, err = producer.createInt64GaugeEntry("process/memory_malloc", "Cumulative count of heap objects allocated", metricdata.UnitDimensionless)
 	if err != nil {
 		return nil, err
 	}
 
-	memStats.memFrees, err = producer.createInt64GaugeEntry("mem_frees", "Cumulative count of heap objects freed", metricdata.UnitDimensionless)
+	memStats.memFrees, err = producer.createInt64GaugeEntry("process/memory_frees", "Cumulative count of heap objects freed", metricdata.UnitDimensionless)
 	if err != nil {
 		return nil, err
 	}
 
 	// Heap
-	memStats.heapAlloc, err = producer.createInt64GaugeEntry("heap_alloc", "Process heap allocation", metricdata.UnitBytes)
+	memStats.heapAlloc, err = producer.createInt64GaugeEntry("process/heap_alloc", "Process heap allocation", metricdata.UnitBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	memStats.heapSys, err = producer.createInt64GaugeEntry("heap_sys", "todo", metricdata.UnitBytes)
+	memStats.heapSys, err = producer.createInt64GaugeEntry("process/sys_heap", "Bytes of heap memory obtained from the OS", metricdata.UnitBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	memStats.heapIdle, err = producer.createInt64GaugeEntry("heap_idle", "todo", metricdata.UnitBytes)
+	memStats.heapIdle, err = producer.createInt64GaugeEntry("process/heap_idle", "Bytes in idle (unused) spans", metricdata.UnitBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	memStats.heapInuse, err = producer.createInt64GaugeEntry("heap_inuse", "todo", metricdata.UnitBytes)
+	memStats.heapInuse, err = producer.createInt64GaugeEntry("process/heap_inuse", "Bytes in in-use spans", metricdata.UnitBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	memStats.heapObjects, err = producer.createInt64GaugeEntry("heap_objects", "The number of objects allocated on the heap", metricdata.UnitDimensionless)
+	memStats.heapObjects, err = producer.createInt64GaugeEntry("process/heap_objects", "The number of objects allocated on the heap", metricdata.UnitDimensionless)
 	if err != nil {
 		return nil, err
 	}
 
-	memStats.heapReleased, err = producer.createInt64GaugeEntry("heap_release", "The number of objects released from the heap", metricdata.UnitBytes)
+	memStats.heapReleased, err = producer.createInt64GaugeEntry("process/heap_release", "The number of objects released from the heap", metricdata.UnitBytes)
 	if err != nil {
 		return nil, err
 	}
 
 	// Stack
-	memStats.stackInuse, err = producer.createInt64GaugeEntry("stack_inuse", "Bytes in stack spans", metricdata.UnitBytes)
+	memStats.stackInuse, err = producer.createInt64GaugeEntry("process/stack_inuse", "Bytes in stack spans", metricdata.UnitBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	memStats.stackSys, err = producer.createInt64GaugeEntry("stack_sys", "The memory used by stack spans and OS thread stacks", metricdata.UnitBytes)
+	memStats.stackSys, err = producer.createInt64GaugeEntry("process/sys_stack", "The memory used by stack spans and OS thread stacks", metricdata.UnitBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	memStats.stackMSpanInuse, err = producer.createInt64GaugeEntry("stack_mspan_inuse", "Bytes of allocated mspan structures", metricdata.UnitBytes)
+	memStats.stackMSpanInuse, err = producer.createInt64GaugeEntry("process/stack_mspan_inuse", "Bytes of allocated mspan structures", metricdata.UnitBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	memStats.stackMSpanSys, err = producer.createInt64GaugeEntry("stack_mspan_sys", "Bytes of memory obtained from the OS for mspan structures", metricdata.UnitBytes)
+	memStats.stackMSpanSys, err = producer.createInt64GaugeEntry("process/sys_stack_mspan", "Bytes of memory obtained from the OS for mspan structures", metricdata.UnitBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	memStats.stackMCacheInuse, err = producer.createInt64GaugeEntry("stack_mcache_inuse", "Bytes of allocated mcache structures", metricdata.UnitBytes)
+	memStats.stackMCacheInuse, err = producer.createInt64GaugeEntry("process/stack_mcache_inuse", "Bytes of allocated mcache structures", metricdata.UnitBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	memStats.stackMCacheSys, err = producer.createInt64GaugeEntry("stack_mcache_sys", "Bytes of memory obtained from the OS for mcache structures", metricdata.UnitBytes)
+	memStats.stackMCacheSys, err = producer.createInt64GaugeEntry("process/sys_stack_mcache", "Bytes of memory obtained from the OS for mcache structures", metricdata.UnitBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -250,12 +250,12 @@ func newCPUStats(producer *producer) (*cpuStats, error) {
 	cpuStats := &cpuStats{}
 	var err error
 
-	cpuStats.numGoroutines, err = producer.createInt64GaugeEntry("cpu_goroutines", "Number of goroutines that currently exist", metricdata.UnitDimensionless)
+	cpuStats.numGoroutines, err = producer.createInt64GaugeEntry("process/cpu_goroutines", "Number of goroutines that currently exist", metricdata.UnitDimensionless)
 	if err != nil {
 		return nil, err
 	}
 
-	cpuStats.numCgoCalls, err = producer.createInt64GaugeEntry("cpu_cgo_calls", "Number of cgo calls made by the current process", metricdata.UnitDimensionless)
+	cpuStats.numCgoCalls, err = producer.createInt64GaugeEntry("process/cpu_cgo_calls", "Number of cgo calls made by the current process", metricdata.UnitDimensionless)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/runmetrics/producer.go
+++ b/plugin/runmetrics/producer.go
@@ -1,0 +1,269 @@
+package runmetrics
+
+import (
+	"errors"
+	"go.opencensus.io/metric"
+	"go.opencensus.io/metric/metricdata"
+	"go.opencensus.io/metric/metricproducer"
+	"runtime"
+)
+
+type (
+	// Producer produces runtime metrics.
+	//
+	// Create a new Producer with NewProducer().
+	// A Producer should then be registered with the global manager:
+	// metricproducer.GlobalManager().AddProducer()
+	Producer struct {
+		options ProducerOptions
+		reg     *metric.Registry
+
+		memStats *memStats
+		cpuStats *cpuStats
+	}
+
+	// ProducerOptions allows to configure Producer.
+	ProducerOptions struct {
+		EnableCPU    bool   // EnableCPU whether CPU metrics shall be recorded
+		EnableMemory bool   // EnableMemory whether memory metrics shall be recorded
+		Prefix       string // Prefix is a custom prefix for metric names
+	}
+
+	memStats struct {
+		memStats runtime.MemStats
+
+		memAlloc   *metric.Int64GaugeEntry
+		memTotal   *metric.Int64GaugeEntry
+		memSys     *metric.Int64GaugeEntry
+		memLookups *metric.Int64GaugeEntry
+		memMalloc  *metric.Int64GaugeEntry
+		memFrees   *metric.Int64GaugeEntry
+
+		heapAlloc    *metric.Int64GaugeEntry
+		heapSys      *metric.Int64GaugeEntry
+		heapIdle     *metric.Int64GaugeEntry
+		heapInuse    *metric.Int64GaugeEntry
+		heapObjects  *metric.Int64GaugeEntry
+		heapReleased *metric.Int64GaugeEntry
+
+		stackInuse       *metric.Int64GaugeEntry
+		stackSys         *metric.Int64GaugeEntry
+		stackMSpanInuse  *metric.Int64GaugeEntry
+		stackMSpanSys    *metric.Int64GaugeEntry
+		stackMCacheInuse *metric.Int64GaugeEntry
+		stackMCacheSys   *metric.Int64GaugeEntry
+	}
+
+	cpuStats struct {
+		numGoroutines *metric.Int64GaugeEntry
+		numCgoCalls   *metric.Int64GaugeEntry
+	}
+)
+
+var _ metricproducer.Producer = (*Producer)(nil)
+
+// NewProducer creates a new runtime metrics producer.
+//
+// Supply ProducerOptions to configure the behavior of the Producer.
+// An error might be returned, if creating metrics gauges fails.
+func NewProducer(options ProducerOptions) (*Producer, error) {
+	collector := &Producer{options: options, reg: metric.NewRegistry()}
+	var err error
+
+	if options.EnableMemory {
+		collector.memStats, err = newMemStats(collector)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if options.EnableCPU {
+		collector.cpuStats, err = newCPUStats(collector)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return collector, err
+}
+
+// Read reads the current runtime metrics.
+func (c *Producer) Read() []*metricdata.Metric {
+	if c.memStats != nil {
+		c.memStats.read()
+	}
+
+	if c.cpuStats != nil {
+		c.cpuStats.read()
+	}
+
+	return c.reg.Read()
+}
+
+func newMemStats(producer *Producer) (*memStats, error) {
+	var err error
+	memStats := &memStats{}
+
+	// General
+	memStats.memAlloc, err = producer.createInt64GaugeEntry("mem_alloc", "Bytes of allocated heap objects", metricdata.UnitBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	memStats.memTotal, err = producer.createInt64GaugeEntry("mem_total", "Cumulative bytes allocated for heap objects", metricdata.UnitBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	memStats.memSys, err = producer.createInt64GaugeEntry("mem_sys", "Total bytes of memory obtained from the OS", metricdata.UnitBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	memStats.memLookups, err = producer.createInt64GaugeEntry("mem_lookups", "Number of pointer lookups performed by the runtime", metricdata.UnitDimensionless)
+	if err != nil {
+		return nil, err
+	}
+
+	memStats.memMalloc, err = producer.createInt64GaugeEntry("mem_malloc", "Cumulative count of heap objects allocated", metricdata.UnitDimensionless)
+	if err != nil {
+		return nil, err
+	}
+
+	memStats.memFrees, err = producer.createInt64GaugeEntry("mem_frees", "Cumulative count of heap objects freed", metricdata.UnitDimensionless)
+	if err != nil {
+		return nil, err
+	}
+
+	// Heap
+	memStats.heapAlloc, err = producer.createInt64GaugeEntry("heap_alloc", "Process heap allocation", metricdata.UnitBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	memStats.heapSys, err = producer.createInt64GaugeEntry("heap_sys", "todo", metricdata.UnitBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	memStats.heapIdle, err = producer.createInt64GaugeEntry("heap_idle", "todo", metricdata.UnitBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	memStats.heapInuse, err = producer.createInt64GaugeEntry("heap_inuse", "todo", metricdata.UnitBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	memStats.heapObjects, err = producer.createInt64GaugeEntry("heap_objects", "The number of objects allocated on the heap", metricdata.UnitDimensionless)
+	if err != nil {
+		return nil, err
+	}
+
+	memStats.heapReleased, err = producer.createInt64GaugeEntry("heap_release", "The number of objects released from the heap", metricdata.UnitBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	// Stack
+	memStats.stackInuse, err = producer.createInt64GaugeEntry("stack_inuse", "Bytes in stack spans", metricdata.UnitBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	memStats.stackSys, err = producer.createInt64GaugeEntry("stack_sys", "The memory used by stack spans and OS thread stacks", metricdata.UnitBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	memStats.stackMSpanInuse, err = producer.createInt64GaugeEntry("stack_mspan_inuse", "Bytes of allocated mspan structures", metricdata.UnitBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	memStats.stackMSpanSys, err = producer.createInt64GaugeEntry("stack_mspan_sys", "Bytes of memory obtained from the OS for mspan structures", metricdata.UnitBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	memStats.stackMCacheInuse, err = producer.createInt64GaugeEntry("stack_mcache_inuse", "Bytes of allocated mcache structures", metricdata.UnitBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	memStats.stackMCacheSys, err = producer.createInt64GaugeEntry("stack_mcache_sys", "Bytes of memory obtained from the OS for mcache structures", metricdata.UnitBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return memStats, nil
+}
+
+func (m *memStats) read() {
+	runtime.ReadMemStats(&m.memStats)
+
+	m.memAlloc.Set(int64(m.memStats.Alloc))
+	m.memTotal.Set(int64(m.memStats.TotalAlloc))
+	m.memSys.Set(int64(m.memStats.Sys))
+	m.memLookups.Set(int64(m.memStats.Lookups))
+	m.memMalloc.Set(int64(m.memStats.Mallocs))
+	m.memFrees.Set(int64(m.memStats.Frees))
+
+	m.heapAlloc.Set(int64(m.memStats.HeapAlloc))
+	m.heapSys.Set(int64(m.memStats.HeapSys))
+	m.heapIdle.Set(int64(m.memStats.HeapIdle))
+	m.heapInuse.Set(int64(m.memStats.HeapInuse))
+	m.heapReleased.Set(int64(m.memStats.HeapReleased))
+	m.heapObjects.Set(int64(m.memStats.HeapObjects))
+
+	m.stackInuse.Set(int64(m.memStats.StackInuse))
+	m.stackSys.Set(int64(m.memStats.StackSys))
+	m.stackMSpanInuse.Set(int64(m.memStats.MSpanInuse))
+	m.stackMSpanSys.Set(int64(m.memStats.MSpanSys))
+	m.stackMCacheInuse.Set(int64(m.memStats.MCacheInuse))
+	m.stackMCacheSys.Set(int64(m.memStats.MCacheSys))
+}
+
+func newCPUStats(collector *Producer) (*cpuStats, error) {
+	cpuStats := &cpuStats{}
+	var err error
+
+	cpuStats.numGoroutines, err = collector.createInt64GaugeEntry("cpu_goroutines", "Number of goroutines that currently exist", metricdata.UnitDimensionless)
+	if err != nil {
+		return nil, err
+	}
+
+	cpuStats.numCgoCalls, err = collector.createInt64GaugeEntry("cpu_cgo_calls", "Number of cgo calls made by the current process", metricdata.UnitDimensionless)
+	if err != nil {
+		return nil, err
+	}
+
+	return cpuStats, nil
+}
+
+func (c *cpuStats) read() {
+	c.numGoroutines.Set(int64(runtime.NumGoroutine()))
+	c.numCgoCalls.Set(runtime.NumCgoCall())
+}
+
+func (c *Producer) createInt64GaugeEntry(name string, description string, unit metricdata.Unit) (*metric.Int64GaugeEntry, error) {
+	if len(c.options.Prefix) > 0 {
+		name = c.options.Prefix + name
+	}
+
+	gauge, err := c.reg.AddInt64Gauge(
+		name,
+		metric.WithDescription(description),
+		metric.WithUnit(unit))
+	if err != nil {
+		return nil, errors.New("error creating gauge for " + name + ": " + err.Error())
+	}
+
+	entry, err := gauge.GetEntry()
+	if err != nil {
+		return nil, errors.New("error getting gauge entry for " + name + ": " + err.Error())
+	}
+
+	return entry, nil
+}

--- a/plugin/runmetrics/producer_test.go
+++ b/plugin/runmetrics/producer_test.go
@@ -42,10 +42,10 @@ func TestEnable(t *testing.T) {
 				EnableMemory: true,
 			},
 			[][]string{
-				{"mem_alloc", "mem_total", "mem_sys", "mem_lookups", "mem_malloc", "mem_frees"},
-				{"heap_alloc", "heap_sys", "heap_idle", "heap_inuse", "heap_objects", "heap_release"},
-				{"stack_inuse", "stack_sys", "stack_mspan_inuse", "stack_mspan_sys", "stack_mcache_inuse", "stack_mspan_sys"},
-				{"cpu_goroutines", "cpu_cgo_calls"},
+				{"process/memory_alloc", "process/total_memory_alloc", "process/sys_memory_alloc", "process/memory_lookups", "process/memory_malloc", "process/memory_frees"},
+				{"process/heap_alloc", "process/sys_heap", "process/heap_idle", "process/heap_inuse", "process/heap_objects", "process/heap_release"},
+				{"process/stack_inuse", "process/sys_stack", "process/stack_mspan_inuse", "process/sys_stack_mspan", "process/stack_mcache_inuse", "process/sys_stack_mcache"},
+				{"process/cpu_goroutines", "process/cpu_cgo_calls"},
 			},
 			[][]string{},
 		},
@@ -56,12 +56,12 @@ func TestEnable(t *testing.T) {
 				EnableMemory: false,
 			},
 			[][]string{
-				{"cpu_goroutines", "cpu_cgo_calls"},
+				{"process/cpu_goroutines", "process/cpu_cgo_calls"},
 			},
 			[][]string{
-				{"mem_alloc", "mem_total", "mem_sys", "mem_lookups", "mem_malloc", "mem_frees"},
-				{"heap_alloc", "heap_sys", "heap_idle", "heap_inuse", "heap_objects", "heap_release"},
-				{"stack_inuse", "stack_sys", "stack_mspan_inuse", "stack_mspan_sys", "stack_mcache_inuse", "stack_mspan_sys"},
+				{"process/memory_alloc", "process/total_memory_alloc", "process/sys_memory_alloc", "process/memory_lookups", "process/memory_malloc", "process/memory_frees"},
+				{"process/heap_alloc", "process/sys_heap", "process/heap_idle", "process/heap_inuse", "process/heap_objects", "process/heap_release"},
+				{"process/stack_inuse", "process/sys_stack", "process/stack_mspan_inuse", "process/sys_stack_mspan", "process/stack_mcache_inuse", "process/sys_stack_mcache"},
 			},
 		},
 		{
@@ -71,12 +71,12 @@ func TestEnable(t *testing.T) {
 				EnableMemory: true,
 			},
 			[][]string{
-				{"mem_alloc", "mem_total", "mem_sys", "mem_lookups", "mem_malloc", "mem_frees"},
-				{"heap_alloc", "heap_sys", "heap_idle", "heap_inuse", "heap_objects", "heap_release"},
-				{"stack_inuse", "stack_sys", "stack_mspan_inuse", "stack_mspan_sys", "stack_mcache_inuse", "stack_mspan_sys"},
+				{"process/memory_alloc", "process/total_memory_alloc", "process/sys_memory_alloc", "process/memory_lookups", "process/memory_malloc", "process/memory_frees"},
+				{"process/heap_alloc", "process/sys_heap", "process/heap_idle", "process/heap_inuse", "process/heap_objects", "process/heap_release"},
+				{"process/stack_inuse", "process/sys_stack", "process/stack_mspan_inuse", "process/sys_stack_mspan", "process/stack_mcache_inuse", "process/sys_stack_mcache"},
 			},
 			[][]string{
-				{"cpu_goroutines", "cpu_cgo_calls"},
+				{"process/cpu_goroutines", "process/cpu_cgo_calls"},
 			},
 		},
 		{
@@ -87,10 +87,10 @@ func TestEnable(t *testing.T) {
 				Prefix:       "test_",
 			},
 			[][]string{
-				{"test_mem_alloc", "test_mem_total", "test_mem_sys", "test_mem_lookups", "test_mem_malloc", "test_mem_frees"},
-				{"test_heap_alloc", "test_heap_sys", "test_heap_idle", "test_heap_inuse", "test_heap_objects", "test_heap_release"},
-				{"test_stack_inuse", "test_stack_sys", "test_stack_mspan_inuse", "test_stack_mspan_sys", "test_stack_mcache_inuse", "test_stack_mspan_sys"},
-				{"test_cpu_goroutines", "test_cpu_cgo_calls"},
+				{"test_process/memory_alloc", "test_process/total_memory_alloc", "test_process/sys_memory_alloc", "test_process/memory_lookups", "test_process/memory_malloc", "test_process/memory_frees"},
+				{"test_process/heap_alloc", "test_process/sys_heap", "test_process/heap_idle", "test_process/heap_inuse", "test_process/heap_objects", "test_process/heap_release"},
+				{"test_process/stack_inuse", "test_process/sys_stack", "test_process/stack_mspan_inuse", "test_process/sys_stack_mspan", "test_process/stack_mcache_inuse", "test_process/sys_stack_mcache"},
+				{"test_process/cpu_goroutines", "test_process/cpu_cgo_calls"},
 			},
 			[][]string{},
 		},

--- a/plugin/runmetrics/producer_test.go
+++ b/plugin/runmetrics/producer_test.go
@@ -22,13 +22,13 @@ func (t *testExporter) ExportMetrics(ctx context.Context, data []*metricdata.Met
 func TestNewProducer(t *testing.T) {
 	tests := []struct {
 		name                string
-		options             runmetrics.ProducerOptions
+		options             runmetrics.RunMetricOptions
 		wantMetricNames     [][]string
 		dontWantMetricNames [][]string
 	}{
 		{
 			"cpu and memory stats",
-			runmetrics.ProducerOptions{
+			runmetrics.RunMetricOptions{
 				EnableCPU:    true,
 				EnableMemory: true,
 			},
@@ -42,7 +42,7 @@ func TestNewProducer(t *testing.T) {
 		},
 		{
 			"only cpu stats",
-			runmetrics.ProducerOptions{
+			runmetrics.RunMetricOptions{
 				EnableCPU:    true,
 				EnableMemory: false,
 			},
@@ -57,7 +57,7 @@ func TestNewProducer(t *testing.T) {
 		},
 		{
 			"only memory stats",
-			runmetrics.ProducerOptions{
+			runmetrics.RunMetricOptions{
 				EnableCPU:    false,
 				EnableMemory: true,
 			},
@@ -72,7 +72,7 @@ func TestNewProducer(t *testing.T) {
 		},
 		{
 			"cpu and memory stats with custom prefix",
-			runmetrics.ProducerOptions{
+			runmetrics.RunMetricOptions{
 				EnableCPU:    true,
 				EnableMemory: true,
 				Prefix:       "test_",

--- a/plugin/runmetrics/producer_test.go
+++ b/plugin/runmetrics/producer_test.go
@@ -1,0 +1,130 @@
+package runmetrics_test
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"go.opencensus.io/metric/metricdata"
+	"go.opencensus.io/metric/metricexport"
+	"go.opencensus.io/metric/metricproducer"
+	"go.opencensus.io/plugin/runmetrics"
+	"testing"
+)
+
+type testExporter struct {
+	data []*metricdata.Metric
+}
+
+func (t *testExporter) ExportMetrics(ctx context.Context, data []*metricdata.Metric) error {
+	t.data = append(t.data, data...)
+	return nil
+}
+
+func TestNewProducer(t *testing.T) {
+	tests := []struct {
+		name                string
+		options             runmetrics.ProducerOptions
+		wantMetricNames     [][]string
+		dontWantMetricNames [][]string
+	}{
+		{
+			"cpu and memory stats",
+			runmetrics.ProducerOptions{
+				EnableCPU:    true,
+				EnableMemory: true,
+			},
+			[][]string{
+				{"mem_alloc", "mem_total", "mem_sys", "mem_lookups", "mem_malloc", "mem_frees"},
+				{"heap_alloc", "heap_sys", "heap_idle", "heap_inuse", "heap_objects", "heap_release"},
+				{"stack_inuse", "stack_sys", "stack_mspan_inuse", "stack_mspan_sys", "stack_mcache_inuse", "stack_mspan_sys"},
+				{"cpu_goroutines", "cpu_cgo_calls"},
+			},
+			[][]string{},
+		},
+		{
+			"only cpu stats",
+			runmetrics.ProducerOptions{
+				EnableCPU:    true,
+				EnableMemory: false,
+			},
+			[][]string{
+				{"cpu_goroutines", "cpu_cgo_calls"},
+			},
+			[][]string{
+				{"mem_alloc", "mem_total", "mem_sys", "mem_lookups", "mem_malloc", "mem_frees"},
+				{"heap_alloc", "heap_sys", "heap_idle", "heap_inuse", "heap_objects", "heap_release"},
+				{"stack_inuse", "stack_sys", "stack_mspan_inuse", "stack_mspan_sys", "stack_mcache_inuse", "stack_mspan_sys"},
+			},
+		},
+		{
+			"only memory stats",
+			runmetrics.ProducerOptions{
+				EnableCPU:    false,
+				EnableMemory: true,
+			},
+			[][]string{
+				{"mem_alloc", "mem_total", "mem_sys", "mem_lookups", "mem_malloc", "mem_frees"},
+				{"heap_alloc", "heap_sys", "heap_idle", "heap_inuse", "heap_objects", "heap_release"},
+				{"stack_inuse", "stack_sys", "stack_mspan_inuse", "stack_mspan_sys", "stack_mcache_inuse", "stack_mspan_sys"},
+			},
+			[][]string{
+				{"cpu_goroutines", "cpu_cgo_calls"},
+			},
+		},
+		{
+			"cpu and memory stats with custom prefix",
+			runmetrics.ProducerOptions{
+				EnableCPU:    true,
+				EnableMemory: true,
+				Prefix:       "test_",
+			},
+			[][]string{
+				{"test_mem_alloc", "test_mem_total", "test_mem_sys", "test_mem_lookups", "test_mem_malloc", "test_mem_frees"},
+				{"test_heap_alloc", "test_heap_sys", "test_heap_idle", "test_heap_inuse", "test_heap_objects", "test_heap_release"},
+				{"test_stack_inuse", "test_stack_sys", "test_stack_mspan_inuse", "test_stack_mspan_sys", "test_stack_mcache_inuse", "test_stack_mspan_sys"},
+				{"test_cpu_goroutines", "test_cpu_cgo_calls"},
+			},
+			[][]string{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			producer, err := runmetrics.NewProducer(test.options)
+
+			if err != nil {
+				t.Errorf("want: nil, got: %v", err)
+			}
+
+			metricproducer.GlobalManager().AddProducer(producer)
+			defer metricproducer.GlobalManager().DeleteProducer(producer)
+
+			exporter := &testExporter{}
+			reader := metricexport.NewReader()
+			reader.ReadAndExport(exporter)
+
+			for _, want := range test.wantMetricNames {
+				assertNames(t, true, exporter, want)
+			}
+
+			for _, dontWant := range test.dontWantMetricNames {
+				assertNames(t, false, exporter, dontWant)
+			}
+		})
+	}
+}
+
+func assertNames(t *testing.T, wantIncluded bool, exporter *testExporter, expectedNames []string) {
+	metricNames := make([]string, 0)
+	for _, v := range exporter.data {
+		metricNames = append(metricNames, v.Descriptor.Name)
+	}
+
+	for _, want := range expectedNames {
+		if wantIncluded {
+			assert.Contains(t, metricNames, want)
+		} else {
+			assert.NotContains(t, metricNames, want)
+		}
+	}
+}


### PR DESCRIPTION
This adds a `metricproducer.Producer` implementation under `/plugin/` which enables the collection of runtime metrics.
 
Fixes #784 