### PR TITLE
Add FormatStatsPath to ochttp Transport to reduce stats path cardinality

### DIFF
--- a/plugin/ochttp/client.go
+++ b/plugin/ochttp/client.go
@@ -56,6 +56,10 @@ type Transport struct {
 	// name equals the URL Path.
 	FormatSpanName func(*http.Request) string
 
+	// FormatStatsPath holds the function to use for standardizing the path
+	// supplied to metrics. By default the path equals the URL path.
+	FormatStatsPath func(*http.Request) string
+
 	// NewClientTrace may be set to a function allowing the current *trace.Span
 	// to be annotated with HTTP request event information emitted by the
 	// httptrace package.
@@ -95,7 +99,13 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		formatSpanName: spanNameFormatter,
 		newClientTrace: t.NewClientTrace,
 	}
-	rt = statsTransport{base: rt}
+
+	statsPathFormatter := t.FormatStatsPath
+	if statsPathFormatter == nil {
+		statsPathFormatter = statsPath
+	}
+
+	rt = statsTransport{base: rt, pathFormatter: statsPathFormatter}
 	return rt.RoundTrip(req)
 }
 


### PR DESCRIPTION
Updates `ochttp.Transport` to accept an optional `FormatStatsPath` which is supplied to `ochttp.statsTransport`. `FormatStatsPath` can override a request URL's path parameter to reduce cardinality for stats similar to `FormatSpanName`.

This should be useful when a resource id is part of a request path such as `/posts/1` or `/posts/2`. Currently each resource is treated as a unique path but it would be nice to optionally treat these requests as a single path.

**Without FormatStatsPath specified**

```
2020/10/01 09:02:59 	Row: 0: &view.Row{
    Tags:[]tag.Tag{
        tag.Tag{Key:tag.Key{name:"http_client_host"}, Value:"jsonplaceholder.typicode.com"}, 
        tag.Tag{Key:tag.Key{name:"http_client_method"}, Value:"GET"}, 
        tag.Tag{Key:tag.Key{name:"http_client_path"}, Value:"/posts/2"}, 
        tag.Tag{Key:tag.Key{name:"http_client_status"}, Value:"200"}
    }, 
    Data:(*view.CountData)(0xc00035c080)
}
2020/10/01 09:02:59 	Row: 1: &view.Row{
    Tags:[]tag.Tag{
        tag.Tag{Key:tag.Key{name:"http_client_host"}, Value:"jsonplaceholder.typicode.com"}, 
        tag.Tag{Key:tag.Key{name:"http_client_method"}, Value:"GET"}, 
        tag.Tag{Key:tag.Key{name:"http_client_path"}, Value:"/posts/1"}, 
        tag.Tag{Key:tag.Key{name:"http_client_status"}, Value:"200"}
    }, 
    Data:(*view.CountData)(0xc00035c100)
}
```

**With FormatStatsPath specified**

```
2020/10/01 09:06:48 	Row: 0: &view.Row{
    Tags:[]tag.Tag{
        tag.Tag{Key:tag.Key{name:"http_client_host"}, Value:"jsonplaceholder.typicode.com"}, 
        tag.Tag{Key:tag.Key{name:"http_client_method"}, Value:"GET"}, 
        tag.Tag{Key:tag.Key{name:"http_client_path"}, Value:"/posts/:id"}, 
        tag.Tag{Key:tag.Key{name:"http_client_status"}, Value:"200"}
    }, 
    Data:(*view.DistributionData)(0xc0001181b0)
}
```