### PR TITLE
Enforce tag equivalence in `view.same()`

### DIFF
--- a/stats/view/view.go
+++ b/stats/view/view.go
@@ -65,6 +65,7 @@ func (v *View) same(other *View) bool {
 		return false
 	}
 	return reflect.DeepEqual(v.Aggregation, other.Aggregation) &&
+		reflect.DeepEqual(v.TagKeys, other.Aggregation) &&
 		v.Measure.Name() == other.Measure.Name()
 }
 

--- a/stats/view/view_test.go
+++ b/stats/view/view_test.go
@@ -430,6 +430,17 @@ func TestRegisterAfterMeasurement(t *testing.T) {
 	}
 }
 
+func TestRegisterDifferentLabelViews(t *testing.T) {
+	restart()
+	m1 := stats.Int64("measure", "desc", "unit")
+	view1 := &View{Name: "count", Measure: m1, Aggregation: Count()}
+	view2 := &View{Name: "count", Measure: m1, TagKeys: []tag.Key{tag.MustNewKey("tag")}, Aggregation: Count()}
+
+	if err := Register(view1, view2); err == nil {
+		t.Errorf("Register(count): should have failed when registering equal views with different tags")
+	}
+}
+
 func TestViewRegister_negativeBucketBounds(t *testing.T) {
 	m := stats.Int64("TestViewRegister_negativeBucketBounds", "", "")
 	v := &View{


### PR DESCRIPTION
Otherwise, the lack of error may lead to developers wasting a lot
of time trying to figure out why do their labels not show up.