### PR TITLE
Fix const labels with derived metrics

### DIFF
--- a/metric/common.go
+++ b/metric/common.go
@@ -133,6 +133,7 @@ func (bm *baseMetric) entryForValues(labelVals []metricdata.LabelValue, newEntry
 }
 
 func (bm *baseMetric) upsertEntry(labelVals []metricdata.LabelValue, newEntry func() baseEntry) error {
+	labelVals = append(bm.constLabelValues, labelVals...)
 	if len(labelVals) != len(bm.keys) {
 		return errKeyValueMismatch
 	}

--- a/metric/gauge_test.go
+++ b/metric/gauge_test.go
@@ -465,6 +465,29 @@ func TestInt64DerivedGaugeEntry_Update(t *testing.T) {
 	}
 }
 
+func TestInt64DerivedGaugeEntry_UpsertConstLabels(t *testing.T) {
+	r := NewRegistry()
+	q := &queueInt64{3}
+	g, _ := r.AddInt64DerivedGauge("g",
+		WithConstLabel(map[metricdata.LabelKey]metricdata.LabelValue{
+			{Key: "const"}: metricdata.NewLabelValue("same"),
+		}))
+	err := g.UpsertEntry(q.ToInt64)
+	if err != nil {
+		t.Errorf("want: nil, got: %v", err)
+	}
+	ms := r.Read()
+	if got, want := ms[0].TimeSeries[0].Points[0].Value.(int64), int64(3); got != want {
+		t.Errorf("value = %v, want %v", got, want)
+	}
+	if got, want := ms[0].Descriptor.LabelKeys[0].Key, "const"; got != want {
+		t.Errorf("label key = %v, want %v", got, want)
+	}
+	if got, want := ms[0].TimeSeries[0].LabelValues[0].Value, "same"; got != want {
+		t.Errorf("label value = %v, want %v", got, want)
+	}
+}
+
 type queueFloat64 struct {
 	size float64
 }


### PR DESCRIPTION
Include the const labels in `baseMetric.upsertEntry` in the same way as `baseMetric.entryForValues`.

The "Derived" form of metrics use an `UpsertEntry` method to provide the function that supplies the metric value as well as the label values. These methods use `baseMetric.upsertEntry` to do the work, but that method was ignoring any const labels set by `WithConstLabel`.

Commit c31d2681 added const labels to metrics and updated `baseMetric.entryForValues` to add the const labels, but `baseMetric.upsertEntry` was not similarly updated.

This causes `UpsertEntry` to return an `errKeyValueMismatch` error ("must supply the same number of label values as keys used to construct this metric") when called unless the values for the const labels were passed to `UpsertEntry`. That kind of defeats the purpose of const labels.

Add a test case for const labels on Int64DerivedGauge. It is not necessary to add test cases for all the derived metrics as they all use the same `baseMetric` implementation.