### PR TITLE
ochttp plugin: add user agent tag key

### DIFF
--- a/plugin/ochttp/server.go
+++ b/plugin/ochttp/server.go
@@ -150,7 +150,8 @@ func (h *Handler) startStats(w http.ResponseWriter, r *http.Request) (http.Respo
 	ctx, _ := tag.New(r.Context(),
 		tag.Upsert(Host, r.Host),
 		tag.Upsert(Path, r.URL.Path),
-		tag.Upsert(Method, r.Method))
+		tag.Upsert(Method, r.Method),
+		tag.Upsert(UserAgent, r.UserAgent()))
 	track := &trackingResponseWriter{
 		start:  time.Now(),
 		ctx:    ctx,

--- a/plugin/ochttp/stats.go
+++ b/plugin/ochttp/stats.go
@@ -112,6 +112,13 @@ var (
 	// handler of the request. This is usually the pattern registered on the a
 	// ServeMux (or similar string).
 	KeyServerRoute = tag.MustNewKey("http_server_route")
+
+	// UserAgent is the value of the HTTP User-Agent header.
+	//
+	// The value of this tag can be controlled by the HTTP client, so you need
+	// to watch out for potentially generating high-cardinality labels in your
+	// metrics backend if you use this tag in views.
+	UserAgent = tag.MustNewKey("http.user_agent")
 )
 
 // Client tag keys.


### PR DESCRIPTION
Makes user agent value available for custom views.