### PR TITLE
Implement server and client `completed_rpcs` (#1214)

### DIFF
--- a/plugin/ocgrpc/client_metrics.go
+++ b/plugin/ocgrpc/client_metrics.go
@@ -27,6 +27,7 @@ var (
 	ClientSentBytesPerRPC        = stats.Int64("grpc.io/client/sent_bytes_per_rpc", "Total bytes sent across all request messages per RPC.", stats.UnitBytes)
 	ClientReceivedMessagesPerRPC = stats.Int64("grpc.io/client/received_messages_per_rpc", "Number of response messages received per RPC (always 1 for non-streaming RPCs).", stats.UnitDimensionless)
 	ClientReceivedBytesPerRPC    = stats.Int64("grpc.io/client/received_bytes_per_rpc", "Total bytes received across all response messages per RPC.", stats.UnitBytes)
+	ClientCompletedRPCs          = stats.Int64("grpc.io/client/completed_rpcs", `Total completed RPCs, where an RPC is either a single non-streaming request and response, or an entire stream start to finish.`, stats.UnitDimensionless)
 	ClientRoundtripLatency       = stats.Float64("grpc.io/client/roundtrip_latency", "Time between first byte of request sent to last byte of response received, or terminal error.", stats.UnitMilliseconds)
 	ClientServerLatency          = stats.Float64("grpc.io/client/server_latency", `Propagated from the server and should have the same value as "grpc.io/server/latency".`, stats.UnitMilliseconds)
 )
@@ -61,7 +62,7 @@ var (
 	}
 
 	ClientCompletedRPCsView = &view.View{
-		Measure:     ClientRoundtripLatency,
+		Measure:     ClientCompletedRPCs,
 		Name:        "grpc.io/client/completed_rpcs",
 		Description: "Count of RPCs by method and status.",
 		TagKeys:     []tag.Key{KeyClientMethod, KeyClientStatus},

--- a/plugin/ocgrpc/client_spec_test.go
+++ b/plugin/ocgrpc/client_spec_test.go
@@ -86,7 +86,7 @@ func TestSpecClientViews(t *testing.T) {
 | grpc.io/client/sent_bytes_per_rpc     | sent_bytes_per_rpc     | distribution | client_method                |
 | grpc.io/client/received_bytes_per_rpc | received_bytes_per_rpc | distribution | client_method                |
 | grpc.io/client/roundtrip_latency      | roundtrip_latency      | distribution | client_method                |
-| grpc.io/client/completed_rpcs         | roundtrip_latency      | count        | client_method, client_status |`
+| grpc.io/client/completed_rpcs         | completed_rpcs         | count        | client_method, client_status |`
 
 	extraViewsSpec := `
 | View name                                | Measure suffix            | Aggregation  | Tags suffix   |

--- a/plugin/ocgrpc/server_metrics.go
+++ b/plugin/ocgrpc/server_metrics.go
@@ -27,6 +27,7 @@ var (
 	ServerReceivedBytesPerRPC    = stats.Int64("grpc.io/server/received_bytes_per_rpc", "Total bytes received across all messages per RPC.", stats.UnitBytes)
 	ServerSentMessagesPerRPC     = stats.Int64("grpc.io/server/sent_messages_per_rpc", "Number of messages sent in each RPC. Has value 1 for non-streaming RPCs.", stats.UnitDimensionless)
 	ServerSentBytesPerRPC        = stats.Int64("grpc.io/server/sent_bytes_per_rpc", "Total bytes sent in across all response messages per RPC.", stats.UnitBytes)
+	ServerCompletedRPCs          = stats.Int64("grpc.io/server/completed_rpcs", "Total completed RPCs, where an RPC is either a single non-streaming request and response, or an entire stream start to finish.", stats.UnitDimensionless)
 	ServerLatency                = stats.Float64("grpc.io/server/server_latency", "Time between first byte of request received to last byte of response sent, or terminal error.", stats.UnitMilliseconds)
 )
 
@@ -67,7 +68,7 @@ var (
 		Name:        "grpc.io/server/completed_rpcs",
 		Description: "Count of RPCs by method and status.",
 		TagKeys:     []tag.Key{KeyServerMethod, KeyServerStatus},
-		Measure:     ServerLatency,
+		Measure:     ServerCompletedRPCs,
 		Aggregation: view.Count(),
 	}
 

--- a/plugin/ocgrpc/server_spec_test.go
+++ b/plugin/ocgrpc/server_spec_test.go
@@ -81,7 +81,7 @@ func TestSpecServerViews(t *testing.T) {
 | grpc.io/server/received_bytes_per_rpc | received_bytes_per_rpc | distribution | server_method                |
 | grpc.io/server/sent_bytes_per_rpc     | sent_bytes_per_rpc     | distribution | server_method                |
 | grpc.io/server/server_latency         | server_latency         | distribution | server_method                |
-| grpc.io/server/completed_rpcs         | server_latency         | count        | server_method, server_status |`
+| grpc.io/server/completed_rpcs         | completed_rpcs         | count        | server_method, server_status |`
 
 	extraViewsSpec := `
 | View name                                | Measure suffix            | Aggregation  | Tags suffix   |

--- a/plugin/ocgrpc/stats_common.go
+++ b/plugin/ocgrpc/stats_common.go
@@ -154,6 +154,7 @@ func handleRPCEnd(ctx context.Context, s *stats.End) {
 				ClientSentBytesPerRPC.M(atomic.LoadInt64(&d.sentBytes)),
 				ClientSentMessagesPerRPC.M(atomic.LoadInt64(&d.sentCount)),
 				ClientReceivedMessagesPerRPC.M(atomic.LoadInt64(&d.recvCount)),
+				ClientCompletedRPCs.M(1),
 				ClientReceivedBytesPerRPC.M(atomic.LoadInt64(&d.recvBytes)),
 				ClientRoundtripLatency.M(latencyMillis)))
 	} else {
@@ -167,6 +168,7 @@ func handleRPCEnd(ctx context.Context, s *stats.End) {
 				ServerSentMessagesPerRPC.M(atomic.LoadInt64(&d.sentCount)),
 				ServerReceivedMessagesPerRPC.M(atomic.LoadInt64(&d.recvCount)),
 				ServerReceivedBytesPerRPC.M(atomic.LoadInt64(&d.recvBytes)),
+				ServerCompletedRPCs.M(1),
 				ServerLatency.M(latencyMillis)))
 	}
 }


### PR DESCRIPTION
The previous implementation appears to be a copy-paste error that directed data into
the latency metric, but never recorded data preserving the latency measure
accuracy. This cl implements the `completed_rpcs` measure by
incrementing by 1 for each `handleRPCEnd` call.

The measure is broken down by method and status.