### PR TITLE
Fix typo in view documentation and remove unnecessary type conversions

### DIFF
--- a/metric/cumulative.go
+++ b/metric/cumulative.go
@@ -116,7 +116,7 @@ func (e *Int64CumulativeEntry) Inc(val int64) {
 	if val <= 0 {
 		return
 	}
-	atomic.AddInt64(&e.val, int64(val))
+	atomic.AddInt64(&e.val, val)
 }
 
 // Int64DerivedCumulative represents int64 cumulative value that is derived from an object.

--- a/metric/metricexport/reader_test.go
+++ b/metric/metricexport/reader_test.go
@@ -33,8 +33,8 @@ var (
 	exporter1  = &metricExporter{}
 	exporter2  = &metricExporter{}
 	gaugeEntry *metric.Int64GaugeEntry
-	duration1  = time.Duration(1000 * time.Millisecond)
-	duration2  = time.Duration(2000 * time.Millisecond)
+	duration1  = 1000 * time.Millisecond
+	duration2  = 2000 * time.Millisecond
 )
 
 type metricExporter struct {
@@ -194,7 +194,7 @@ func TestNewIntervalReaderWithNilExporter(t *testing.T) {
 
 func TestNewIntervalReaderStartWithInvalidInterval(t *testing.T) {
 	ir, err := NewIntervalReader(reader1, exporter1)
-	ir.ReportingInterval = time.Duration(500 * time.Millisecond)
+	ir.ReportingInterval = 500 * time.Millisecond
 	err = ir.Start()
 	if err == nil {
 		t.Fatalf("expected error but got nil\n")

--- a/plugin/ochttp/server.go
+++ b/plugin/ochttp/server.go
@@ -128,7 +128,7 @@ func (h *Handler) startTrace(w http.ResponseWriter, r *http.Request) (*http.Requ
 		// TODO: Handle cases where ContentLength is not set.
 	} else if r.ContentLength > 0 {
 		span.AddMessageReceiveEvent(0, /* TODO: messageID */
-			int64(r.ContentLength), -1)
+			r.ContentLength, -1)
 	}
 	return r.WithContext(ctx), span.End
 }
@@ -173,8 +173,6 @@ type trackingResponseWriter struct {
 
 // Compile time assertion for ResponseWriter interface
 var _ http.ResponseWriter = (*trackingResponseWriter)(nil)
-
-var logTagsErrorOnce sync.Once
 
 func (t *trackingResponseWriter) end(tags *addedTags) {
 	t.endOnce.Do(func() {

--- a/stats/view/doc.go
+++ b/stats/view/doc.go
@@ -29,7 +29,7 @@
 // LastValue just keeps track of the most recently recorded measurement value.
 // All aggregations are cumulative.
 //
-// Views can be registerd and unregistered at any time during program execution.
+// Views can be registered and unregistered at any time during program execution.
 //
 // Libraries can define views but it is recommended that in most cases registering
 // views be left up to applications.

--- a/tag/map_codec.go
+++ b/tag/map_codec.go
@@ -168,7 +168,7 @@ func Encode(m *Map) []byte {
 	eg := &encoderGRPC{
 		buf: make([]byte, len(m.m)),
 	}
-	eg.writeByte(byte(tagsVersionID))
+	eg.writeByte(tagsVersionID)
 	for k, v := range m.m {
 		if v.m.ttl.ttl == valueTTLUnlimitedPropagation {
 			eg.writeByte(byte(keyTypeString))

--- a/tag/map_codec_test.go
+++ b/tag/map_codec_test.go
@@ -91,7 +91,7 @@ func TestEncodeDecode(t *testing.T) {
 
 		got := make([]keyValue, 0)
 		for k, v := range decoded.m {
-			got = append(got, keyValue{k, string(v.value)})
+			got = append(got, keyValue{k, v.value})
 		}
 		want := tc.pairs
 


### PR DESCRIPTION
Fix typo in view documentation and remove unnecessary type conversions.