### PR TITLE
Register metrics in benchmark

### DIFF
--- a/stats/benchmark_test.go
+++ b/stats/benchmark_test.go
@@ -109,5 +109,13 @@ func BenchmarkRecord8_8Tags(b *testing.B) {
 }
 
 func makeMeasure() *stats.Int64Measure {
-	return stats.Int64("m", "test measure", "")
+	m := stats.Int64("m", "test measure", "")
+	v := &view.View{
+		Measure:     m,
+		Aggregation: view.Sum(),
+	}
+	if err := view.Register(v); err != nil {
+		panic(err.Error())
+	}
+	return m
 }


### PR DESCRIPTION
Currently, the metric we record is not registered. This hits the
fast-path code of not actually recording the metric, so we miss out on
detecting any performance to that main code path.

This registers the metrics so we actually trigger `record`.

Related: https://github.com/census-instrumentation/opencensus-go/issues/1265