### PR TITLE
Comment on GRPC latency measure reuse (#1214)

### DIFF
--- a/plugin/ocgrpc/client_metrics.go
+++ b/plugin/ocgrpc/client_metrics.go
@@ -60,6 +60,8 @@ var (
 		Aggregation: DefaultMillisecondsDistribution,
 	}
 
+	// Purposely reuses the count from `ClientRoundtripLatency`, tagging
+	// with method and status to result in ClientCompletedRpcs.
 	ClientCompletedRPCsView = &view.View{
 		Measure:     ClientRoundtripLatency,
 		Name:        "grpc.io/client/completed_rpcs",

--- a/plugin/ocgrpc/server_metrics.go
+++ b/plugin/ocgrpc/server_metrics.go
@@ -63,6 +63,8 @@ var (
 		Aggregation: DefaultMillisecondsDistribution,
 	}
 
+	// Purposely reuses the count from `ServerLatency`, tagging
+	// with method and status to result in ServerCompletedRpcs.
 	ServerCompletedRPCsView = &view.View{
 		Name:        "grpc.io/server/completed_rpcs",
 		Description: "Count of RPCs by method and status.",


### PR DESCRIPTION
This reuse previously threw us for a loop. We mistakenly thought it was
a copy/paste error.
https://github.com/census-instrumentation/opencensus-go/issues/1214
https://github.com/census-instrumentation/opencensus-go/pull/1216