### PR TITLE
Provide accessor to the span implementation

### DIFF
--- a/trace/trace_api.go
+++ b/trace/trace_api.go
@@ -148,6 +148,11 @@ type Span struct {
 	internal SpanInterface
 }
 
+// Internal returns the underlying implementation of the Span
+func (s *Span) Internal() SpanInterface {
+	return s.internal
+}
+
 // IsRecordingEvents returns true if events are being recorded for this span.
 // Use this check to avoid computing expensive annotations when they will never
 // be used.


### PR DESCRIPTION
This is needed if the SDK needs to cast to its underlying type.

Part of https://github.com/open-telemetry/opentelemetry-go/issues/93

@nilebox 