### PR TITLE
Delete views from measure ref when unregistering

### DIFF
--- a/stats/view/worker.go
+++ b/stats/view/worker.go
@@ -314,10 +314,13 @@ func (w *worker) tryRegisterView(v *View) (*viewInternal, error) {
 	return vi, nil
 }
 
-func (w *worker) unregisterView(viewName string) {
+func (w *worker) unregisterView(v *viewInternal) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	delete(w.views, viewName)
+	delete(w.views, v.view.Name)
+	if measure := w.measures[v.view.Measure.Name()]; measure != nil {
+		delete(measure.views, v)
+	}
 }
 
 func (w *worker) reportView(v *viewInternal, now time.Time) {

--- a/stats/view/worker_commands.go
+++ b/stats/view/worker_commands.go
@@ -103,7 +103,7 @@ func (cmd *unregisterFromViewReq) handleCommand(w *worker) {
 			// The collected data can be cleared.
 			vi.clearRows()
 		}
-		w.unregisterView(name)
+		w.unregisterView(vi)
 	}
 	cmd.done <- struct{}{}
 }


### PR DESCRIPTION
Currently measure refs will accumulate views that have been unregistered which can skew benchmarks when tests frequently reregister their views.