### PR TITLE
refine: the server-side http Request Body is always non-nil

### DIFF
--- a/plugin/ochttp/server.go
+++ b/plugin/ochttp/server.go
@@ -130,7 +130,7 @@ func (h *Handler) startTrace(w http.ResponseWriter, r *http.Request) (*http.Requ
 		}
 	}
 	span.AddAttributes(requestAttrs(r)...)
-	if r.Body == http.NoBody {
+	if r.Body == nil || r.Body == http.NoBody {
 		// TODO: Handle cases where ContentLength is not set.
 	} else if r.ContentLength > 0 {
 		span.AddMessageReceiveEvent(0, /* TODO: messageID */

--- a/plugin/ochttp/server.go
+++ b/plugin/ochttp/server.go
@@ -156,7 +156,7 @@ func (h *Handler) startStats(w http.ResponseWriter, r *http.Request) (http.Respo
 		ctx:    ctx,
 		writer: w,
 	}
-	if r.Body == http.NoBody {
+	if r.Body == nil || r.Body == http.NoBody {
 		// TODO: Handle cases where ContentLength is not set.
 		track.reqSize = -1
 	} else if r.ContentLength > 0 {

--- a/plugin/ochttp/server.go
+++ b/plugin/ochttp/server.go
@@ -130,7 +130,7 @@ func (h *Handler) startTrace(w http.ResponseWriter, r *http.Request) (*http.Requ
 		}
 	}
 	span.AddAttributes(requestAttrs(r)...)
-	if r.Body == nil {
+	if r.Body == http.NoBody {
 		// TODO: Handle cases where ContentLength is not set.
 	} else if r.ContentLength > 0 {
 		span.AddMessageReceiveEvent(0, /* TODO: messageID */
@@ -156,7 +156,7 @@ func (h *Handler) startStats(w http.ResponseWriter, r *http.Request) (http.Respo
 		ctx:    ctx,
 		writer: w,
 	}
-	if r.Body == nil {
+	if r.Body == http.NoBody {
 		// TODO: Handle cases where ContentLength is not set.
 		track.reqSize = -1
 	} else if r.ContentLength > 0 {


### PR DESCRIPTION
```
	// For server requests, the Request Body is always non-nil
	// but will return EOF immediately when no body is present.
	// The Server will close the request body. The ServeHTTP
	// Handler does not need to.
	//
	// Body must allow Read to be called concurrently with Close.
	// In particular, calling Close should unblock a Read waiting
	// for input.
	Body io.ReadCloser
```
per `net/htp/request.go`, server-side http request body is always no-nil
we should use `http.NoBody` instead `nil` here