### PR TITLE
Convert 500 http status code to trace.status

### DIFF
--- a/plugin/ochttp/trace.go
+++ b/plugin/ochttp/trace.go
@@ -198,6 +198,8 @@ func TraceStatus(httpStatusCode int, statusLine string) trace.Status {
 		code = trace.StatusCodeUnauthenticated
 	case http.StatusTooManyRequests:
 		code = trace.StatusCodeResourceExhausted
+	case http.StatusInternalServerError:
+		code = trace.StatusCodeInternal
 	case http.StatusNotImplemented:
 		code = trace.StatusCodeUnimplemented
 	case http.StatusServiceUnavailable:

--- a/plugin/ochttp/trace_test.go
+++ b/plugin/ochttp/trace_test.go
@@ -667,7 +667,7 @@ func TestStatusUnitTest(t *testing.T) {
 		{200, trace.Status{Code: trace.StatusCodeOK, Message: `OK`}},
 		{204, trace.Status{Code: trace.StatusCodeOK, Message: `OK`}},
 		{100, trace.Status{Code: trace.StatusCodeUnknown, Message: `UNKNOWN`}},
-		{500, trace.Status{Code: trace.StatusCodeUnknown, Message: `UNKNOWN`}},
+		{500, trace.Status{Code: trace.StatusCodeInternal, Message: `INTERNAL`}},
 		{400, trace.Status{Code: trace.StatusCodeInvalidArgument, Message: `INVALID_ARGUMENT`}},
 		{422, trace.Status{Code: trace.StatusCodeInvalidArgument, Message: `INVALID_ARGUMENT`}},
 		{499, trace.Status{Code: trace.StatusCodeCancelled, Message: `CANCELLED`}},


### PR DESCRIPTION
Is there any reason why we aren't converting http status code to a trace.Status? The `http.StatusInternalServerError` has a corresponding trace status code `trace.StatusCodeInternal` 