### PR TITLE
Safely reject invalid-length span and trace ids

### DIFF
--- a/plugin/ochttp/propagation/b3/b3.go
+++ b/plugin/ochttp/propagation/b3/b3.go
@@ -68,7 +68,7 @@ func ParseTraceID(tid string) (trace.TraceID, bool) {
 		return trace.TraceID{}, false
 	}
 	b, err := hex.DecodeString(tid)
-	if err != nil {
+	if err != nil || len(b) > 16 {
 		return trace.TraceID{}, false
 	}
 	var traceID trace.TraceID
@@ -90,7 +90,7 @@ func ParseSpanID(sid string) (spanID trace.SpanID, ok bool) {
 		return trace.SpanID{}, false
 	}
 	b, err := hex.DecodeString(sid)
-	if err != nil {
+	if err != nil || len(b) > 8 {
 		return trace.SpanID{}, false
 	}
 	start := 8 - len(b)

--- a/plugin/ochttp/propagation/b3/b3_test.go
+++ b/plugin/ochttp/propagation/b3/b3_test.go
@@ -104,11 +104,33 @@ func TestHTTPFormat_FromRequest(t *testing.T) {
 			wantOk: false,
 		},
 		{
+			name: "invalid >128-bit trace ID + 64-bit span ID; no sampling header",
+			makeReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "http://example.com", nil)
+				req.Header.Set(TraceIDHeader, "0020000000000001002000000000000111")
+				req.Header.Set(SpanIDHeader, "0020000000000001")
+				return req
+			},
+			wantSc: trace.SpanContext{},
+			wantOk: false,
+		},
+		{
 			name: "128-bit trace ID; invalid span ID; no sampling header",
 			makeReq: func() *http.Request {
 				req, _ := http.NewRequest("GET", "http://example.com", nil)
 				req.Header.Set(TraceIDHeader, "463ac35c9f6413ad48485a3953bb6124")
 				req.Header.Set(SpanIDHeader, "")
+				return req
+			},
+			wantSc: trace.SpanContext{},
+			wantOk: false,
+		},
+		{
+			name: "128-bit trace ID; invalid >64 bit span ID; no sampling header",
+			makeReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "http://example.com", nil)
+				req.Header.Set(TraceIDHeader, "463ac35c9f6413ad48485a3953bb6124")
+				req.Header.Set(SpanIDHeader, "002000000000000111")
 				return req
 			},
 			wantSc: trace.SpanContext{},


### PR DESCRIPTION
Fixes #1205 

Current behaviour is to panic on span/trace IDs with valid hex encoding which exceed expected lengths.

This PR causes these IDs to be rejected as for any other invalid encoding.