### PR TITLE
Bump version to next expected release

### DIFF
--- a/opencensus.go
+++ b/opencensus.go
@@ -17,5 +17,5 @@ package opencensus // import "go.opencensus.io"
 
 // Version is the current release version of OpenCensus in use.
 func Version() string {
-	return "0.23.0"
+	return "0.24.0"
 }


### PR DESCRIPTION
This is necessary to un-break the build (e.g., https://github.com/census-instrumentation/opencensus-go/pull/1256/checks?check_run_id=2393176622)