### PR TITLE
Allow overriding health endpoint check in handler

### DIFF
--- a/plugin/ochttp/server.go
+++ b/plugin/ochttp/server.go
@@ -73,7 +73,8 @@ type Handler struct {
 
 	// IsHealthEndpoint holds the function to use for determining if the
 	// incoming HTTP request should be considered a health check. If set and
-	// returns true, no trace will be recorded.
+	// returns true no trace will be recorded, otherwise the handler will
+	// use the private isHealthEndpoint func in this package.
 	IsHealthEndpoint func(string) bool
 }
 

--- a/plugin/ochttp/server.go
+++ b/plugin/ochttp/server.go
@@ -75,7 +75,7 @@ type Handler struct {
 	// incoming HTTP request should be considered a health check. This is in
 	// addition to the private isHealthEndpoint func which may also indicate
 	// tracing should be skipped.
-	IsHealthEndpoint func(string) bool
+	IsHealthEndpoint func(*http.Request) bool
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -93,7 +93,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) startTrace(w http.ResponseWriter, r *http.Request) (*http.Request, func()) {
-	if h.IsHealthEndpoint != nil && h.IsHealthEndpoint(r.URL.Path) || isHealthEndpoint(r.URL.Path) {
+	if h.IsHealthEndpoint != nil && h.IsHealthEndpoint(r) || isHealthEndpoint(r.URL.Path) {
 		return r, func() {}
 	}
 	var name string

--- a/plugin/ochttp/server.go
+++ b/plugin/ochttp/server.go
@@ -72,9 +72,9 @@ type Handler struct {
 	FormatSpanName func(*http.Request) string
 
 	// IsHealthEndpoint holds the function to use for determining if the
-	// incoming HTTP request should be considered a health check. If set and
-	// returns true no trace will be recorded, otherwise the handler will
-	// use the private isHealthEndpoint func in this package.
+	// incoming HTTP request should be considered a health check. This is in
+	// addition to the private isHealthEndpoint func which may also indicate
+	// tracing should be skipped.
 	IsHealthEndpoint func(string) bool
 }
 

--- a/plugin/ochttp/server.go
+++ b/plugin/ochttp/server.go
@@ -70,6 +70,11 @@ type Handler struct {
 	// from the information found in the incoming HTTP Request. By default the
 	// name equals the URL Path.
 	FormatSpanName func(*http.Request) string
+
+	// IsHealthEndpoint holds the function to use for determining if the
+	// incoming HTTP request should be considered a health check. If set and
+	// returns true, no trace will be recorded.
+	IsHealthEndpoint func(string) bool
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -87,7 +92,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) startTrace(w http.ResponseWriter, r *http.Request) (*http.Request, func()) {
-	if isHealthEndpoint(r.URL.Path) {
+	if h.IsHealthEndpoint != nil && h.IsHealthEndpoint(r.URL.Path) || isHealthEndpoint(r.URL.Path) {
 		return r, func() {}
 	}
 	var name string

--- a/plugin/ochttp/server_test.go
+++ b/plugin/ochttp/server_test.go
@@ -555,9 +555,9 @@ func TestHandlerImplementsHTTPCloseNotify(t *testing.T) {
 	}
 }
 
-func testHealthEndpointSkipArray(p string) bool {
+func testHealthEndpointSkipArray(r *http.Request) bool {
 	for _, toSkip := range []string{"/health", "/metrics"} {
-		if p == toSkip {
+		if r.URL.Path == toSkip {
 			return true
 		}
 	}
@@ -570,7 +570,7 @@ func TestIgnoreHealthEndpoints(t *testing.T) {
 	client := &http.Client{}
 	tests := []struct {
 		path               string
-		healthEndpointFunc func(string) bool
+		healthEndpointFunc func(*http.Request) bool
 	}{
 		{"/healthz", nil},
 		{"/_ah/health", nil},


### PR DESCRIPTION
Addresses #1171 by allowing users to supply a `func (string) bool` which can be used to determine if the path is a health-check, falling back to the existing solution if no func is supplied.

Test copied from `TestIgnoreHealthz` to supply the new parameter but I'd be happy to merge them or modify the cases.