### PR TITLE
Allow creating additional View universes.

### DIFF
--- a/stats/benchmark_test.go
+++ b/stats/benchmark_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
 	_ "go.opencensus.io/stats/view" // enable collection
 	"go.opencensus.io/tag"
 )
@@ -50,6 +51,22 @@ func BenchmarkRecord8(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		stats.Record(ctx, m.M(1), m.M(1), m.M(1), m.M(1), m.M(1), m.M(1), m.M(1), m.M(1))
 	}
+}
+
+func BenchmarkRecord8_WithRecorder(b *testing.B) {
+	ctx := context.Background()
+	meter := view.NewMeter()
+	meter.Start()
+	defer meter.Stop()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		// Note that this benchmark has one extra allocation for stats.WithRecorder.
+		// If you cache the recorder option, this benchmark should be equally fast as BenchmarkRecord8
+		stats.RecordWithOptions(ctx, stats.WithRecorder(meter), stats.WithMeasurements(m.M(1), m.M(1), m.M(1), m.M(1), m.M(1), m.M(1), m.M(1), m.M(1)))
+	}
+
+	b.StopTimer()
 }
 
 func BenchmarkRecord8_Parallel(b *testing.B) {

--- a/stats/record.go
+++ b/stats/record.go
@@ -31,6 +31,15 @@ func init() {
 	}
 }
 
