### PR TITLE
Don't panic if internal.MeasurementRecorder hasn't been initialized

### DIFF
--- a/stats/record.go
+++ b/stats/record.go
@@ -96,7 +96,12 @@ func Record(ctx context.Context, ms ...Measurement) {
 	if len(ms) == 0 {
 		return
 	}
-	recorder := internal.MeasurementRecorder.(measurementRecorder)
+	recorder, initialized := internal.MeasurementRecorder.(measurementRecorder)
+	if !initialized {
+		// The init function in view/worker.go has not been run yet. It is
+		// safe to assume no view has been registered and drop the measurement.
+		return
+	}
 	record := false
 	for _, m := range ms {
 		if m.desc.subscribed() {


### PR DESCRIPTION
Fixes https://github.com/census-instrumentation/opencensus-go/issues/1289

I verified that the example in the report no longer panics after this fix.

cc @tzembo 