### PR TITLE
Fix formatting to pass with go1.17

### DIFF
--- a/tag/profile_19.go
+++ b/tag/profile_19.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build go1.9
 // +build go1.9
 
 package tag

--- a/tag/profile_not19.go
+++ b/tag/profile_not19.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !go1.9
 // +build !go1.9
 
 package tag

--- a/trace/trace_go11.go
+++ b/trace/trace_go11.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build go1.11
 // +build go1.11
 
 package trace

--- a/trace/trace_nongo11.go
+++ b/trace/trace_nongo11.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !go1.11
 // +build !go1.11
 
 package trace


### PR DESCRIPTION
The CI job currently uses an unpinned image. This was recently updated
to golang 1.17, causing all PRs to fail. This fixes those build failures