### PR TITLE
fix memory leak cause by the spanStore.(census-instrumentation/opence…

### DIFF
--- a/trace/spanstore.go
+++ b/trace/spanstore.go
@@ -49,7 +49,7 @@ func (i internalOnly) ReportActiveSpans(name string) []*SpanData {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for activeSpan := range s.active {
-		if s, ok := activeSpan.internal.(*span); ok {
+		if s, ok := activeSpan.(*span); ok {
 			out = append(out, s.makeSpanData())
 		}
 	}
@@ -187,7 +187,7 @@ func (i internalOnly) ReportSpansByLatency(name string, minLatency, maxLatency t
 // bucketed by latency.
 type spanStore struct {
 	mu                     sync.Mutex // protects everything below.
-	active                 map[*Span]struct{}
+	active                 map[SpanInterface]struct{}
 	errors                 map[int32]*bucket
 	latency                []bucket
 	maxSpansPerErrorBucket int
@@ -196,7 +196,7 @@ type spanStore struct {
 // newSpanStore creates a span store.
 func newSpanStore(name string, latencyBucketSize int, errorBucketSize int) *spanStore {
 	s := &spanStore{
-		active:                 make(map[*Span]struct{}),
+		active:                 make(map[SpanInterface]struct{}),
 		latency:                make([]bucket, len(defaultLatencies)+1),
 		maxSpansPerErrorBucket: errorBucketSize,
 	}
@@ -273,7 +273,7 @@ func (s *spanStore) resize(latencyBucketSize int, errorBucketSize int) {
 }
 
 // add adds a span to the active bucket of the spanStore.
-func (s *spanStore) add(span *Span) {
+func (s *spanStore) add(span SpanInterface) {
 	s.mu.Lock()
 	s.active[span] = struct{}{}
 	s.mu.Unlock()
@@ -281,7 +281,7 @@ func (s *spanStore) add(span *Span) {
 
 // finished removes a span from the active set, and adds a corresponding
 // SpanData to a latency or error bucket.
-func (s *spanStore) finished(span *Span, sd *SpanData) {
+func (s *spanStore) finished(span SpanInterface, sd *SpanData) {
 	latency := sd.EndTime.Sub(sd.StartTime)
 	if latency < 0 {
 		latency = 0

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -65,6 +65,8 @@ type span struct {
 	endOnce sync.Once
 
 	executionTracerTaskEnd func() // ends the execution tracer span
+
+	activeExporter *Span // corresponding exporter in the active set of spanStore
 }
 
 // IsRecordingEvents returns true if events are being recorded for this span.
@@ -266,7 +268,9 @@ func startSpanInternal(name string, hasParent bool, parent SpanContext, remotePa
 		ss = spanStoreForNameCreateIfNew(name)
 		if ss != nil {
 			s.spanStore = ss
-			ss.add(NewSpan(s))
+			ns := NewSpan(s)
+			s.activeExporter = ns
+			ss.add(ns)
 		}
 	}
 
@@ -291,7 +295,7 @@ func (s *span) End() {
 			sd := s.makeSpanData()
 			sd.EndTime = internal.MonotonicEndTime(sd.StartTime)
 			if s.spanStore != nil {
-				s.spanStore.finished(NewSpan(s), sd)
+				s.spanStore.finished(s.activeExporter, sd)
 			}
 			if mustExport {
 				for e := range exp {


### PR DESCRIPTION
…nsus-go#1245)

* when enable the spanStore and call startSpan and End in a loop, it cause memory leak. Found that it delete the wrong ptr in active set of spanStore in span's End() Method