### PR TITLE
Record a Start Time Per Time Series within a View

### DIFF
--- a/plugin/ocgrpc/client_stats_handler_test.go
+++ b/plugin/ocgrpc/client_stats_handler_test.go
@@ -320,14 +320,7 @@ func TestClientDefaultCollections(t *testing.T) {
 				continue
 			}
 			for i := range gotRows {
-				switch data := gotRows[i].Data.(type) {
-				case *view.CountData:
-					data.Start = time.Time{}
-				case *view.SumData:
-					data.Start = time.Time{}
-				case *view.DistributionData:
-					data.Start = time.Time{}
-				}
+				clearStart(gotRows[i].Data)
 			}
 
 			for _, gotRow := range gotRows {
@@ -429,4 +422,17 @@ func containsRow(rows []*view.Row, r *view.Row) bool {
 // Compare exemplars while ignoring exemplar timestamp, since timestamp is non-deterministic.
 func cmpExemplar(got, want *metricdata.Exemplar) string {
 	return cmp.Diff(got, want, cmpopts.IgnoreFields(metricdata.Exemplar{}, "Timestamp"), cmpopts.IgnoreUnexported(metricdata.Exemplar{}))
+}
+
+// clearStart clears the Start field from data if present. Useful for testing in cases where the
+// start time will be nondeterministic.
+func clearStart(data view.AggregationData) {
+	switch data := data.(type) {
+	case *view.CountData:
+		data.Start = time.Time{}
+	case *view.SumData:
+		data.Start = time.Time{}
+	case *view.DistributionData:
+		data.Start = time.Time{}
+	}
 }

--- a/plugin/ocgrpc/client_stats_handler_test.go
+++ b/plugin/ocgrpc/client_stats_handler_test.go
@@ -18,7 +18,6 @@ package ocgrpc
 import (
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -320,7 +319,7 @@ func TestClientDefaultCollections(t *testing.T) {
 				continue
 			}
 			for i := range gotRows {
-				clearStart(gotRows[i].Data)
+				view.ClearStart(gotRows[i].Data)
 			}
 
 			for _, gotRow := range gotRows {
@@ -422,17 +421,4 @@ func containsRow(rows []*view.Row, r *view.Row) bool {
 // Compare exemplars while ignoring exemplar timestamp, since timestamp is non-deterministic.
 func cmpExemplar(got, want *metricdata.Exemplar) string {
 	return cmp.Diff(got, want, cmpopts.IgnoreFields(metricdata.Exemplar{}, "Timestamp"), cmpopts.IgnoreUnexported(metricdata.Exemplar{}))
-}
-
-// clearStart clears the Start field from data if present. Useful for testing in cases where the
-// start time will be nondeterministic.
-func clearStart(data view.AggregationData) {
-	switch data := data.(type) {
-	case *view.CountData:
-		data.Start = time.Time{}
-	case *view.SumData:
-		data.Start = time.Time{}
-	case *view.DistributionData:
-		data.Start = time.Time{}
-	}
 }

--- a/plugin/ocgrpc/client_stats_handler_test.go
+++ b/plugin/ocgrpc/client_stats_handler_test.go
@@ -18,6 +18,7 @@ package ocgrpc
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -317,6 +318,16 @@ func TestClientDefaultCollections(t *testing.T) {
 			if err != nil {
 				t.Errorf("%q: RetrieveData(%q) = %v", tc.label, wantData.v().Name, err)
 				continue
+			}
+			for i := range gotRows {
+				switch data := gotRows[i].Data.(type) {
+				case *view.CountData:
+					data.Start = time.Time{}
+				case *view.SumData:
+					data.Start = time.Time{}
+				case *view.DistributionData:
+					data.Start = time.Time{}
+				}
 			}
 
 			for _, gotRow := range gotRows {

--- a/plugin/ocgrpc/server_stats_handler_test.go
+++ b/plugin/ocgrpc/server_stats_handler_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"reflect"
 	"testing"
-	"time"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/stats"
@@ -307,14 +306,7 @@ func TestServerDefaultCollections(t *testing.T) {
 			}
 
 			for i := range gotRows {
-				switch data := gotRows[i].Data.(type) {
-				case *view.CountData:
-					data.Start = time.Time{}
-				case *view.SumData:
-					data.Start = time.Time{}
-				case *view.DistributionData:
-					data.Start = time.Time{}
-				}
+				clearStart(gotRows[i].Data)
 			}
 
 			for _, gotRow := range gotRows {

--- a/plugin/ocgrpc/server_stats_handler_test.go
+++ b/plugin/ocgrpc/server_stats_handler_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"reflect"
 	"testing"
+	"time"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/stats"
@@ -303,6 +304,17 @@ func TestServerDefaultCollections(t *testing.T) {
 			if err != nil {
 				t.Errorf("%q: RetrieveData (%q) = %v", tc.label, wantData.v().Name, err)
 				continue
+			}
+
+			for i := range gotRows {
+				switch data := gotRows[i].Data.(type) {
+				case *view.CountData:
+					data.Start = time.Time{}
+				case *view.SumData:
+					data.Start = time.Time{}
+				case *view.DistributionData:
+					data.Start = time.Time{}
+				}
 			}
 
 			for _, gotRow := range gotRows {

--- a/plugin/ocgrpc/server_stats_handler_test.go
+++ b/plugin/ocgrpc/server_stats_handler_test.go
@@ -306,7 +306,7 @@ func TestServerDefaultCollections(t *testing.T) {
 			}
 
 			for i := range gotRows {
-				clearStart(gotRows[i].Data)
+				view.ClearStart(gotRows[i].Data)
 			}
 
 			for _, gotRow := range gotRows {

--- a/plugin/ochttp/route_test.go
+++ b/plugin/ochttp/route_test.go
@@ -55,14 +55,7 @@ func TestWithRouteTag(t *testing.T) {
 
 	got := e.rowsForView("request_total")
 	for i := range got {
-		switch data := got[i].Data.(type) {
-		case *view.CountData:
-			data.Start = time.Time{}
-		case *view.SumData:
-			data.Start = time.Time{}
-		case *view.DistributionData:
-			data.Start = time.Time{}
-		}
+		clearStart(got[i].Data)
 	}
 	want := []*view.Row{
 		{Data: &view.CountData{Value: 1}, Tags: []tag.Tag{{Key: ochttp.KeyServerRoute, Value: "/a/"}}},
@@ -102,14 +95,7 @@ func TestSetRoute(t *testing.T) {
 
 	got := e.rowsForView("request_total")
 	for i := range got {
-		switch data := got[i].Data.(type) {
-		case *view.CountData:
-			data.Start = time.Time{}
-		case *view.SumData:
-			data.Start = time.Time{}
-		case *view.DistributionData:
-			data.Start = time.Time{}
-		}
+		clearStart(got[i].Data)
 	}
 	want := []*view.Row{
 		{Data: &view.CountData{Value: 1}, Tags: []tag.Tag{{Key: ochttp.KeyServerRoute, Value: "/a/"}}},
@@ -135,4 +121,17 @@ func (t *testStatsExporter) rowsForView(name string) []*view.Row {
 		}
 	}
 	return rows
+}
+
+// clearStart clears the Start field from data if present. Useful for testing in cases where the
+// start time will be nondeterministic.
+func clearStart(data view.AggregationData) {
+	switch data := data.(type) {
+	case *view.CountData:
+		data.Start = time.Time{}
+	case *view.SumData:
+		data.Start = time.Time{}
+	case *view.DistributionData:
+		data.Start = time.Time{}
+	}
 }

--- a/plugin/ochttp/route_test.go
+++ b/plugin/ochttp/route_test.go
@@ -18,7 +18,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"go.opencensus.io/plugin/ochttp"
@@ -55,7 +54,7 @@ func TestWithRouteTag(t *testing.T) {
 
 	got := e.rowsForView("request_total")
 	for i := range got {
-		clearStart(got[i].Data)
+		view.ClearStart(got[i].Data)
 	}
 	want := []*view.Row{
 		{Data: &view.CountData{Value: 1}, Tags: []tag.Tag{{Key: ochttp.KeyServerRoute, Value: "/a/"}}},
@@ -95,7 +94,7 @@ func TestSetRoute(t *testing.T) {
 
 	got := e.rowsForView("request_total")
 	for i := range got {
-		clearStart(got[i].Data)
+		view.ClearStart(got[i].Data)
 	}
 	want := []*view.Row{
 		{Data: &view.CountData{Value: 1}, Tags: []tag.Tag{{Key: ochttp.KeyServerRoute, Value: "/a/"}}},
@@ -121,17 +120,4 @@ func (t *testStatsExporter) rowsForView(name string) []*view.Row {
 		}
 	}
 	return rows
-}
-
-// clearStart clears the Start field from data if present. Useful for testing in cases where the
-// start time will be nondeterministic.
-func clearStart(data view.AggregationData) {
-	switch data := data.(type) {
-	case *view.CountData:
-		data.Start = time.Time{}
-	case *view.SumData:
-		data.Start = time.Time{}
-	case *view.DistributionData:
-		data.Start = time.Time{}
-	}
 }

--- a/plugin/ochttp/route_test.go
+++ b/plugin/ochttp/route_test.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"go.opencensus.io/plugin/ochttp"
@@ -53,6 +54,16 @@ func TestWithRouteTag(t *testing.T) {
 	view.Unregister(v) // trigger exporting
 
 	got := e.rowsForView("request_total")
+	for i := range got {
+		switch data := got[i].Data.(type) {
+		case *view.CountData:
+			data.Start = time.Time{}
+		case *view.SumData:
+			data.Start = time.Time{}
+		case *view.DistributionData:
+			data.Start = time.Time{}
+		}
+	}
 	want := []*view.Row{
 		{Data: &view.CountData{Value: 1}, Tags: []tag.Tag{{Key: ochttp.KeyServerRoute, Value: "/a/"}}},
 	}
@@ -90,6 +101,16 @@ func TestSetRoute(t *testing.T) {
 	view.Unregister(v) // trigger exporting
 
 	got := e.rowsForView("request_total")
+	for i := range got {
+		switch data := got[i].Data.(type) {
+		case *view.CountData:
+			data.Start = time.Time{}
+		case *view.SumData:
+			data.Start = time.Time{}
+		case *view.DistributionData:
+			data.Start = time.Time{}
+		}
+	}
 	want := []*view.Row{
 		{Data: &view.CountData{Value: 1}, Tags: []tag.Tag{{Key: ochttp.KeyServerRoute, Value: "/a/"}}},
 	}

--- a/stats/view/aggregation.go
+++ b/stats/view/aggregation.go
@@ -54,13 +54,13 @@ var (
 	aggCount = &Aggregation{
 		Type: AggTypeCount,
 		newData: func(t time.Time) AggregationData {
-			return &CountData{StartTime: t}
+			return &CountData{Start: t}
 		},
 	}
 	aggSum = &Aggregation{
 		Type: AggTypeSum,
 		newData: func(t time.Time) AggregationData {
-			return &SumData{StartTime: t}
+			return &SumData{Start: t}
 		},
 	}
 )

--- a/stats/view/aggregation.go
+++ b/stats/view/aggregation.go
@@ -15,6 +15,8 @@
 
 package view
 
+import "time"
+
 // AggType represents the type of aggregation function used on a View.
 type AggType int
 
@@ -45,20 +47,20 @@ type Aggregation struct {
 	Type    AggType   // Type is the AggType of this Aggregation.
 	Buckets []float64 // Buckets are the bucket endpoints if this Aggregation represents a distribution, see Distribution.
 
-	newData func() AggregationData
+	newData func(time.Time) AggregationData
 }
 
 var (
 	aggCount = &Aggregation{
 		Type: AggTypeCount,
-		newData: func() AggregationData {
-			return &CountData{}
+		newData: func(t time.Time) AggregationData {
+			return &CountData{StartTime: t}
 		},
 	}
 	aggSum = &Aggregation{
 		Type: AggTypeSum,
-		newData: func() AggregationData {
-			return &SumData{}
+		newData: func(t time.Time) AggregationData {
+			return &SumData{StartTime: t}
 		},
 	}
 )
@@ -103,8 +105,8 @@ func Distribution(bounds ...float64) *Aggregation {
 		Type:    AggTypeDistribution,
 		Buckets: bounds,
 	}
-	agg.newData = func() AggregationData {
-		return newDistributionData(agg)
+	agg.newData = func(t time.Time) AggregationData {
+		return newDistributionData(agg, t)
 	}
 	return agg
 }
@@ -114,7 +116,7 @@ func Distribution(bounds ...float64) *Aggregation {
 func LastValue() *Aggregation {
 	return &Aggregation{
 		Type: AggTypeLastValue,
-		newData: func() AggregationData {
+		newData: func(_ time.Time) AggregationData {
 			return &LastValueData{}
 		},
 	}

--- a/stats/view/aggregation_data.go
+++ b/stats/view/aggregation_data.go
@@ -61,7 +61,7 @@ func (a *CountData) equal(other AggregationData) bool {
 		return false
 	}
 
-	return a.Value == a2.Value && a.Start.Equal(a2.Start)
+	return a.Start.Equal(a2.Start) && a.Value == a2.Value
 }
 
 func (a *CountData) toPoint(metricType metricdata.Type, t time.Time) metricdata.Point {
@@ -102,7 +102,7 @@ func (a *SumData) equal(other AggregationData) bool {
 	if !ok {
 		return false
 	}
-	return math.Pow(a.Value-a2.Value, 2) < epsilon && a.Start.Equal(a2.Start)
+	return a.Start.Equal(a2.Start) && math.Pow(a.Value-a2.Value, 2) < epsilon
 }
 
 func (a *SumData) toPoint(metricType metricdata.Type, t time.Time) metricdata.Point {
@@ -241,7 +241,11 @@ func (a *DistributionData) equal(other AggregationData) bool {
 			return false
 		}
 	}
-	return a.Count == a2.Count && a.Min == a2.Min && a.Max == a2.Max && math.Pow(a.Mean-a2.Mean, 2) < epsilon && math.Pow(a.variance()-a2.variance(), 2) < epsilon && a.Start.Equal(a2.Start)
+	return a.Start.Equal(a2.Start) &&
+		a.Count == a2.Count &&
+		a.Min == a2.Min &&
+		a.Max == a2.Max &&
+		math.Pow(a.Mean-a2.Mean, 2) < epsilon && math.Pow(a.variance()-a2.variance(), 2) < epsilon
 }
 
 func (a *DistributionData) toPoint(metricType metricdata.Type, t time.Time) metricdata.Point {

--- a/stats/view/aggregation_data.go
+++ b/stats/view/aggregation_data.go
@@ -31,6 +31,7 @@ type AggregationData interface {
 	clone() AggregationData
 	equal(other AggregationData) bool
 	toPoint(t metricdata.Type, time time.Time) metricdata.Point
+	startTime() time.Time
 }
 
 const epsilon = 1e-9
@@ -72,6 +73,10 @@ func (a *CountData) toPoint(metricType metricdata.Type, t time.Time) metricdata.
 	}
 }
 
+func (a *CountData) startTime() time.Time {
+	return a.StartTime
+}
+
 // SumData is the aggregated data for the Sum aggregation.
 // A sum aggregation processes data and sums up the recordings.
 //
@@ -108,6 +113,10 @@ func (a *SumData) toPoint(metricType metricdata.Type, t time.Time) metricdata.Po
 	default:
 		panic("unsupported metricdata.Type")
 	}
+}
+
+func (a *SumData) startTime() time.Time {
+	return a.StartTime
 }
 
 // DistributionData is the aggregated data for the
@@ -260,6 +269,10 @@ func (a *DistributionData) toPoint(metricType metricdata.Type, t time.Time) metr
 	}
 }
 
+func (a *DistributionData) startTime() time.Time {
+	return a.StartTime
+}
+
 // LastValueData returns the last value recorded for LastValue aggregation.
 type LastValueData struct {
 	Value float64
@@ -294,4 +307,8 @@ func (l *LastValueData) toPoint(metricType metricdata.Type, t time.Time) metricd
 	default:
 		panic("unsupported metricdata.Type")
 	}
+}
+
+func (d *LastValueData) startTime() time.Time {
+	return time.Time{}
 }

--- a/stats/view/aggregation_data.go
+++ b/stats/view/aggregation_data.go
@@ -40,7 +40,8 @@ const epsilon = 1e-9
 //
 // Most users won't directly access count data.
 type CountData struct {
-	Value int64
+	StartTime time.Time
+	Value     int64
 }
 
 func (a *CountData) isAggregationData() bool { return true }
@@ -76,7 +77,8 @@ func (a *CountData) toPoint(metricType metricdata.Type, t time.Time) metricdata.
 //
 // Most users won't directly access sum data.
 type SumData struct {
-	Value float64
+	StartTime time.Time
+	Value     float64
 }
 
 func (a *SumData) isAggregationData() bool { return true }
@@ -126,9 +128,10 @@ type DistributionData struct {
 	// an exemplar for the associated bucket, or nil.
 	ExemplarsPerBucket []*metricdata.Exemplar
 	bounds             []float64 // histogram distribution of the values
+	StartTime          time.Time
 }
 
-func newDistributionData(agg *Aggregation) *DistributionData {
+func newDistributionData(agg *Aggregation, t time.Time) *DistributionData {
 	bucketCount := len(agg.Buckets) + 1
 	return &DistributionData{
 		CountPerBucket:     make([]int64, bucketCount),
@@ -136,6 +139,7 @@ func newDistributionData(agg *Aggregation) *DistributionData {
 		bounds:             agg.Buckets,
 		Min:                math.MaxFloat64,
 		Max:                math.SmallestNonzeroFloat64,
+		StartTime:          t,
 	}
 }
 

--- a/stats/view/aggregation_data.go
+++ b/stats/view/aggregation_data.go
@@ -73,6 +73,7 @@ func (a *CountData) toPoint(metricType metricdata.Type, t time.Time) metricdata.
 	}
 }
 
+// StartTime returns the start time of the data being aggregated by CountData.
 func (a *CountData) StartTime() time.Time {
 	return a.Start
 }
@@ -115,6 +116,7 @@ func (a *SumData) toPoint(metricType metricdata.Type, t time.Time) metricdata.Po
 	}
 }
 
+// StartTime returns the start time of the data being aggregated by SumData.
 func (a *SumData) StartTime() time.Time {
 	return a.Start
 }
@@ -269,6 +271,7 @@ func (a *DistributionData) toPoint(metricType metricdata.Type, t time.Time) metr
 	}
 }
 
+// StartTime returns the start time of the data being aggregated by DistributionData.
 func (a *DistributionData) StartTime() time.Time {
 	return a.Start
 }
@@ -309,6 +312,8 @@ func (l *LastValueData) toPoint(metricType metricdata.Type, t time.Time) metricd
 	}
 }
 
-func (d *LastValueData) StartTime() time.Time {
+// StartTime returns an empty time value as start time is not recorded when using last value
+// aggregation.
+func (l *LastValueData) StartTime() time.Time {
 	return time.Time{}
 }

--- a/stats/view/aggregation_data.go
+++ b/stats/view/aggregation_data.go
@@ -321,3 +321,16 @@ func (l *LastValueData) toPoint(metricType metricdata.Type, t time.Time) metricd
 func (l *LastValueData) StartTime() time.Time {
 	return time.Time{}
 }
+
+// ClearStart clears the Start field from data if present. Useful for testing in cases where the
+// start time will be nondeterministic.
+func ClearStart(data AggregationData) {
+	switch data := data.(type) {
+	case *CountData:
+		data.Start = time.Time{}
+	case *SumData:
+		data.Start = time.Time{}
+	case *DistributionData:
+		data.Start = time.Time{}
+	}
+}

--- a/stats/view/aggregation_data_test.go
+++ b/stats/view/aggregation_data_test.go
@@ -29,7 +29,7 @@ func TestDataClone(t *testing.T) {
 	agg := &Aggregation{
 		Buckets: []float64{1, 2, 3, 4},
 	}
-	dist := newDistributionData(agg)
+	dist := newDistributionData(agg, time.Time{})
 	dist.Count = 7
 	dist.Max = 11
 	dist.Min = 1
@@ -72,7 +72,7 @@ func TestDistributionData_addSample(t *testing.T) {
 	agg := &Aggregation{
 		Buckets: []float64{1, 2},
 	}
-	dd := newDistributionData(agg)
+	dd := newDistributionData(agg, time.Time{})
 	attachments1 := map[string]interface{}{"key1": "value1"}
 	t1 := time.Now()
 	dd.addSample(0.5, attachments1, t1)

--- a/stats/view/collector.go
+++ b/stats/view/collector.go
@@ -35,7 +35,7 @@ type collector struct {
 func (c *collector) addSample(s string, v float64, attachments map[string]interface{}, t time.Time) {
 	aggregator, ok := c.signatures[s]
 	if !ok {
-		aggregator = c.a.newData()
+		aggregator = c.a.newData(t)
 		c.signatures[s] = aggregator
 	}
 	aggregator.addSample(v, attachments, t)

--- a/stats/view/view_to_metric.go
+++ b/stats/view/view_to_metric.go
@@ -123,7 +123,7 @@ func rowToTimeseries(v *viewInternal, row *Row, now time.Time) *metricdata.TimeS
 	return &metricdata.TimeSeries{
 		Points:      []metricdata.Point{row.Data.toPoint(v.metricDescriptor.Type, now)},
 		LabelValues: toLabelValues(row, v.metricDescriptor.LabelKeys),
-		StartTime:   row.Data.startTime(),
+		StartTime:   row.Data.StartTime(),
 	}
 }
 

--- a/stats/view/view_to_metric.go
+++ b/stats/view/view_to_metric.go
@@ -119,20 +119,15 @@ func toLabelValues(row *Row, expectedKeys []metricdata.LabelKey) []metricdata.La
 	return labelValues
 }
 
-func rowToTimeseries(v *viewInternal, row *Row, now time.Time, startTime time.Time) *metricdata.TimeSeries {
+func rowToTimeseries(v *viewInternal, row *Row, now time.Time) *metricdata.TimeSeries {
 	return &metricdata.TimeSeries{
 		Points:      []metricdata.Point{row.Data.toPoint(v.metricDescriptor.Type, now)},
 		LabelValues: toLabelValues(row, v.metricDescriptor.LabelKeys),
-		StartTime:   startTime,
+		StartTime:   row.Data.startTime(),
 	}
 }
 
-func viewToMetric(v *viewInternal, r *resource.Resource, now time.Time, startTime time.Time) *metricdata.Metric {
-	if v.metricDescriptor.Type == metricdata.TypeGaugeInt64 ||
-		v.metricDescriptor.Type == metricdata.TypeGaugeFloat64 {
-		startTime = time.Time{}
-	}
-
+func viewToMetric(v *viewInternal, r *resource.Resource, now time.Time) *metricdata.Metric {
 	rows := v.collectedRows()
 	if len(rows) == 0 {
 		return nil
@@ -140,7 +135,7 @@ func viewToMetric(v *viewInternal, r *resource.Resource, now time.Time, startTim
 
 	ts := []*metricdata.TimeSeries{}
 	for _, row := range rows {
-		ts = append(ts, rowToTimeseries(v, row, now, startTime))
+		ts = append(ts, rowToTimeseries(v, row, now))
 	}
 
 	m := &metricdata.Metric{

--- a/stats/view/view_to_metric_test.go
+++ b/stats/view/view_to_metric_test.go
@@ -253,7 +253,6 @@ func initMetricDescriptors() {
 }
 
 func Test_ViewToMetric(t *testing.T) {
-	startTime := time.Now().Add(-60 * time.Second)
 	now := time.Now()
 	tests := []*testToMetrics{
 		{
@@ -277,7 +276,7 @@ func Test_ViewToMetric(t *testing.T) {
 						},
 					},
 						LabelValues: labelValues,
-						StartTime:   startTime,
+						StartTime:   now,
 					},
 				},
 			},
@@ -305,7 +304,7 @@ func Test_ViewToMetric(t *testing.T) {
 							},
 						},
 						LabelValues: labelValues,
-						StartTime:   startTime,
+						StartTime:   now,
 					},
 				},
 			},
@@ -320,7 +319,7 @@ func Test_ViewToMetric(t *testing.T) {
 						metricdata.NewInt64Point(now, 2),
 					},
 						LabelValues: labelValues,
-						StartTime:   startTime,
+						StartTime:   now,
 					},
 				},
 			},
@@ -335,7 +334,7 @@ func Test_ViewToMetric(t *testing.T) {
 						metricdata.NewInt64Point(now, 2),
 					},
 						LabelValues: labelValues,
-						StartTime:   startTime,
+						StartTime:   now,
 					},
 				},
 			},
@@ -350,7 +349,7 @@ func Test_ViewToMetric(t *testing.T) {
 						metricdata.NewInt64Point(now, 6),
 					},
 						LabelValues: labelValues,
-						StartTime:   startTime,
+						StartTime:   now,
 					},
 				},
 			},
@@ -365,7 +364,7 @@ func Test_ViewToMetric(t *testing.T) {
 						metricdata.NewFloat64Point(now, 6.9),
 					},
 						LabelValues: labelValues,
-						StartTime:   startTime,
+						StartTime:   now,
 					},
 				},
 			},
@@ -417,12 +416,10 @@ func Test_ViewToMetric(t *testing.T) {
 		},
 	}
 
