### PR TITLE
fix: zpages default handler add trailing slash

### DIFF
--- a/zpages/zpages.go
+++ b/zpages/zpages.go
@@ -57,7 +57,7 @@ func Handle(mux *http.ServeMux, pathPrefix string) {
 	}
 	mux.HandleFunc(path.Join(pathPrefix, "rpcz"), rpczHandler)
 	mux.HandleFunc(path.Join(pathPrefix, "tracez"), tracezHandler)
-	mux.Handle(path.Join(pathPrefix, "public/"), http.FileServer(fs))
+	mux.Handle(path.Join(pathPrefix, "public/") + "/", http.FileServer(fs))
 }
 
 var enableOnce sync.Once


### PR DESCRIPTION
the path.Join call path.Clean will clean trailing slash