### PR TITLE
Add AlwaysParentSampler

### DIFF
--- a/trace/sampling.go
+++ b/trace/sampling.go
@@ -73,3 +73,11 @@ func NeverSample() Sampler {
 		return SamplingDecision{Sample: false}
 	}
 }
+
+// AlwaysParentSampler returns a Sampler that only samples spans,
+// and only if the parent span has already decided that it should be sampled.
+func AlwaysParentSampler() Sampler {
+	return func(p SamplingParameters) SamplingDecision {
+		return SamplingDecision{Sample: p.ParentContext.IsSampled()}
+	}
+}

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -101,13 +101,22 @@ func TestSampling(t *testing.T) {
 		{true, false, 1, NeverSample(), 0},
 		{true, false, 0, AlwaysSample(), 1},
 		{true, false, 1, AlwaysSample(), 1},
+		{true, false, 0, AlwaysParentSampler(), 0},
+		{true, false, 1, AlwaysParentSampler(), 1},
+
+		{false, true, 0, nil, 0},
+		{false, true, 1, nil, 1},
 		{false, true, 0, NeverSample(), 0},
 		{false, true, 1, NeverSample(), 0},
 		{false, true, 0, AlwaysSample(), 1},
 		{false, true, 1, AlwaysSample(), 1},
+		{false, true, 0, AlwaysParentSampler(), 0},
+		{false, true, 1, AlwaysParentSampler(), 1},
+
 		{false, false, 0, nil, 0},
 		{false, false, 0, NeverSample(), 0},
 		{false, false, 0, AlwaysSample(), 1},
+		{false, false, 0, AlwaysParentSampler(), 0},
 	} {
 		var ctx context.Context
 		if test.remoteParent {


### PR DESCRIPTION
Adds a sampler that inherits sampling decision from parent span, and defaults to not sample if it has no parent.