-	wantMetrics := []*metricdata.Metric{}
 	for _, tc := range tests {
 		tc.vi, _ = defaultWorker.tryRegisterView(tc.view)
 		tc.vi.clearRows()
 		tc.vi.subscribe()
-		wantMetrics = append(wantMetrics, tc.wantMetric)
 	}
 
 	for i, tc := range tests {
@@ -447,7 +444,7 @@ func Test_ViewToMetric(t *testing.T) {
 			tc.vi.addSample(tag.FromContext(ctx), v, nil, now)
 		}
 
-		gotMetric := viewToMetric(tc.vi, nil, now, startTime)
+		gotMetric := viewToMetric(tc.vi, nil, now)
 		if !cmp.Equal(gotMetric, tc.wantMetric) {
 			// JSON format is strictly for checking the content when test fails. Do not use JSON
 			// format to determine if the two values are same as it doesn't differentiate between
@@ -461,7 +458,6 @@ func Test_ViewToMetric(t *testing.T) {
 // Test to verify that a metric converted from a view with Aggregation Count should always
 // have Dimensionless unit.
 func TestUnitConversionForAggCount(t *testing.T) {
-	startTime := time.Now().Add(-60 * time.Second)
 	now := time.Now()
 	tests := []*struct {
 		name     string
@@ -509,7 +505,7 @@ func TestUnitConversionForAggCount(t *testing.T) {
 
 	for _, tc := range tests {
 		tc.vi.addSample(tag.FromContext(context.Background()), 5.0, nil, now)
-		gotMetric := viewToMetric(tc.vi, nil, now, startTime)
+		gotMetric := viewToMetric(tc.vi, nil, now)
 		gotUnit := gotMetric.Descriptor.Unit
 		if !cmp.Equal(gotUnit, tc.wantUnit) {
 			t.Errorf("Verify Unit: %s: Got:%v Want:%v", tc.name, gotUnit, tc.wantUnit)

--- a/stats/view/worker.go
+++ b/stats/view/worker.go
@@ -41,9 +41,9 @@ type measureRef struct {
 }
 
 type worker struct {
-	measures   map[string]*measureRef
-	views      map[string]*viewInternal
-	startTimes map[*viewInternal]time.Time
+	measures       map[string]*measureRef
+	views          map[string]*viewInternal
+	viewStartTimes map[*viewInternal]time.Time
 
 	timer      *time.Ticker
 	c          chan command
@@ -244,13 +244,13 @@ func (w *worker) SetReportingPeriod(d time.Duration) {
 // a single process.
 func NewMeter() Meter {
 	return &worker{
-		measures:   make(map[string]*measureRef),
-		views:      make(map[string]*viewInternal),
-		startTimes: make(map[*viewInternal]time.Time),
-		timer:      time.NewTicker(defaultReportingDuration),
-		c:          make(chan command, 1024),
-		quit:       make(chan bool),
-		done:       make(chan bool),
+		measures:       make(map[string]*measureRef),
+		views:          make(map[string]*viewInternal),
+		viewStartTimes: make(map[*viewInternal]time.Time),
+		timer:          time.NewTicker(defaultReportingDuration),
+		c:              make(chan command, 1024),
+		quit:           make(chan bool),
+		done:           make(chan bool),
 
 		exporters: make(map[Exporter]struct{}),
 	}
@@ -324,7 +324,7 @@ func (w *worker) tryRegisterView(v *View) (*viewInternal, error) {
 		return x, nil
 	}
 	w.views[vi.view.Name] = vi
-	w.startTimes[vi] = time.Now()
+	w.viewStartTimes[vi] = time.Now()
 	ref := w.getMeasureRef(vi.view.Measure.Name())
 	ref.views[vi] = struct{}{}
 	return vi, nil
@@ -334,7 +334,7 @@ func (w *worker) unregisterView(v *viewInternal) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	delete(w.views, v.view.Name)
-	delete(w.startTimes, v)
+	delete(w.viewStartTimes, v)
 	if measure := w.measures[v.view.Measure.Name()]; measure != nil {
 		delete(measure.views, v)
 	}
@@ -347,7 +347,7 @@ func (w *worker) reportView(v *viewInternal) {
 	rows := v.collectedRows()
 	viewData := &Data{
 		View:  v.view,
-		Start: w.startTimes[v],
+		Start: w.viewStartTimes[v],
 		End:   time.Now(),
 		Rows:  rows,
 	}

--- a/stats/view/worker.go
+++ b/stats/view/worker.go
@@ -371,15 +371,7 @@ func (w *worker) toMetric(v *viewInternal, now time.Time) *metricdata.Metric {
 		return nil
 	}
 
-	var startTime time.Time
-	if v.metricDescriptor.Type == metricdata.TypeGaugeInt64 ||
-		v.metricDescriptor.Type == metricdata.TypeGaugeFloat64 {
-		startTime = time.Time{}
-	} else {
-		startTime = w.startTimes[v]
-	}
-
-	return viewToMetric(v, w.r, now, startTime)
+	return viewToMetric(v, w.r, now)
 }
 
 // Read reads all view data and returns them as metrics.

--- a/stats/view/worker_test.go
+++ b/stats/view/worker_test.go
@@ -213,12 +213,12 @@ func Test_Worker_MultiExport(t *testing.T) {
 			case *CountData:
 				got := ts.Points[0].Value.(int64)
 				if wantValue.Value != got {
-					t.Errorf("Mismatched value (want %d, got %d) for %v in %q", wantValue, got, ts, key)
+					t.Errorf("Mismatched value (want %d, got %d) for %v in %q", wantValue.Value, got, ts, key)
 				}
 			case *SumData:
 				got := ts.Points[0].Value.(float64)
 				if wantValue.Value != got {
-					t.Errorf("Mismatched value (want %f, got %f) for %v in %q", wantValue, got, ts, key)
+					t.Errorf("Mismatched value (want %f, got %f) for %v in %q", wantValue.Value, got, ts, key)
 				}
 			default:
 				t.Errorf("Unexpected type of data: %T for %v in %q", wantValue, want[i], key)


### PR DESCRIPTION
Currently all time series within a view will use a single start time recorded when the view is registered. Consequently if a time series is first recorded long after the view is registered the first point will be misattributed to a potentially very long time interval. Instead record a separate start time per time series within AggregationData that is recorded when data for that time series is first recorded. This start time is used when converting rows to TimeSeries and may also be used directly by stats exporters.