### PR TITLE
Add SetPath method to ochttp package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module go.opencensus.io
 require (
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
 	github.com/golang/protobuf v1.4.3
-	github.com/google/go-cmp v0.5.3
+	github.com/google/go-cmp v0.5.9
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
 	google.golang.org/grpc v1.33.2

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.3 h1:x95R7cp+rSeeqAMI2knLtQ0DKlaBhv2NrtrOvafPHRo=
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/plugin/ochttp/route.go
+++ b/plugin/ochttp/route.go
@@ -30,6 +30,15 @@ func SetRoute(ctx context.Context, route string) {
 	}
 }
 
+// SetPath sets the http_server_path tag to the given value.
+// It's useful when need replace the default path value.
+// For example default path value is "/a/123" and you want to set the path value to "/a/:id".
+func SetPath(ctx context.Context, route string) {
+	if a, ok := ctx.Value(addedTagsKey{}).(*addedTags); ok {
+		a.t = append(a.t, tag.Upsert(Path, route))
+	}
+}
+
 // WithRouteTag returns an http.Handler that records stats with the
 // http_server_route tag set to the given value.
 func WithRouteTag(handler http.Handler, route string) http.Handler {


### PR DESCRIPTION
I am faced with the problem that metrics can take up a large size. After analyzing them, I found a large number of metrics of the form.  
GET http_path=/a/d22a92ac-49d4-4926-bdcc-a56658159b4d.  
GET http_path=/a/78ac4c27-38ed-45af-b2a0-8dcb91586323.  
GET http_path=/a/0da797f8-cba0-4980-9cf7-5830fa5040df.  

These are the same endpoint, but different entity IDs.  
My PR suggests setting aliases in the http_path by calling the Set Path method.   
After calling the method, I see only one line with the endpoint call.  
GET http_path=/a/:id.  

Thanks!   