### PR TITLE
Lazily initialize the `view` package's default worker

### DIFF
--- a/stats/view/export.go
+++ b/stats/view/export.go
@@ -36,10 +36,12 @@ type Exporter interface {
 //
 // Binaries can register exporters, libraries shouldn't register exporters.
 func RegisterExporter(e Exporter) {
+	maybeInitDefaultWorker()
 	defaultWorker.RegisterExporter(e)
 }
 
 // UnregisterExporter unregisters an exporter.
 func UnregisterExporter(e Exporter) {
+	maybeInitDefaultWorker()
 	defaultWorker.UnregisterExporter(e)
 }

--- a/stats/view/export_test.go
+++ b/stats/view/export_test.go
@@ -1,0 +1,24 @@
+package view
+
+import "testing"
+
+// Exporting functionality is tested in `worker_test.go`. These are a trivial
+// set of tests to make sure that these package-level exports will correctly
+// initialize defaultWorker if necessary.
+func TestRegisterExporter(t *testing.T) {
+	stopAndClearDefaultWorker()
+
+	e := &countExporter{}
+	RegisterExporter(e)
+
+	if _, ok := defaultWorker.exporters[e]; !ok {
+		t.Errorf("exporter doesn't appear to be registered with the default worker")
+	}
+}
+
+func TestUnregisterExporter(t *testing.T) {
+	stopAndClearDefaultWorker()
+
+	e := &countExporter{}
+	UnregisterExporter(e)
+}


### PR DESCRIPTION
See discussion in #1191 for impetus, but in general, it's not
particularly good practice to start up goroutines in package `init`
functions, with one reason being that it means that they're started for
projects that don't even make use of the package, and maybe just have it
as a transitive dependency.

So here, remove the `view` package's default worker in favor of a new
function that'll lazily initialize one when any package-level functions
are called that use the default worker. We use a `sync.Once` that has an
optimized short-circuit path in case the work's already been done, so
new overhead should be negligible, and registering/unregistering views
is probably not a particularly common operation anyway.

This change is backwards compatible, with use of the package's API
staying exactly the same. Test coverage seems to be pretty good, with a
function that previously reset the default worker between test cases
which I've modified to instead reset the default worker back to its
uninitialized state, and thereby verify that the test cases can
initialize it if necessary.

I thought about trying to deinitialize the default worker in case its
last view is unregistered, but decided against it because (1) it's more
invasive, (2) it's not likely to actually help anyone in practice as
views probably stay registered for a program's entire duration anwyay,
and (3) its interaction with the existing package-level `Stop` function
would take some thinking through.