+// ResolvedOptions can be used to extract the current tags and measurements
+// from context and stats arguments when using custom workers to export stats
+// to a separate exporter.
+type ResolvedOptions struct {
+	Attachments metricdata.Attachments
+	Tags        *tag.Map
+	Measures    []Measurement
+}
+
 type recordOptions struct {
 	attachments  metricdata.Attachments
 	mutators     []tag.Mutator
@@ -84,6 +93,23 @@ func RecordWithTags(ctx context.Context, mutators []tag.Mutator, ms ...Measureme
 	return RecordWithOptions(ctx, WithTags(mutators...), WithMeasurements(ms...))
 }
 
+// ResolveOptions determines the full set of Tags, Measurements, etc from the
+// provided Options and context.Context. This is mostly useful when using
+// multiple exporters.
+func ResolveOptions(ctx context.Context, ros ...Options) (*ResolvedOptions, error) {
+	o := createRecordOption(ros...)
+
+	if len(o.mutators) > 0 {
+		var err error
+		if ctx, err = tag.New(ctx, o.mutators...); err != nil {
+			return nil, err
+		}
+	}
+	return &ResolvedOptions{Tags: tag.FromContext(ctx),
+		Measures:    o.measurements,
+		Attachments: o.attachments}, nil
+}
+
 // RecordWithOptions records measurements from the given options (if any) against context
 // and tags and attachments in the options (if any).
 // If there are any tags in the context, measurements will be tagged with them.
@@ -92,6 +118,8 @@ func RecordWithOptions(ctx context.Context, ros ...Options) error {
 	if len(o.measurements) == 0 {
 		return nil
 	}
+	// This could use ResolveOptions, but it does additional work to
+	// short-circuit if there are no metrics that need to be exported.
 	recorder := internal.DefaultRecorder
 	if recorder == nil {
 		return nil

--- a/stats/record.go
+++ b/stats/record.go
@@ -31,9 +31,11 @@ func init() {
 	}
 }
 
-// Recorder is a subset of the view.Meter interface which only includes
-// the Record method, to avoid circular imports between stats and view.
+// Recorder provides an interface for exporting measurement information from
+// the static Record method by using the WithRecorder option.
 type Recorder interface {
+	// Record records a set of measurements associated with the given tags and attachments.
+	// The second argument is a `[]Measurement`.
 	Record(*tag.Map, interface{}, map[string]interface{})
 }
 
@@ -65,9 +67,9 @@ func WithMeasurements(measurements ...Measurement) Options {
 	}
 }
 
-// WithMeter records the measurements to the specified `view.Meter`, rather
+// WithRecorder records the measurements to the specified `Recorder`, rather
 // than to the global metrics recorder.
-func WithMeter(meter Recorder) Options {
+func WithRecorder(meter Recorder) Options {
 	return func(ro *recordOptions) {
 		ro.recorder = meter
 	}

--- a/stats/record_test.go
+++ b/stats/record_test.go
@@ -95,8 +95,8 @@ func cmpExemplar(got, want *metricdata.Exemplar) string {
 	return cmp.Diff(got, want, cmpopts.IgnoreFields(metricdata.Exemplar{}, "Timestamp"), cmpopts.IgnoreUnexported(metricdata.Exemplar{}))
 }
 
-func TestResolveOptions(t *testing.T) {
-	meter := view.NewWorker()
+func TestRecordWithMeter(t *testing.T) {
+	meter := view.NewMeter()
 	meter.Start()
 	k1 := tag.MustNewKey("k1")
 	k2 := tag.MustNewKey("k2")
@@ -128,7 +128,7 @@ func TestResolveOptions(t *testing.T) {
 		stats.WithTags(tag.Upsert(k1, "bar"), tag.Insert(k2, "bar")),
 		stats.WithAttachments(attachments),
 		stats.WithMeasurements(m1.M(12), m1.M(6), m2.M(5)),
-		stats.WithMeter(meter))
+		stats.WithRecorder(meter))
 	if err != nil {
 		t.Fatalf("Failed to resolve data point: %v", err)
 	}

--- a/stats/record_test.go
+++ b/stats/record_test.go
@@ -98,6 +98,7 @@ func cmpExemplar(got, want *metricdata.Exemplar) string {
 func TestRecordWithMeter(t *testing.T) {
 	meter := view.NewMeter()
 	meter.Start()
+	defer meter.Stop()
 	k1 := tag.MustNewKey("k1")
 	k2 := tag.MustNewKey("k2")
 	m1 := stats.Int64("TestResolveOptions/m1", "", stats.UnitDimensionless)

--- a/stats/view/benchmark_test.go
+++ b/stats/view/benchmark_test.go
@@ -46,7 +46,7 @@ var (
 // BenchmarkRecordReqCommand benchmarks calling the internal recording machinery
 // directly.
 func BenchmarkRecordReqCommand(b *testing.B) {
-	w := newWorker()
+	w := NewWorker().(*worker)
 
 	register := &registerViewReq{views: []*View{view}, err: make(chan error, 1)}
 	register.handleCommand(w)

--- a/stats/view/benchmark_test.go
+++ b/stats/view/benchmark_test.go
@@ -46,7 +46,7 @@ var (
 // BenchmarkRecordReqCommand benchmarks calling the internal recording machinery
 // directly.
 func BenchmarkRecordReqCommand(b *testing.B) {
-	w := NewWorker().(*worker)
+	w := NewMeter().(*worker)
 
 	register := &registerViewReq{views: []*View{view}, err: make(chan error, 1)}
 	register.handleCommand(w)
@@ -54,21 +54,7 @@ func BenchmarkRecordReqCommand(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	const tagCount = 10
-	ctxs := make([]context.Context, 0, tagCount)
-	for i := 0; i < tagCount; i++ {
-		ctx, _ := tag.New(context.Background(),
-			tag.Upsert(k1, fmt.Sprintf("v%d", i)),
-			tag.Upsert(k2, fmt.Sprintf("v%d", i)),
-			tag.Upsert(k3, fmt.Sprintf("v%d", i)),
-			tag.Upsert(k4, fmt.Sprintf("v%d", i)),
-			tag.Upsert(k5, fmt.Sprintf("v%d", i)),
-			tag.Upsert(k6, fmt.Sprintf("v%d", i)),
-			tag.Upsert(k7, fmt.Sprintf("v%d", i)),
-			tag.Upsert(k8, fmt.Sprintf("v%d", i)),
-		)
-		ctxs = append(ctxs, ctx)
-	}
+	ctxs := prepareContexts(10)
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -90,4 +76,42 @@ func BenchmarkRecordReqCommand(b *testing.B) {
 		}
 		record.handleCommand(w)
 	}
+}
+
+func BenchmarkRecordViaStats(b *testing.B) {
+
+	meter := NewMeter()
+	meter.Start()
+	defer meter.Stop()
+	meter.Register(view)
+	defer meter.Unregister(view)
+
+	ctxs := prepareContexts(10)
+	rec := stats.WithRecorder(meter)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		stats.RecordWithOptions(ctxs[i%len(ctxs)], rec, stats.WithMeasurements(m.M(1), m.M(1), m.M(1), m.M(1), m.M(1), m.M(1), m.M(1), m.M(1)))
+	}
+
+}
+
+func prepareContexts(tagCount int) []context.Context {
+	ctxs := make([]context.Context, 0, tagCount)
+	for i := 0; i < tagCount; i++ {
+		ctx, _ := tag.New(context.Background(),
+			tag.Upsert(k1, fmt.Sprintf("v%d", i)),
+			tag.Upsert(k2, fmt.Sprintf("v%d", i)),
+			tag.Upsert(k3, fmt.Sprintf("v%d", i)),
+			tag.Upsert(k4, fmt.Sprintf("v%d", i)),
+			tag.Upsert(k5, fmt.Sprintf("v%d", i)),
+			tag.Upsert(k6, fmt.Sprintf("v%d", i)),
+			tag.Upsert(k7, fmt.Sprintf("v%d", i)),
+			tag.Upsert(k8, fmt.Sprintf("v%d", i)),
+		)
+		ctxs = append(ctxs, ctx)
+	}
+
+	return ctxs
 }

--- a/stats/view/export.go
+++ b/stats/view/export.go
@@ -14,13 +14,6 @@
 
 package view
 
-import "sync"
-
-var (
-	exportersMu sync.RWMutex // guards exporters
-	exporters   = make(map[Exporter]struct{})
-)
-
 // Exporter exports the collected records as view data.
 //
 // The ExportView method should return quickly; if an
@@ -43,16 +36,10 @@ type Exporter interface {
 //
 // Binaries can register exporters, libraries shouldn't register exporters.
 func RegisterExporter(e Exporter) {
-	exportersMu.Lock()
-	defer exportersMu.Unlock()
-
-	exporters[e] = struct{}{}
+	defaultWorker.RegisterExporter(e)
 }
 
 // UnregisterExporter unregisters an exporter.
 func UnregisterExporter(e Exporter) {
-	exportersMu.Lock()
-	defer exportersMu.Unlock()
-
-	delete(exporters, e)
+	defaultWorker.UnregisterExporter(e)
 }

--- a/stats/view/worker.go
+++ b/stats/view/worker.go
@@ -28,7 +28,7 @@ import (
 )
 
 func init() {
-	defaultWorker = NewWorker().(*worker)
+	defaultWorker = NewMeter().(*worker)
 	go defaultWorker.start()
 	internal.DefaultRecorder = record
 }
@@ -60,8 +60,7 @@ type worker struct {
 // Note that this is an advanced use case, and the static functions in this
 // module should cover the common use cases.
 type Meter interface {
-	// Record records a set of measurements ms associated with the given tags and attachments.
-	Record(tags *tag.Map, ms interface{}, attachments map[string]interface{})
+	stats.Recorder
 	// Find returns a registered view associated with this name.
 	// If no registered view is found, nil is returned.
 	Find(name string) *View
@@ -233,8 +232,10 @@ func (w *worker) SetReportingPeriod(d time.Duration) {
 	<-req.c // don't return until the timer is set to the new duration.
 }
 
-// NewWorker constructs a
-func NewWorker() Meter {
+// NewMeter constructs a Meter instance. You should only need to use this if
+// you need to separate out Measurement recordings and View aggregations within
+// a single process.
+func NewMeter() Meter {
 	return &worker{
 		measures:   make(map[string]*measureRef),
 		views:      make(map[string]*viewInternal),

--- a/stats/view/worker_test.go
+++ b/stats/view/worker_test.go
@@ -123,7 +123,7 @@ func Test_Worker_MultiExport(t *testing.T) {
 
 	// This test reports the same data for the default worker and a secondary
 	// worker, and ensures that the stats are kept independently.
-	worker2 := NewWorker().(*worker)
+	worker2 := NewMeter().(*worker)
 	worker2.Start()
 
 	m := stats.Float64("Test_Worker_MultiExport/MF1", "desc MF1", "unit")
@@ -397,7 +397,7 @@ func TestReportUsage(t *testing.T) {
 func Test_SetReportingPeriodReqNeverBlocks(t *testing.T) {
 	t.Parallel()
 
-	worker := NewWorker().(*worker)
+	worker := NewMeter().(*worker)
 	durations := []time.Duration{-1, 0, 10, 100 * time.Millisecond}
 	for i, duration := range durations {
 		ackChan := make(chan bool, 1)
@@ -616,6 +616,6 @@ func (e *vdExporter) ExportView(vd *Data) {
 // restart stops the current processors and creates a new one.
 func restart() {
 	defaultWorker.Stop()
-	defaultWorker = NewWorker().(*worker)
+	defaultWorker = NewMeter().(*worker)
 	go defaultWorker.start()
 }

--- a/stats/view/worker_test.go
+++ b/stats/view/worker_test.go
@@ -187,7 +187,7 @@ func Test_Worker_MultiExport(t *testing.T) {
 	for _, wantRow := range wantRows {
 		retrieve := RetrieveData
 		if wantRow.w != nil {
-			retrieve = wantRow.w.(*worker).retrieveData
+			retrieve = wantRow.w.(*worker).RetrieveData
 		}
 		gotRows, err := retrieve(wantRow.view)
 		if err != nil {
@@ -207,7 +207,7 @@ func Test_Worker_MultiExport(t *testing.T) {
 		}
 	}
 	// Verify that worker has not been computing sum:
-	got, err := worker2.retrieveData(sum.Name)
+	got, err := worker2.RetrieveData(sum.Name)
 	if err == nil {
 		t.Errorf("%s: expected no data because it was not registered, got %#v", sum.Name, got)
 	}


### PR DESCRIPTION
Fixes #1195

I wanted to be able to export statistics for multiple Resources, but I discovered that all the stats aggregation was bundled into a single "universe" in the stats/view `defaultWorker`. This PR moves all the singleton state into a `Worker` interface, and maintains the simple singleton interface for the common case, but allows creating additional `Workers` in complex cases.